### PR TITLE
chore: Transform images

### DIFF
--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -70,6 +70,7 @@ interface ProductOptions {
   baseUrl: string;
   /** Price coded currency, e.g.: USD, BRL */
   priceCurrency: string;
+  imagesByKey?: Map<string, string>;
 }
 
 /** Returns first available sku */
@@ -221,6 +222,14 @@ const toAdditionalPropertyReferenceId = (
   }));
 };
 
+const getImageKey = (src = "") => {
+  const match = new URLPattern({
+    pathname: "/arquivos/ids/:skuId/:imageId",
+  }).exec(src);
+
+  return match?.pathname.groups.imageId || src;
+};
+
 export const toProduct = <P extends LegacyProductVTEX | ProductVTEX>(
   product: P,
   sku: P["items"][number],
@@ -239,6 +248,12 @@ export const toProduct = <P extends LegacyProductVTEX | ProductVTEX>(
     items,
   } = product;
   const { name, ean, itemId: skuId, referenceId = [] } = sku;
+  const imagesByKey = options.imagesByKey ?? items
+    .flatMap((i) => i.images)
+    .reduce((map, img) => {
+      map.set(getImageKey(img.imageUrl), img.imageUrl);
+      return map;
+    }, new Map<string, string>());
 
   const groupAdditionalProperty = isLegacyProduct(product)
     ? legacyToProductGroupAdditionalProperties(product)
@@ -260,7 +275,9 @@ export const toProduct = <P extends LegacyProductVTEX | ProductVTEX>(
     ? {
       "@type": "ProductGroup",
       productGroupID: productId,
-      hasVariant: items.map((sku) => toProduct(product, sku, 1, options)),
+      hasVariant: items.map((sku) =>
+        toProduct(product, sku, 1, { ...options, imagesByKey })
+      ),
       url: getProductGroupURL(baseUrl, product).href,
       name: product.productName,
       additionalProperty: groupAdditionalProperty,
@@ -301,11 +318,12 @@ export const toProduct = <P extends LegacyProductVTEX | ProductVTEX>(
     releaseDate,
     additionalProperty,
     isVariantOf,
-    image: images.map(({ imageUrl, imageText, imageLabel }) => ({
-      "@type": "ImageObject" as const,
-      alternateName: imageText ?? imageLabel ?? "",
-      url: imageUrl,
-    })),
+    image: images.map(({ imageUrl, imageText, imageLabel }) => {
+      const url = imagesByKey.get(getImageKey(imageUrl)) ?? imageUrl;
+      const alternateName = imageText || imageLabel || "";
+
+      return { "@type": "ImageObject" as const, alternateName, url };
+    }),
     offers: offers.length > 0
       ? {
         "@type": "AggregateOffer",


### PR DESCRIPTION
Some VTEX stores have the same image for different skus. For instance, a shirt have the same image for different sizes. In this case, the API returns the following:

```
{
    skus: [
      {
        id: sku-1
        image: [
          "https://bravtexfashionstore.vtexassets.com/arquivos/ids/123/a.jpg",
          "https://bravtexfashionstore.vtexassets.com/arquivos/ids/124/b.jpg",
          "https://bravtexfashionstore.vtexassets.com/arquivos/ids/125/c.jpg"
        ]
      },
      {
        id: sku-2
        image: [
          "https://bravtexfashionstore.vtexassets.com/arquivos/ids/321/a.jpg",
          "https://bravtexfashionstore.vtexassets.com/arquivos/ids/322/b.jpg",
          "https://bravtexfashionstore.vtexassets.com/arquivos/ids/323/c.jpg"
        ]
      }
    ]
  }
```

Note that the urls are different, but the images are the same in both SKUs (a.jpg, b.jpg, c.jpg). 

This transforms the urls so we have the same image url for both skus. This improves our image billing and prevent images blinking when switching skus

```
{
    skus: [
      {
        id: sku-1
        image: [
          "https://bravtexfashionstore.vtexassets.com/arquivos/ids/123/a.jpg",
          "https://bravtexfashionstore.vtexassets.com/arquivos/ids/124/b.jpg",
          "https://bravtexfashionstore.vtexassets.com/arquivos/ids/125/c.jpg"
        ]
      },
      {
        id: sku-2
        image: [
          "https://bravtexfashionstore.vtexassets.com/arquivos/ids/123/a.jpg",
          "https://bravtexfashionstore.vtexassets.com/arquivos/ids/124/b.jpg",
          "https://bravtexfashionstore.vtexassets.com/arquivos/ids/125/c.jpg"
        ]
      }
    ]
  }
```