### PR TITLE
fix: Duplicated images

### DIFF
--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -227,7 +227,11 @@ const getImageKey = (src = "") => {
     pathname: "/arquivos/ids/:skuId/:imageId",
   }).exec(src);
 
-  return match?.pathname.groups.imageId || src;
+  if (match == null) {
+    return src;
+  }
+
+  return `${match.pathname.groups.imageId}${match.search.input}`;
 };
 
 export const toProduct = <P extends LegacyProductVTEX | ProductVTEX>(


### PR DESCRIPTION
Turns out the querystring is also important for the final rendered image