### PR TITLE
subscribe action + simulate action | WIP

### DIFF
--- a/shopify/actions/customer/createCustomer.ts
+++ b/shopify/actions/customer/createCustomer.ts
@@ -1,0 +1,41 @@
+import { AppContext } from "../../mod.ts";
+import { Data, Variables, query } from "../../utils/queries/createCustomer.ts";
+
+type CreateCustomerProps = {
+  input: {
+    email: string;
+    emailMarketingConsent : {
+      consentUpdatedAt?: string;
+      marketingOptInLevel?: string;
+      marketingState: string;
+    }
+    tags: string[];
+  };
+};
+
+const action = async (
+  { input }: CreateCustomerProps,
+  _req: Request,
+  ctx: AppContext,
+): Promise<{id: string}> => {
+  const { admin } = ctx;
+
+  const { payload : {customer} }  = await admin.query<Data, Variables>({
+    variables: { 
+      input:{
+        email: input.email,
+        emailMarketingConsent: {
+          marketingState: input.emailMarketingConsent.marketingState,
+          consentUpdatedAt: input.emailMarketingConsent.consentUpdatedAt,
+          marketingOptInLevel: input.emailMarketingConsent.marketingOptInLevel
+        },
+        tags: input.tags,
+      }
+    },
+    query,
+  });
+
+  return customer;
+};
+
+export default action;

--- a/shopify/actions/customer/createCustomer.ts
+++ b/shopify/actions/customer/createCustomer.ts
@@ -17,7 +17,7 @@ const action = async (
   { input }: CreateCustomerProps,
   _req: Request,
   ctx: AppContext,
-): Promise<{id: string}> => {
+): Promise<Data['payload']['customer']> => {
   const { admin } = ctx;
 
   const { payload : {customer} }  = await admin.query<Data, Variables>({

--- a/shopify/actions/customer/updateCustomer.ts
+++ b/shopify/actions/customer/updateCustomer.ts
@@ -1,0 +1,31 @@
+import { AppContext } from "../../mod.ts";
+import { Data, Variables, query } from "../../utils/queries/updateCustomer.ts";
+
+type UpdateCustomerProps = {
+  input: {
+    id: string;
+    tags: string[];
+  };
+};
+
+const action = async (
+  { input }: UpdateCustomerProps,
+  _req: Request,
+  ctx: AppContext,
+): Promise<{id: string}> => {
+  const { admin } = ctx;
+  
+  const { payload : {customer} }  = await admin.query<Data, Variables>({
+    variables: { 
+      input:{
+        id: input.id,
+        tags: input.tags,
+      }
+    },
+    query,
+  });
+
+  return customer;
+};
+
+export default action;

--- a/shopify/actions/customer/updateCustomer.ts
+++ b/shopify/actions/customer/updateCustomer.ts
@@ -12,7 +12,7 @@ const action = async (
   { input }: UpdateCustomerProps,
   _req: Request,
   ctx: AppContext,
-): Promise<{id: string}> => {
+): Promise<Data['payload']['customer']> => {
   const { admin } = ctx;
   
   const { payload : {customer} }  = await admin.query<Data, Variables>({

--- a/shopify/actions/newsletter/subscribe.ts
+++ b/shopify/actions/newsletter/subscribe.ts
@@ -1,5 +1,5 @@
 import { AppContext } from "../../mod.ts";
-import { Data, Variables, query } from "../../utils/queries/subscribe.ts";
+import createCustomerAction from "../customer/createCustomer.ts";
 
 type SubscribeCustomerProps = {
   input: {
@@ -13,29 +13,18 @@ type SubscribeCustomerProps = {
   };
 };
 
+
 const action = async (
   { input }: SubscribeCustomerProps,
-  _req: Request,
+  req: Request,
   ctx: AppContext,
 ): Promise<{id: string}> => {
-  const { admin } = ctx;
 
-  const { payload : {customer} }  = await admin.query<Data, Variables>({
-    variables: { 
-      input:{
-        email: input.email,
-        emailMarketingConsent: {
-          marketingState: input.emailMarketingConsent.marketingState,
-          consentUpdatedAt: input.emailMarketingConsent.consentUpdatedAt,
-          marketingOptInLevel: input.emailMarketingConsent.marketingOptInLevel
-        },
-        tags: input.tags
-      }
-    },
-    query,
-  });
+  const { id } = await createCustomerAction({ input }, req, ctx)
 
-  return customer;
+  return {
+    id
+  };
 };
 
 export default action;

--- a/shopify/actions/newsletter/subscribe.ts
+++ b/shopify/actions/newsletter/subscribe.ts
@@ -1,0 +1,43 @@
+import { AppContext } from "../../mod.ts";
+import { Data, Variables, query } from "../../utils/queries/subscribe.ts";
+
+type CreateCustomerProps = {
+  input: {
+    email: string;
+    emailMarketingConsent : {
+      consentUpdatedAt?: string;
+      marketingOptInLevel?: string;
+      marketingState: string;
+    }
+    tags: string[];
+  };
+};
+
+const action = async (
+  { input }: CreateCustomerProps,
+  _req: Request,
+  ctx: AppContext,
+): Promise<{id: string}> => {
+  const { admin } = ctx;
+  
+  console.log(input)
+
+  const { payload : {customer} }  = await admin.query<Data, Variables>({
+    variables: { 
+      input:{
+        email: input.email,
+        emailMarketingConsent: {
+          marketingState: input.emailMarketingConsent.marketingState,
+          consentUpdatedAt: input.emailMarketingConsent.consentUpdatedAt,
+          marketingOptInLevel: input.emailMarketingConsent.marketingOptInLevel
+        },
+        tags: input.tags
+      }
+    },
+    query,
+  });
+
+  return customer;
+};
+
+export default action;

--- a/shopify/actions/newsletter/subscribe.ts
+++ b/shopify/actions/newsletter/subscribe.ts
@@ -1,7 +1,7 @@
 import { AppContext } from "../../mod.ts";
 import { Data, Variables, query } from "../../utils/queries/subscribe.ts";
 
-type CreateCustomerProps = {
+type SubscribeCustomerProps = {
   input: {
     email: string;
     emailMarketingConsent : {
@@ -14,13 +14,11 @@ type CreateCustomerProps = {
 };
 
 const action = async (
-  { input }: CreateCustomerProps,
+  { input }: SubscribeCustomerProps,
   _req: Request,
   ctx: AppContext,
 ): Promise<{id: string}> => {
   const { admin } = ctx;
-  
-  console.log(input)
 
   const { payload : {customer} }  = await admin.query<Data, Variables>({
     variables: { 

--- a/shopify/actions/order/draftOrderCalculate.ts
+++ b/shopify/actions/order/draftOrderCalculate.ts
@@ -1,0 +1,42 @@
+import { AppContext } from "../../mod.ts";
+import { Data, Variables, query } from "../../utils/queries/draftOrderCalculate.ts";
+
+type DraftOrderCalculateProps = {
+  input: {
+    lineItems: {
+        variantId: string;
+        quantity: number;
+    }[];
+    shippingAddress:{
+        zip: string;
+        countryCode: string;
+        province: string;
+    }
+  };
+};
+
+const action = async (
+  { input }: DraftOrderCalculateProps,
+  _req: Request,
+  ctx: AppContext,
+): Promise<Data['payload']['calculatedDraftOrder']> => {
+  const { admin } = ctx;
+
+  const {payload : { calculatedDraftOrder }}  = await admin.query<Data, Variables>({
+    variables: { 
+      input:{
+        lineItems: [...input.lineItems],
+        shippingAddress: {
+            zip: input.shippingAddress.zip,
+            countryCode: input.shippingAddress.countryCode,
+            province: input.shippingAddress.province,
+        },
+      }
+    },
+    query,
+  });
+
+  return calculatedDraftOrder;
+};
+
+export default action;

--- a/shopify/loaders/proxy.ts
+++ b/shopify/loaders/proxy.ts
@@ -10,6 +10,7 @@ const PATHS_TO_PROXY = [
   "/password/*",
   "/challenge",
   "/challenge/*",
+  "/account/login",
 ];
 const decoSiteMapUrl = "/sitemap/deco.xml";
 

--- a/shopify/manifest.gen.ts
+++ b/shopify/manifest.gen.ts
@@ -11,6 +11,7 @@ import * as $$$$0 from "./handlers/sitemap.ts";
 import * as $$$$$$$$$0 from "./actions/cart/updateCoupons.ts";
 import * as $$$$$$$$$1 from "./actions/cart/updateItems.ts";
 import * as $$$$$$$$$2 from "./actions/cart/addItems.ts";
+import * as $$$$$$$$$3 from "./actions/newsletter/subscribe.ts";
 
 const manifest = {
   "loaders": {
@@ -27,6 +28,7 @@ const manifest = {
     "shopify/actions/cart/addItems.ts": $$$$$$$$$2,
     "shopify/actions/cart/updateCoupons.ts": $$$$$$$$$0,
     "shopify/actions/cart/updateItems.ts": $$$$$$$$$1,
+    "shopify/actions/newsletter/subscribe.ts": $$$$$$$$$3,
   },
   "name": "shopify",
   "baseUrl": import.meta.url,

--- a/shopify/manifest.gen.ts
+++ b/shopify/manifest.gen.ts
@@ -15,6 +15,8 @@ import * as $$$$$$$$$3 from "./actions/newsletter/subscribe.ts";
 import * as $$$$$$$$$4 from "./actions/customer/updateCustomer.ts";
 import * as $$$$$$$$$5 from "./actions/customer/createCustomer.ts";
 
+import * as $$$$$$$$$6 from "./actions/customer/createCustomer.ts";
+
 const manifest = {
   "loaders": {
     "shopify/loaders/cart.ts": $$$4,
@@ -27,12 +29,13 @@ const manifest = {
     "shopify/handlers/sitemap.ts": $$$$0,
   },
   "actions": {
-    "shopify/actions/cart/addItems.ts": $$$$$$$$$2,
-    "shopify/actions/cart/updateCoupons.ts": $$$$$$$$$0,
-    "shopify/actions/cart/updateItems.ts": $$$$$$$$$1,
-    "shopify/actions/customer/createCustomer.ts": $$$$$$$$$5,
-    "shopify/actions/customer/updateCustomer.ts": $$$$$$$$$4,
-    "shopify/actions/newsletter/subscribe.ts": $$$$$$$$$3,
+    "shopify/actions/cart/addItems.ts": $$$$$$$$$3,
+    "shopify/actions/cart/updateCoupons.ts": $$$$$$$$$1,
+    "shopify/actions/cart/updateItems.ts": $$$$$$$$$2,
+    "shopify/actions/customer/createCustomer.ts": $$$$$$$$$6,
+    "shopify/actions/customer/updateCustomer.ts": $$$$$$$$$5,
+    "shopify/actions/newsletter/subscribe.ts": $$$$$$$$$4,
+    "shopify/actions/order/draftOrderCalculate.ts": $$$$$$$$$0,
   },
   "name": "shopify",
   "baseUrl": import.meta.url,

--- a/shopify/manifest.gen.ts
+++ b/shopify/manifest.gen.ts
@@ -12,6 +12,8 @@ import * as $$$$$$$$$0 from "./actions/cart/updateCoupons.ts";
 import * as $$$$$$$$$1 from "./actions/cart/updateItems.ts";
 import * as $$$$$$$$$2 from "./actions/cart/addItems.ts";
 import * as $$$$$$$$$3 from "./actions/newsletter/subscribe.ts";
+import * as $$$$$$$$$4 from "./actions/customer/updateCustomer.ts";
+import * as $$$$$$$$$5 from "./actions/customer/createCustomer.ts";
 
 const manifest = {
   "loaders": {
@@ -28,6 +30,8 @@ const manifest = {
     "shopify/actions/cart/addItems.ts": $$$$$$$$$2,
     "shopify/actions/cart/updateCoupons.ts": $$$$$$$$$0,
     "shopify/actions/cart/updateItems.ts": $$$$$$$$$1,
+    "shopify/actions/customer/createCustomer.ts": $$$$$$$$$5,
+    "shopify/actions/customer/updateCustomer.ts": $$$$$$$$$4,
     "shopify/actions/newsletter/subscribe.ts": $$$$$$$$$3,
   },
   "name": "shopify",

--- a/shopify/mod.ts
+++ b/shopify/mod.ts
@@ -19,6 +19,12 @@ export interface Props {
   storefrontAccessToken: string;
 
   /**
+   * @ttile Access Token
+   * @description Shopify admin access token.
+   */
+  adminAccessToken: string;
+
+  /**
    * @description Use Shopify as backend platform
    */
   platform: "shopify";
@@ -26,13 +32,14 @@ export interface Props {
 
 export interface State extends Props {
   storefront: ReturnType<typeof createGraphqlClient>;
+  admin: ReturnType<typeof createGraphqlClient>;
 }
 
 /**
  * @title Shopify
  */
 export default function App(props: Props): App<Manifest, State> {
-  const { storeName, storefrontAccessToken } = props;
+  const { storeName, storefrontAccessToken, adminAccessToken } = props;
   const storefront = createGraphqlClient({
     endpoint: `https://${storeName}.myshopify.com/api/2023-07/graphql.json`,
     fetcher: fetchSafe,
@@ -42,5 +49,15 @@ export default function App(props: Props): App<Manifest, State> {
     }),
   });
 
-  return { state: { ...props, storefront }, manifest };
+  const admin = createGraphqlClient({
+    endpoint:
+      `https://${storeName}.myshopify.com/admin/api/2023-07/graphql.json`,
+    fetcher: fetchSafe,
+    headers: new Headers({
+      "Content-Type": "application/json",
+      "X-Shopify-Access-Token": adminAccessToken,
+    }),
+  });
+
+  return { state: { ...props, storefront, admin }, manifest };
 }

--- a/shopify/mod.ts
+++ b/shopify/mod.ts
@@ -2,6 +2,7 @@ import type { App, FnContext } from "deco/mod.ts";
 import { fetchSafe } from "../utils/fetch.ts";
 import { createGraphqlClient } from "../utils/graphql.ts";
 import manifest, { Manifest } from "./manifest.gen.ts";
+import type { SecretString } from "../website/loaders/secretString.ts";
 
 export type AppContext = FnContext<State, Manifest>;
 
@@ -22,7 +23,7 @@ export interface Props {
    * @ttile Access Token
    * @description Shopify admin access token.
    */
-  adminAccessToken: string;
+  adminAccessToken: SecretString;
 
   /**
    * @description Use Shopify as backend platform
@@ -55,7 +56,7 @@ export default function App(props: Props): App<Manifest, State> {
     fetcher: fetchSafe,
     headers: new Headers({
       "Content-Type": "application/json",
-      "X-Shopify-Access-Token": adminAccessToken,
+      "X-Shopify-Access-Token": adminAccessToken || "",
     }),
   });
 

--- a/shopify/utils/queries/createCustomer.ts
+++ b/shopify/utils/queries/createCustomer.ts
@@ -1,0 +1,35 @@
+import { gql } from "../../../utils/graphql.ts";
+
+export const query = gql`
+mutation customerCreate($input: CustomerInput!) {
+  payload: customerCreate(input: $input) {
+    customer {
+      id
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}
+`;
+
+export interface Variables {
+  input: {
+    email: string;
+    emailMarketingConsent?: {
+      consentUpdatedAt?: string;
+      marketingOptInLevel?: string;
+      marketingState: string;
+    };
+    tags?: string[];
+  };
+}
+
+export interface Data {
+  payload: {
+    customer: {
+      id: string;
+    };
+  };
+}

--- a/shopify/utils/queries/draftOrderCalculate.ts
+++ b/shopify/utils/queries/draftOrderCalculate.ts
@@ -1,0 +1,49 @@
+import { gql } from "../../../utils/graphql.ts";
+
+export const query = gql`
+mutation draftOrderCalculate($input: DraftOrderInput!) {
+  payload: draftOrderCalculate(input: $input) {
+    calculatedDraftOrder {
+        availableShippingRates {
+            title
+            handle
+            price {
+              amount
+            }
+        }
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}
+`;
+
+export interface Variables {
+  input: {
+    lineItems: {
+        variantId: string;
+        quantity: number;
+    }[];
+    shippingAddress: {
+        zip: string;
+        countryCode: string;
+        province: string;
+    }
+  };
+}
+
+export interface Data {
+  payload: {
+    calculatedDraftOrder: {
+        availableShippingRates: {
+            title : string;
+            handle: string;
+            price :{
+              amount : string
+            }
+        }[]
+    };
+  };
+}

--- a/shopify/utils/queries/subscribe.ts
+++ b/shopify/utils/queries/subscribe.ts
@@ -1,0 +1,35 @@
+import { gql } from "../../../utils/graphql.ts";
+
+export const query = gql`
+mutation customerCreate($input: CustomerInput!) {
+  payload: customerCreate(input: $input) {
+    customer {
+      id
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}
+`;
+
+export interface Variables {
+  input: {
+    email: string;
+    emailMarketingConsent: {
+      consentUpdatedAt?: string;
+      marketingOptInLevel?: string;
+      marketingState: string;
+    };
+    tags: string[];
+  };
+}
+
+export interface Data {
+  payload: {
+    customer: {
+      id: string;
+    };
+  };
+}

--- a/shopify/utils/queries/updateCustomer.ts
+++ b/shopify/utils/queries/updateCustomer.ts
@@ -1,8 +1,8 @@
 import { gql } from "../../../utils/graphql.ts";
 
 export const query = gql`
-mutation customerCreate($input: CustomerInput!) {
-  payload: customerCreate(input: $input) {
+mutation customerUpdate($input: CustomerInput!) {
+  payload: customerUpdate(input: $input) {
     customer {
       id
     }
@@ -16,13 +16,8 @@ mutation customerCreate($input: CustomerInput!) {
 
 export interface Variables {
   input: {
-    email: string;
-    emailMarketingConsent: {
-      consentUpdatedAt?: string;
-      marketingOptInLevel?: string;
-      marketingState: string;
-    };
-    tags: string[];
+    id: string;
+    tags?: string[];
   };
 }
 

--- a/website/loaders/secret.ts
+++ b/website/loaders/secret.ts
@@ -22,7 +22,7 @@ export interface Props {
   name?: string;
 }
 
-const cache: Record<string, Promise<string>> = {};
+const cache: Record<string, Promise<string | null>> = {};
 
 /**
  * @title Secret
@@ -43,15 +43,14 @@ export default function Secret(
       if (!encrypted) {
         return Promise.resolve(null);
       }
-      try{
-        return cache[encrypted] ??= decryptFromHex(encrypted).then((d) =>
-          d.decrypted
-        );
-      }catch(err){
+
+      return cache[encrypted] ??= decryptFromHex(encrypted).then((d) =>
+        d.decrypted
+      ).catch((err) => {
         console.error(err);
-        return Promise.resolve(null);
-      }
-      
+        return null;
+      });
+
     },
   };
 }

--- a/website/loaders/secret.ts
+++ b/website/loaders/secret.ts
@@ -43,9 +43,15 @@ export default function Secret(
       if (!encrypted) {
         return Promise.resolve(null);
       }
-      return cache[encrypted] ??= decryptFromHex(encrypted).then((d) =>
-        d.decrypted
-      );
+      try{
+        return cache[encrypted] ??= decryptFromHex(encrypted).then((d) =>
+          d.decrypted
+        );
+      }catch(err){
+        console.error(err);
+        return Promise.resolve(null);
+      }
+      
     },
   };
 }

--- a/website/loaders/secretString.ts
+++ b/website/loaders/secretString.ts
@@ -1,0 +1,13 @@
+import { Secret } from "./secret.ts";
+
+export interface Props{
+    secret: Secret;
+}
+
+export type SecretString = string | null;
+
+/** @title Secret String */
+export default function({ secret } : Props) : Promise<SecretString>{
+
+    return secret.get();
+}

--- a/website/manifest.gen.ts
+++ b/website/manifest.gen.ts
@@ -5,12 +5,13 @@
 import * as $0 from "./functions/requestToParam.ts";
 import * as $$$0 from "./loaders/image.ts";
 import * as $$$1 from "./loaders/redirectsFromCsv.ts";
-import * as $$$2 from "./loaders/extension.ts";
-import * as $$$3 from "./loaders/secret.ts";
-import * as $$$4 from "./loaders/pages.ts";
-import * as $$$5 from "./loaders/asset.ts";
-import * as $$$6 from "./loaders/fonts/local.ts";
-import * as $$$7 from "./loaders/fonts/googleFonts.ts";
+import * as $$$2 from "./loaders/secretString.ts";
+import * as $$$3 from "./loaders/extension.ts";
+import * as $$$4 from "./loaders/secret.ts";
+import * as $$$5 from "./loaders/pages.ts";
+import * as $$$6 from "./loaders/asset.ts";
+import * as $$$7 from "./loaders/fonts/local.ts";
+import * as $$$8 from "./loaders/fonts/googleFonts.ts";
 import * as $$$$0 from "./handlers/router.ts";
 import * as $$$$1 from "./handlers/sitemap.ts";
 import * as $$$$2 from "./handlers/proxy.ts";
@@ -41,14 +42,15 @@ const manifest = {
     "website/functions/requestToParam.ts": $0,
   },
   "loaders": {
-    "website/loaders/asset.ts": $$$5,
-    "website/loaders/extension.ts": $$$2,
-    "website/loaders/fonts/googleFonts.ts": $$$7,
-    "website/loaders/fonts/local.ts": $$$6,
+    "website/loaders/asset.ts": $$$6,
+    "website/loaders/extension.ts": $$$3,
+    "website/loaders/fonts/googleFonts.ts": $$$8,
+    "website/loaders/fonts/local.ts": $$$7,
     "website/loaders/image.ts": $$$0,
-    "website/loaders/pages.ts": $$$4,
+    "website/loaders/pages.ts": $$$5,
     "website/loaders/redirectsFromCsv.ts": $$$1,
-    "website/loaders/secret.ts": $$$3,
+    "website/loaders/secret.ts": $$$4,
+    "website/loaders/secretString.ts": $$$2,
   },
   "handlers": {
     "website/handlers/fresh.ts": $$$$3,


### PR DESCRIPTION
I didn't find an endpoint at storefront API, so I had to create a new GraphqlClient connecting to admin API, follow the structure that gimenes did before.

CustomerCreate at storefront: https://shopify.dev/docs/api/storefront/2023-07/mutations/customerCreate

It requires emails and password, I think it's use to create logins.

CustomerCreate at admin api: https://shopify.dev/docs/api/admin-graphql/2023-07/mutations/customerCreate

Buttt, the new client requires a new token. In this PR I just created a normal string field to receive that at admin.

What do you think about it? Do we have to use Secrets?