### PR TITLE
Add missing VTEX catalog filters URL on categories and search

### DIFF
--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -515,20 +515,14 @@ export const legacyFacetToFilter = (
   map: string,
   behavior: "dynamic" | "static",
 ): Filter | null => {
-  const mapSegments = map.split(",");
+  const mapSegments = map.split(",").filter((x) => x.length > 0);
   const pathSegments = url.pathname
     .replace(/^\//, "")
     .split("/")
     .slice(0, mapSegments.length);
   const mapSet = new Set(mapSegments);
   const pathSet = new Set(pathSegments);
-
   const getLink = (facet: LegacyFacet, selected: boolean) => {
-    // Do not allow removing root facet to avoid going back to home page
-    if (mapSegments.length === 1) {
-      return `${url.pathname}${url.search}`;
-    }
-
     const index = pathSegments.findIndex((s) => s === facet.Value);
     const newMap = selected
       ? [...mapSegments.filter((_, i) => i !== index)]
@@ -541,6 +535,10 @@ export const legacyFacetToFilter = (
     link.searchParams.set("map", newMap.join(","));
     if (behavior === "static") {
       link.searchParams.set("fmap", url.searchParams.get("fmap") || map);
+    }
+    const currentQuery = url.searchParams.get("q");
+    if (currentQuery) {
+      link.searchParams.set("q", currentQuery);
     }
 
     return `${link.pathname}${link.search}`;

--- a/website/components/_Controls.tsx
+++ b/website/components/_Controls.tsx
@@ -11,6 +11,7 @@ declare global {
     LIVE: {
       page: Page;
       site: Site;
+      flags?: Flag[];
     };
   }
 }


### PR DESCRIPTION
Fix legacy filters to:

- keep current query on URL
- ignore empty mappings (ex.: `,c` should be only 1 mapping)
- allow root facet to be removing (thus returning to home)

Tests:
- Landing: https://deco-sites-embelleze-59yjtgj1w3qg.deno.dev/
- Search: https://deco-sites-embelleze-59yjtgj1w3qg.deno.dev/s?q=coloridos
- Departament: https://deco-sites-embelleze-59yjtgj1w3qg.deno.dev/Condicionador