### PR TITLE
Add support for searching by productId on productList loader

### DIFF
--- a/vtex/loaders/legacy/productList.ts
+++ b/vtex/loaders/legacy/productList.ts
@@ -8,7 +8,7 @@ import {
 } from "../../utils/segment.ts";
 import { withIsSimilarTo } from "../../utils/similars.ts";
 import { toProduct } from "../../utils/transform.ts";
-import type { LegacySort, ProductID } from "../../utils/types.ts";
+import type { LegacySort } from "../../utils/types.ts";
 
 export interface CollectionProps extends CommonProps {
   // TODO: pattern property isn't being handled by RJSF
@@ -53,12 +53,14 @@ export interface SkuIDProps extends CommonProps {
   /**
    * @description SKU ids to retrieve
    */
-  ids?: ProductID[];
-  skus?: ProductID[];
+  ids?: string[];
 }
 
 export interface ProductIDProps extends CommonProps {
-  productIds?: ProductID[];
+  /**
+   * @description Product ids to retrieve
+   */
+  productIds?: string[];
 }
 
 export interface CommonProps {
@@ -83,8 +85,7 @@ const isCollectionProps = (p: any): p is CollectionProps =>
 const isValidArrayProp = (prop: any) => Array.isArray(prop) && prop.length > 0;
 
 // deno-lint-ignore no-explicit-any
-const isSKUIDProps = (p: any): p is SkuIDProps =>
-  isValidArrayProp(p.ids) || isValidArrayProp(p.skus);
+const isSKUIDProps = (p: any): p is SkuIDProps => isValidArrayProp(p.ids);
 
 // deno-lint-ignore no-explicit-any
 const isProductIDProps = (p: any): p is ProductIDProps =>
@@ -103,13 +104,11 @@ const fromProps = (props: Props) => {
   };
 
   if (isSKUIDProps(props)) {
-    const ids = props.ids || [];
-    const skus = props.skus || [];
+    const skuIds = props.ids || [];
 
-    const skuIds = new Set([...ids, ...skus]);
-    Array.from(skuIds).forEach((skuId) => params.fq.push(`skuId:${skuId}`));
+    skuIds.forEach((skuId) => params.fq.push(`skuId:${skuId}`));
     params._from = 0;
-    params._to = Math.max(skuIds.size - 1, 0);
+    params._to = Math.max(skuIds.length - 1, 0);
 
     return params;
   }


### PR DESCRIPTION
## Description

This PR aims to add support for [searching by productId](https://developers.vtex.com/docs/api-reference/search-api#get-/api/catalog_system/pub/products/search) on the productList loader by adding 2 new props while keeping backward compatibility with the `ids` prop.

## Changes

- Add `skus` and `productIds` props that will have the data for each type of search
- The `ids` prop fallbacks to the same behavior as `skus` to be backward compatible
- Add a helper function to avoid code duplication

## Test instructions

- Test using `ids` or `skus`, should return a list of skus;
- Test using `productIds` should return a list of products;
- Other behaviors should stay the same.