### PR TITLE
Product list transform vnda

### DIFF
--- a/vnda/loaders/productList.ts
+++ b/vnda/loaders/productList.ts
@@ -20,7 +20,7 @@ export interface Props {
   tags?: string[];
 
   /** @description search for products by id */
-  ids: number[]
+  ids: number[];
 }
 
 /**
@@ -41,7 +41,7 @@ const productListLoader = async (
     sort: props?.sort,
     per_page: props?.count,
     "tags[]": props?.tags,
-    "ids[]": props?.ids
+    "ids[]": props?.ids,
   }, STALE).then((res) => res.json());
 
   return search.results?.map((product) =>

--- a/vnda/loaders/productList.ts
+++ b/vnda/loaders/productList.ts
@@ -18,6 +18,9 @@ export interface Props {
 
   /** @description search for products that have certain tag */
   tags?: string[];
+
+  /** @description search for products by id */
+  ids: number[]
 }
 
 /**
@@ -38,6 +41,7 @@ const productListLoader = async (
     sort: props?.sort,
     per_page: props?.count,
     "tags[]": props?.tags,
+    "ids[]": props?.ids
   }, STALE).then((res) => res.json());
 
   return search.results?.map((product) =>

--- a/vnda/utils/transform.ts
+++ b/vnda/utils/transform.ts
@@ -158,6 +158,16 @@ const toPropertyValue = (variant: VNDAProduct): PropertyValue[] =>
       } as PropertyValue)
     ).filter((x): x is PropertyValue => Boolean(x));
 
+    const toPropertyValueTags = (tags: ProductSearch["tags"]): PropertyValue[] =>
+    tags?.map((tag) =>
+      tag && ({
+        "@type": "PropertyValue",
+        name: tag.name,
+        value: JSON.stringify(tag),
+        valueReference: "TAGS",
+      } as PropertyValue)
+    )
+
 // deno-lint-ignore no-explicit-any
 const isProductVariant = (p: any): p is VariantProductSearch =>
   typeof p.id === "number";
@@ -191,6 +201,8 @@ export const toProduct = (
   const offer = toOffer(variant);
   const offers = offer ? [offer] : [];
 
+  const myTags = "tags" in product ? product.tags : []
+
   return {
     "@type": "Product",
     productID,
@@ -198,7 +210,7 @@ export const toProduct = (
     url: variantUrl,
     name: product.name,
     description: product.description,
-    additionalProperty: toPropertyValue(variant),
+    additionalProperty: [...toPropertyValue(variant), ...toPropertyValueTags(myTags) ],
     inProductGroupWithID: productGroupID,
     gtin: product.reference,
     isVariantOf: {

--- a/vnda/utils/transform.ts
+++ b/vnda/utils/transform.ts
@@ -158,15 +158,15 @@ const toPropertyValue = (variant: VNDAProduct): PropertyValue[] =>
       } as PropertyValue)
     ).filter((x): x is PropertyValue => Boolean(x));
 
-    const toPropertyValueTags = (tags: ProductSearch["tags"]): PropertyValue[] =>
-    tags?.map((tag) =>
-      tag && ({
-        "@type": "PropertyValue",
-        name: tag.name,
-        value: JSON.stringify(tag),
-        valueReference: "TAGS",
-      } as PropertyValue)
-    )
+const toPropertyValueTags = (tags: ProductSearch["tags"]): PropertyValue[] =>
+  tags?.map((tag) =>
+    tag && ({
+      "@type": "PropertyValue",
+      name: tag.name,
+      value: JSON.stringify(tag),
+      valueReference: "TAGS",
+    } as PropertyValue)
+  );
 
 // deno-lint-ignore no-explicit-any
 const isProductVariant = (p: any): p is VariantProductSearch =>
@@ -201,7 +201,7 @@ export const toProduct = (
   const offer = toOffer(variant);
   const offers = offer ? [offer] : [];
 
-  const myTags = "tags" in product ? product.tags : []
+  const myTags = "tags" in product ? product.tags : [];
 
   return {
     "@type": "Product",
@@ -210,7 +210,10 @@ export const toProduct = (
     url: variantUrl,
     name: product.name,
     description: product.description,
-    additionalProperty: [...toPropertyValue(variant), ...toPropertyValueTags(myTags) ],
+    additionalProperty: [
+      ...toPropertyValue(variant),
+      ...toPropertyValueTags(myTags),
+    ],
     inProductGroupWithID: productGroupID,
     gtin: product.reference,
     isVariantOf: {


### PR DESCRIPTION
# Motive

When you call the VNDA search API, you receive a field called "tags." Today, in PDP, we must also receive this field like that, but VNDA has an error in this endpoint. So, I added the possibility to search by ID in the search endpoint (ProductList - Loader) and added the "tags" field in the "additionalProperty."

![image](https://github.com/deco-cx/apps/assets/108771428/eab01f63-9054-4fd5-abbd-0d09f1237285)

# Changes

## transform.ts
![image](https://github.com/deco-cx/apps/assets/108771428/c82b6200-0b53-425a-9aeb-ca096bd05b11)

![Captura de tela de 2023-09-14 15-13-49](https://github.com/deco-cx/apps/assets/108771428/d5f3c1ac-1977-409f-9129-fb43e7d12419)

## productList.ts

![Captura de tela de 2023-09-14 15-13-19](https://github.com/deco-cx/apps/assets/108771428/f19b07e1-725e-45d2-8806-9590b852ff8f)

