### PR TITLE
Deprecate STD VTEX Loaders

### DIFF
--- a/compat/std/loaders/vtex/intelligentSearch/productDetailsPage.ts
+++ b/compat/std/loaders/vtex/intelligentSearch/productDetailsPage.ts
@@ -1,0 +1,20 @@
+import type { ProductDetailsPage } from "../../../../../commerce/types.ts";
+import {
+  Props,
+} from "../../../../../vtex/loaders/intelligentSearch/productDetailsPage.ts";
+import { VTEXContext } from "../../../mod.ts";
+
+/**
+ * @title VTEX Integration - Intelligent Search
+ * @description Product Details Page loader
+ * @deprecated true
+ */
+const loader = async (
+  props: Props,
+  _req: Request,
+  ctx: VTEXContext,
+): Promise<ProductDetailsPage | null> => {
+  return await ctx.invoke.vtex.loaders.intelligentSearch.productDetailsPage(props);
+};
+
+export default loader;

--- a/compat/std/loaders/vtex/intelligentSearch/productList.ts
+++ b/compat/std/loaders/vtex/intelligentSearch/productList.ts
@@ -1,0 +1,20 @@
+import type { Product } from "../../../../../commerce/types.ts";
+import {
+  Props,
+} from "../../../../../vtex/loaders/intelligentSearch/productList.ts";
+import { VTEXContext } from "../../../mod.ts";
+
+/**
+ * @title VTEX Integration - Intelligent Search
+ * @description Product List loader
+ * @deprecated true
+ */
+const loader = async (
+  props: Props,
+  _req: Request,
+  ctx: VTEXContext,
+): Promise<Product[] | null> => {
+  return await ctx.invoke.vtex.loaders.intelligentSearch.productList(props);
+};
+
+export default loader;

--- a/compat/std/loaders/vtex/intelligentSearch/productListingPage.ts
+++ b/compat/std/loaders/vtex/intelligentSearch/productListingPage.ts
@@ -1,0 +1,22 @@
+import type { ProductListingPage } from "../../../../../commerce/types.ts";
+import {
+  Props,
+} from "../../../../../vtex/loaders/intelligentSearch/productListingPage.ts";
+import { VTEXContext } from "../../../mod.ts";
+
+/**
+ * @title VTEX Integration - Intelligent Search
+ * @description Product Listing Page loader
+ * @deprecated true
+ */
+const loader = async (
+  props: Props,
+  _req: Request,
+  ctx: VTEXContext,
+): Promise<ProductListingPage | null> => {
+  return await ctx.invoke.vtex.loaders.intelligentSearch.productListingPage(
+    props,
+  );
+};
+
+export default loader;

--- a/compat/std/loaders/vtex/intelligentSearch/suggestions.ts
+++ b/compat/std/loaders/vtex/intelligentSearch/suggestions.ts
@@ -1,0 +1,22 @@
+import type { Suggestion } from "../../../../../commerce/types.ts";
+import {
+  Props,
+} from "../../../../../vtex/loaders/intelligentSearch/suggestions.ts";
+import { VTEXContext } from "../../../mod.ts";
+
+/**
+ * @title VTEX Integration - Intelligent Search
+ * @description Product Suggestion loader
+ * @deprecated true
+ */
+const loader = async (
+  props: Props,
+  _req: Request,
+  ctx: VTEXContext,
+): Promise<Suggestion | null> => {
+  return await ctx.invoke.vtex.loaders.intelligentSearch.suggestions(
+    props,
+  );
+};
+
+export default loader;

--- a/compat/std/loaders/vtex/legacy/productDetailsPage.ts
+++ b/compat/std/loaders/vtex/legacy/productDetailsPage.ts
@@ -1,0 +1,20 @@
+import type { ProductDetailsPage } from "../../../../../commerce/types.ts";
+import {
+  Props,
+} from "../../../../../vtex/loaders/legacy/productDetailsPage.ts";
+import { VTEXContext } from "../../../mod.ts";
+
+/**
+ * @title VTEX Integration - Legacy Search
+ * @description Product Details Page loader
+ * @deprecated true
+ */
+const loader = async (
+  props: Props,
+  _req: Request,
+  ctx: VTEXContext,
+): Promise<ProductDetailsPage | null> => {
+  return await ctx.invoke.vtex.loaders.legacy.productDetailsPage(props);
+};
+
+export default loader;

--- a/compat/std/loaders/vtex/legacy/productList.ts
+++ b/compat/std/loaders/vtex/legacy/productList.ts
@@ -1,0 +1,20 @@
+import type { Product } from "../../../../../commerce/types.ts";
+import {
+  Props,
+} from "../../../../../vtex/loaders/legacy/productList.ts";
+import { VTEXContext } from "../../../mod.ts";
+
+/**
+ * @title VTEX Integration - Legacy Search
+ * @description Product List loader
+ * @deprecated true
+ */
+const loader = async (
+  props: Props,
+  _req: Request,
+  ctx: VTEXContext,
+): Promise<Product[] | null> => {
+  return await ctx.invoke.vtex.loaders.legacy.productList(props);
+};
+
+export default loader;

--- a/compat/std/loaders/vtex/legacy/productListingPage.ts
+++ b/compat/std/loaders/vtex/legacy/productListingPage.ts
@@ -1,0 +1,22 @@
+import type { ProductListingPage } from "../../../../../commerce/types.ts";
+import {
+  Props,
+} from "../../../../../vtex/loaders/legacy/productListingPage.ts";
+import { VTEXContext } from "../../../mod.ts";
+
+/**
+ * @title VTEX Integration - Legacy Search
+ * @description Product Listing Page loader
+ * @deprecated true
+ */
+const loader = async (
+  props: Props,
+  _req: Request,
+  ctx: VTEXContext,
+): Promise<ProductListingPage | null> => {
+  return await ctx.invoke.vtex.loaders.legacy.productListingPage(
+    props,
+  );
+};
+
+export default loader;

--- a/compat/std/loaders/vtex/legacy/relatedProductsLoader.ts
+++ b/compat/std/loaders/vtex/legacy/relatedProductsLoader.ts
@@ -1,0 +1,22 @@
+import type { Product } from "../../../../../commerce/types.ts";
+import {
+  Props,
+} from "../../../../../vtex/loaders/legacy/relatedProductsLoader.ts";
+import { VTEXContext } from "../../../mod.ts";
+
+/**
+ * @title VTEX Integration - Related Products
+ * @description Related Products loader
+ * @deprecated true
+ */
+const loader = async (
+  props: Props,
+  _req: Request,
+  ctx: VTEXContext,
+): Promise<Product[] | null> => {
+  return await ctx.invoke.vtex.loaders.legacy.relatedProductsLoader(
+    props,
+  );
+};
+
+export default loader;

--- a/compat/std/loaders/vtex/legacy/suggestions.ts
+++ b/compat/std/loaders/vtex/legacy/suggestions.ts
@@ -1,0 +1,21 @@
+import type { Suggestion } from "../../../../../commerce/types.ts";
+import {
+  Props,
+} from "../../../../../vtex/loaders/legacy/suggestions.ts";
+import { VTEXContext } from "../../../mod.ts";
+
+/**
+ * @title Suggestions - VTEX Legacy
+ * @deprecated true
+ */
+const loader = async (
+  props: Props,
+  _req: Request,
+  ctx: VTEXContext,
+): Promise<Suggestion | null> => {
+  return await ctx.invoke.vtex.loaders.legacy.suggestions(
+    props,
+  );
+};
+
+export default loader;

--- a/compat/std/loaders/vtex/navbar.ts
+++ b/compat/std/loaders/vtex/navbar.ts
@@ -1,0 +1,19 @@
+import type { Navbar } from "../../../../commerce/types.ts";
+import {
+  Props,
+} from "../../../../vtex/loaders/navbar.ts";
+import { VTEXContext } from "../../mod.ts";
+
+/**
+ * @title Navbar
+ * @deprecated true
+ */
+const loader = async (
+  props: Props,
+  _req: Request,
+  ctx: VTEXContext,
+): Promise<Navbar[] | null> => {
+  return await ctx.invoke.vtex.loaders.navbar(props);
+};
+
+export default loader;

--- a/compat/std/loaders/vtex/proxy.ts
+++ b/compat/std/loaders/vtex/proxy.ts
@@ -1,0 +1,17 @@
+import { Props } from "../../../../vtex/loaders/proxy.ts";
+import { Route } from "../../../../website/flags/audience.ts";
+import { VTEXContext } from "../../mod.ts";
+
+/**
+ * @title VTEX Proxy Routes
+ * @deprecated true
+ */
+const loader = async (
+  props: Props,
+  _req: Request,
+  ctx: VTEXContext,
+): Promise<Route[]> => {
+  return await ctx.invoke.vtex.loaders.proxy(props);
+};
+
+export default loader;

--- a/compat/std/manifest.gen.ts
+++ b/compat/std/manifest.gen.ts
@@ -13,8 +13,19 @@ import * as $7 from "./functions/vtexProductDetailsPage.ts";
 import * as $8 from "./functions/vtexLegacyProductList.ts";
 import * as $9 from "./functions/vtexLegacyRelatedProductsLoader.ts";
 import * as $10 from "./functions/requestToParam.ts";
-import * as $$$0 from "./loaders/x/redirects.ts";
-import * as $$$1 from "./loaders/x/font.ts";
+import * as $$$0 from "./loaders/vtex/legacy/productList.ts";
+import * as $$$1 from "./loaders/vtex/legacy/productDetailsPage.ts";
+import * as $$$2 from "./loaders/vtex/legacy/productListingPage.ts";
+import * as $$$3 from "./loaders/vtex/legacy/relatedProductsLoader.ts";
+import * as $$$4 from "./loaders/vtex/legacy/suggestions.ts";
+import * as $$$5 from "./loaders/vtex/navbar.ts";
+import * as $$$6 from "./loaders/vtex/proxy.ts";
+import * as $$$7 from "./loaders/vtex/intelligentSearch/productList.ts";
+import * as $$$8 from "./loaders/vtex/intelligentSearch/productDetailsPage.ts";
+import * as $$$9 from "./loaders/vtex/intelligentSearch/productListingPage.ts";
+import * as $$$10 from "./loaders/vtex/intelligentSearch/suggestions.ts";
+import * as $$$11 from "./loaders/x/redirects.ts";
+import * as $$$12 from "./loaders/x/font.ts";
 import * as $$$$$$0 from "./sections/SEOPLP.tsx";
 import * as $$$$$$1 from "./sections/Analytics.tsx";
 import * as $$$$$$2 from "./sections/VTEXPortalDataLayerCompatibility.tsx";
@@ -35,8 +46,19 @@ const manifest = {
     "deco-sites/std/functions/vtexWishlist.ts": $4,
   },
   "loaders": {
-    "deco-sites/std/loaders/x/font.ts": $$$1,
-    "deco-sites/std/loaders/x/redirects.ts": $$$0,
+    "deco-sites/std/loaders/vtex/intelligentSearch/productDetailsPage.ts": $$$8,
+    "deco-sites/std/loaders/vtex/intelligentSearch/productList.ts": $$$7,
+    "deco-sites/std/loaders/vtex/intelligentSearch/productListingPage.ts": $$$9,
+    "deco-sites/std/loaders/vtex/intelligentSearch/suggestions.ts": $$$10,
+    "deco-sites/std/loaders/vtex/legacy/productDetailsPage.ts": $$$1,
+    "deco-sites/std/loaders/vtex/legacy/productList.ts": $$$0,
+    "deco-sites/std/loaders/vtex/legacy/productListingPage.ts": $$$2,
+    "deco-sites/std/loaders/vtex/legacy/relatedProductsLoader.ts": $$$3,
+    "deco-sites/std/loaders/vtex/legacy/suggestions.ts": $$$4,
+    "deco-sites/std/loaders/vtex/navbar.ts": $$$5,
+    "deco-sites/std/loaders/vtex/proxy.ts": $$$6,
+    "deco-sites/std/loaders/x/font.ts": $$$12,
+    "deco-sites/std/loaders/x/redirects.ts": $$$11,
   },
   "sections": {
     "deco-sites/std/sections/Analytics.tsx": $$$$$$1,

--- a/compat/std/mod.ts
+++ b/compat/std/mod.ts
@@ -95,8 +95,6 @@ const manifestMappings = {
     "deco-sites/std/loaders/nuvemShop/nuvemShopProductList.ts": NOT_IMPLEMENTED,
     "deco-sites/std/loaders/nuvemShop/nuvemShopProductListingPage.ts":
       NOT_IMPLEMENTED,
-    "deco-sites/std/loaders/vtex/legacy/suggestions.ts":
-      "vtex/loaders/legacy/suggestions.ts",
     "deco-sites/std/loaders/vnda/cart.ts": "vnda/loaders/cart.ts",
     "deco-sites/std/loaders/vnda/productDetailsPage.ts":
       "vnda/loaders/productDetailsPage.ts",
@@ -105,24 +103,6 @@ const manifestMappings = {
       "vnda/loaders/productListingPage.ts",
     "deco-sites/std/loaders/vnda/proxy.ts": "vnda/loaders/proxy.ts",
     "deco-sites/std/loaders/vtex/cart.ts": "vtex/loaders/cart.ts",
-    "deco-sites/std/loaders/vtex/intelligentSearch/productDetailsPage.ts":
-      "vtex/loaders/intelligentSearch/productDetailsPage.ts",
-    "deco-sites/std/loaders/vtex/intelligentSearch/productList.ts":
-      "vtex/loaders/intelligentSearch/productList.ts",
-    "deco-sites/std/loaders/vtex/intelligentSearch/productListingPage.ts":
-      "vtex/loaders/intelligentSearch/productListingPage.ts",
-    "deco-sites/std/loaders/vtex/intelligentSearch/suggestions.ts":
-      "vtex/loaders/intelligentSearch/suggestions.ts",
-    "deco-sites/std/loaders/vtex/legacy/productDetailsPage.ts":
-      "vtex/loaders/legacy/productDetailsPage.ts",
-    "deco-sites/std/loaders/vtex/legacy/productList.ts":
-      "vtex/loaders/legacy/productList.ts",
-    "deco-sites/std/loaders/vtex/legacy/productListingPage.ts":
-      "vtex/loaders/legacy/productListingPage.ts",
-    "deco-sites/std/loaders/vtex/legacy/relatedProductsLoader.ts":
-      "vtex/loaders/legacy/relatedProductsLoader.ts",
-    "deco-sites/std/loaders/vtex/navbar.ts": "vtex/loaders/navbar.ts",
-    "deco-sites/std/loaders/vtex/proxy.ts": "vtex/loaders/proxy.ts",
     "deco-sites/std/loaders/vtex/user.ts": "vtex/loaders/user.ts",
     "deco-sites/std/loaders/vtex/wishlist.ts": "vtex/loaders/wishlist.ts",
     "deco-sites/std/loaders/x/image.ts": "website/loaders/image.ts",
@@ -275,6 +255,14 @@ export function WithoutCommerce(
     dependencies: [liveApp],
   };
 }
+
+export type VTEXContext = AC<
+  App<
+    Manifest,
+    State,
+    [ReturnType<typeof $live>, ReturnType<typeof vtex>]
+  >
+>;
 
 export type AppContext = AC<ReturnType<typeof Std>>;
 export default function Std(


### PR DESCRIPTION
This makes the admin showing only non-deprecated loaders when selecting loaders