### PR TITLE
Allow category tree filters on vtex legacy filters

### DIFF
--- a/vtex/utils/types.ts
+++ b/vtex/utils/types.ts
@@ -659,6 +659,7 @@ export type LegacyProduct = IProduct & {
 
 export type LegacyFacets = {
   Departments: LegacyFacet[];
+  CategoriesTrees: LegacyFacet[];
   Brands: LegacyFacet[];
   SpecificationFilters: Record<string, LegacyFacet[]>;
 };
@@ -693,6 +694,7 @@ export interface Category {
 }
 
 export interface LegacyFacet {
+  Id: number;
   Quantity: number;
   Name: string;
   Link: string;


### PR DESCRIPTION
Feature description:
This PR Allows the category tree filters to Vtex Legacy ProductListingPage. By sending to front the categories below the current department or category.

Use case:
https://www.austral.com.br/masculino?O=OrderByScoreDESC
https://australroupas.deco.site/masculino?O=OrderByScoreDESC