### PR TITLE
Move apps to decohub and add them as peer deps

### DIFF
--- a/compat/std/mod.ts
+++ b/compat/std/mod.ts
@@ -277,6 +277,12 @@ export default function Std(
     { manifest: AppManifest; sourceMap: SourceMap }
   > = {};
 
+  if (!props.commerce) {
+    throw new Error(
+      "Missing commerce props. Please migrate to apps before removing commerce prop",
+    );
+  }
+
   const commerceApp = commerce(
     props,
   );
@@ -362,7 +368,7 @@ export default function Std(
     manifest: _manifest as Manifest,
     dependencies: [liveApp, {
       ...commerceApp,
-      dependencies: [webSiteApp, commerceApp.dependencies![1]],
+      dependencies: [webSiteApp, commerceApp.dependencies![1]!],
     }],
   };
 }

--- a/decohub/apps/shopify.ts
+++ b/decohub/apps/shopify.ts
@@ -1,0 +1,1 @@
+export { default } from "../../shopify/mod.ts";

--- a/decohub/apps/vnda.ts
+++ b/decohub/apps/vnda.ts
@@ -1,0 +1,1 @@
+export { default } from "../../vnda/mod.ts";

--- a/decohub/apps/vtex.ts
+++ b/decohub/apps/vtex.ts
@@ -1,0 +1,1 @@
+export { default } from "../../vtex/mod.ts";

--- a/decohub/apps/wake.ts
+++ b/decohub/apps/wake.ts
@@ -1,0 +1,1 @@
+export { default } from "../../wake/mod.ts";

--- a/decohub/manifest.gen.ts
+++ b/decohub/manifest.gen.ts
@@ -2,17 +2,25 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$$$$$$$$$0 from "./apps/workflows.ts";
-import * as $$$$$$$$$$$1 from "./apps/admin.ts";
-import * as $$$$$$$$$$$2 from "./apps/handlebars.ts";
-import * as $$$$$$$$$$$3 from "./apps/verified-reviews.ts";
+import * as $$$$$$$$$$$0 from "./apps/wake.ts";
+import * as $$$$$$$$$$$1 from "./apps/workflows.ts";
+import * as $$$$$$$$$$$2 from "./apps/vnda.ts";
+import * as $$$$$$$$$$$3 from "./apps/admin.ts";
+import * as $$$$$$$$$$$4 from "./apps/vtex.ts";
+import * as $$$$$$$$$$$5 from "./apps/shopify.ts";
+import * as $$$$$$$$$$$6 from "./apps/handlebars.ts";
+import * as $$$$$$$$$$$7 from "./apps/verified-reviews.ts";
 
 const manifest = {
   "apps": {
-    "decohub/apps/admin.ts": $$$$$$$$$$$1,
-    "decohub/apps/handlebars.ts": $$$$$$$$$$$2,
-    "decohub/apps/verified-reviews.ts": $$$$$$$$$$$3,
-    "decohub/apps/workflows.ts": $$$$$$$$$$$0,
+    "decohub/apps/admin.ts": $$$$$$$$$$$3,
+    "decohub/apps/handlebars.ts": $$$$$$$$$$$6,
+    "decohub/apps/shopify.ts": $$$$$$$$$$$5,
+    "decohub/apps/verified-reviews.ts": $$$$$$$$$$$7,
+    "decohub/apps/vnda.ts": $$$$$$$$$$$2,
+    "decohub/apps/vtex.ts": $$$$$$$$$$$4,
+    "decohub/apps/wake.ts": $$$$$$$$$$$0,
+    "decohub/apps/workflows.ts": $$$$$$$$$$$1,
   },
   "name": "decohub",
   "baseUrl": import.meta.url,

--- a/shopify/mod.ts
+++ b/shopify/mod.ts
@@ -38,6 +38,8 @@ export interface State extends Props {
   admin: ReturnType<typeof createGraphqlClient>;
 }
 
+export const color = 0x96BF48;
+
 /**
  * @title Shopify
  */

--- a/vnda/mod.ts
+++ b/vnda/mod.ts
@@ -42,6 +42,8 @@ export interface State extends Props {
   api: ReturnType<typeof createHttpClient<OpenAPI>>;
 }
 
+export const color = 0x0C29D0;
+
 /**
  * @title VNDA
  */

--- a/vtex/mod.ts
+++ b/vtex/mod.ts
@@ -32,6 +32,8 @@ interface State extends Props {
   io: ReturnType<typeof createGraphqlClient>;
 }
 
+export const color = 0xF71963;
+
 /**
  * @title VTEX
  */

--- a/wake/mod.ts
+++ b/wake/mod.ts
@@ -39,6 +39,8 @@ export interface State extends Props {
   storefront: ReturnType<typeof createGraphqlClient>;
 }
 
+export const color = 0xB600EE;
+
 /**
  * @title Wake
  */


### PR DESCRIPTION
We currently have all commerce apps as dependencies of the site app. This causes the following dependency graph:

```
site.ts -> commerce.ts -> (vtex.ts | wake.ts | shopify.ts | vnda.ts)
```

The issue with this is that commerce.ts needs to know all commerce platforms. This PR makes it so we have the following dependency graph:

```
site.ts -> commerce.ts
vtex.ts
wake.ts
...
```

This causes the form the go from having a dedicated commerce prop inside site.ts, to the user having to install the app in the apps pannel
before: <img width="388" alt="image" src="https://github.com/deco-cx/apps/assets/1753396/01a4eacc-531a-485c-8325-28753353ec18">
after: 
<img width="1488" alt="image" src="https://github.com/deco-cx/apps/assets/1753396/0f444edd-0a24-4b74-bd65-1601fb80f852">


