### PR TITLE
fix/addPropsCurrentpage

### DIFF
--- a/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -96,6 +96,11 @@ export interface Props {
    * @description Include similar products
    */
   similars?: boolean;
+
+  /**
+   * @ignore
+   */
+  currentPage?: number;
 }
 
 // TODO (mcandeia) investigating bugs related to returning the same set of products but different queries.
@@ -114,7 +119,7 @@ const searchArgsOf = (props: Props, url: URL) => {
   const query = props.query ?? url.searchParams.get("q") ?? "";
   const currentPageoffset = props.pageOffset ?? 1;
   const page =
-    props.pageOffset ??
+    props.currentPage ??
     Math.min(
       url.searchParams.get("page") ? Number(url.searchParams.get("page")) - currentPageoffset : 0,
       VTEX_MAX_PAGES - currentPageoffset

--- a/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -100,7 +100,7 @@ export interface Props {
   /**
    * @ignore
    */
-  currentPage?: number;
+  page?: number;
 }
 
 // TODO (mcandeia) investigating bugs related to returning the same set of products but different queries.
@@ -119,7 +119,7 @@ const searchArgsOf = (props: Props, url: URL) => {
   const query = props.query ?? url.searchParams.get("q") ?? "";
   const currentPageoffset = props.pageOffset ?? 1;
   const page =
-    props.currentPage ??
+    props.page??
     Math.min(
       url.searchParams.get("page") ? Number(url.searchParams.get("page")) - currentPageoffset : 0,
       VTEX_MAX_PAGES - currentPageoffset


### PR DESCRIPTION
Previously, I had submitted a [pull request](https://github.com/deco-cx/apps/pull/61) that received the current page from the pageOffset prop:

``` const page =
  props.pageOffset ??
  Math.min(
    url.searchParams.get("page") ? Number(url.searchParams.get("page")) - currentPageoffset : 0,
    VTEX_MAX_PAGES - currentPageoffset
  );
```
However, this resulted in a bug where it was duplicating the number of pages because in one part of the code, it was adding the page constant to the pageOffset prop.