### PR TITLE
Fix: include meta noindex on empty searchs and PDP

### DIFF
--- a/commerce/sections/Seo/SeoPDP.tsx
+++ b/commerce/sections/Seo/SeoPDP.tsx
@@ -13,6 +13,7 @@ function Section({ jsonLD, ...props }: Props) {
   const canonical = jsonLD?.breadcrumbList
     ? canonicalFromBreadcrumblist(jsonLD?.breadcrumbList)
     : null;
+  const noIndexing = !jsonLD;
 
   return (
     <Seo
@@ -22,6 +23,7 @@ function Section({ jsonLD, ...props }: Props) {
       image={image || props.image}
       canonical={canonical || props.canonical}
       jsonLDs={[jsonLD]}
+      noIndexing={noIndexing}
     />
   );
 }

--- a/commerce/sections/Seo/SeoPLP.tsx
+++ b/commerce/sections/Seo/SeoPLP.tsx
@@ -13,6 +13,8 @@ function Section({ jsonLD, ...props }: Props) {
     ? canonicalFromBreadcrumblist(jsonLD?.breadcrumb)
     : null;
 
+  const noIndexing = !jsonLD || !jsonLD.products.length;
+
   return (
     <Seo
       {...props}
@@ -20,6 +22,7 @@ function Section({ jsonLD, ...props }: Props) {
       description={description || props.description}
       canonical={canonical || props.canonical}
       jsonLDs={[jsonLD]}
+      noIndexing={noIndexing}
     />
   );
 }


### PR DESCRIPTION
When a search return no products, this shouldn't be tracked by search engines, só this meta its required.