### PR TITLE
Feat: add redirect type in redirectsFromCsv

### DIFF
--- a/website/loaders/redirectsFromCsv.ts
+++ b/website/loaders/redirectsFromCsv.ts
@@ -1,6 +1,8 @@
 import { join } from "std/path/mod.ts";
 import { Route } from "../flags/audience.ts";
 
+const REDIRECT_TYPE_ENUM = ["temporary", "permanent"];
+
 /** @titleBy from */
 export interface Redirect {
   from: string;
@@ -30,23 +32,37 @@ const getRedirectFromFile = async (from: string) => {
     return [];
   }
 
-  const redirectsFromFiles: Redirects["redirects"] = redirectsRaw?.split("\r\n")
-    .slice(1).map((row) => {
-      const parts = row.split(",");
+  const redirectsFromFiles: Redirects["redirects"] = redirectsRaw
+    ?.split("\r\n")
+    .slice(1)
+    .map((row) => {
+      // this regex is necessary to handle csv with comma as part of value
+      const parts = row.split(/,(?=(?:(?:[^"]*"){2})*[^"]*$)/);
+
+      const typeRowIndex = parts.findIndex((part: string) =>
+        REDIRECT_TYPE_ENUM.includes(part)
+      );
+
+      const type = (parts[typeRowIndex] as Redirect["type"]) ?? "temporary";
+
+      if (typeRowIndex !== -1) {
+        parts.splice(typeRowIndex, 1);
+      }
+
       const last = parts[parts.length - 1];
       parts.splice(parts.length - 1, 1);
+
       return [
         removeTrailingSlash(parts.join(",").replaceAll('"', "")),
-        removeTrailingSlash(last),
+        removeTrailingSlash(last.replaceAll('"', "")),
+        type,
       ];
-    }).filter((
-      [from, to],
-    ) => from && to && from !== to).map((
-      [from, to],
-    ) => ({
+    })
+    .filter(([from, to]) => from && to && from !== to)
+    .map(([from, to, type]) => ({
       from,
       to,
-      type: "temporary",
+      type: type as Redirect["type"],
     }));
 
   return redirectsFromFiles.map(({ from, to, type }) => ({
@@ -65,16 +81,15 @@ const getRedirectFromFile = async (from: string) => {
 export const removeTrailingSlash = (path: string) =>
   path.endsWith("/") && path.length > 1 ? path.slice(0, path.length - 1) : path;
 
-export default async function redirect(
-  { redirects, from }: Redirects,
-): Promise<Route[]> {
+export default async function redirect({
+  redirects,
+  from,
+}: Redirects): Promise<Route[]> {
   redirectsFromFile ??= from ? getRedirectFromFile(from) : Promise.resolve([]);
 
   const redirectsFromFiles: Route[] = await redirectsFromFile;
 
-  const routes: Route[] = (redirects || []).map((
-    { from, to, type },
-  ) => ({
+  const routes: Route[] = (redirects || []).map(({ from, to, type }) => ({
     pathTemplate: from,
     isHref: true,
     handler: {


### PR DESCRIPTION
this PR

**add:** the possiblity to provide a redirect type on csv, before its allways generated a temp redirect,

**fix:** the split function uses a simple comma as parameter, but when column has a comma as value its not working result in a wrong url `to` and wrong url `for`