### PR TITLE
Fix vtex plp loader

### DIFF
--- a/admin/manifest.gen.ts
+++ b/admin/manifest.gen.ts
@@ -2,34 +2,34 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/blocks/revision.ts";
-import * as $$$1 from "./loaders/blocks/published.ts";
-import * as $$$2 from "./loaders/blocks/latest.ts";
-import * as $$$3 from "./loaders/blocks/listRevisions.ts";
-import * as $$$4 from "./loaders/state.ts";
-import * as $$$5 from "./loaders/releases/blocks.ts";
-import * as $$$$$$$$$0 from "./actions/blocks/publish.ts";
-import * as $$$$$$$$$1 from "./actions/blocks/restore.ts";
-import * as $$$$$$$$$2 from "./actions/blocks/safeDelete.ts";
-import * as $$$$$$$$$3 from "./actions/blocks/newRevision.ts";
-import * as $$$$$$$$$4 from "./actions/blocks/delete.ts";
+import * as $$$0 from "./loaders/releases/blocks.ts";
+import * as $$$1 from "./loaders/state.ts";
+import * as $$$2 from "./loaders/blocks/revision.ts";
+import * as $$$3 from "./loaders/blocks/published.ts";
+import * as $$$4 from "./loaders/blocks/latest.ts";
+import * as $$$5 from "./loaders/blocks/listRevisions.ts";
+import * as $$$$$$$$$0 from "./actions/blocks/safeDelete.ts";
+import * as $$$$$$$$$1 from "./actions/blocks/newRevision.ts";
+import * as $$$$$$$$$2 from "./actions/blocks/delete.ts";
+import * as $$$$$$$$$3 from "./actions/blocks/publish.ts";
+import * as $$$$$$$$$4 from "./actions/blocks/restore.ts";
 import * as $$$$$$$$$5 from "./actions/pages/publish.ts";
 
 const manifest = {
   "loaders": {
-    "deco-sites/admin/loaders/blocks/latest.ts": $$$2,
-    "deco-sites/admin/loaders/blocks/listRevisions.ts": $$$3,
-    "deco-sites/admin/loaders/blocks/published.ts": $$$1,
-    "deco-sites/admin/loaders/blocks/revision.ts": $$$0,
-    "deco-sites/admin/loaders/releases/blocks.ts": $$$5,
-    "deco-sites/admin/loaders/state.ts": $$$4,
+    "deco-sites/admin/loaders/blocks/latest.ts": $$$4,
+    "deco-sites/admin/loaders/blocks/listRevisions.ts": $$$5,
+    "deco-sites/admin/loaders/blocks/published.ts": $$$3,
+    "deco-sites/admin/loaders/blocks/revision.ts": $$$2,
+    "deco-sites/admin/loaders/releases/blocks.ts": $$$0,
+    "deco-sites/admin/loaders/state.ts": $$$1,
   },
   "actions": {
-    "deco-sites/admin/actions/blocks/delete.ts": $$$$$$$$$4,
-    "deco-sites/admin/actions/blocks/newRevision.ts": $$$$$$$$$3,
-    "deco-sites/admin/actions/blocks/publish.ts": $$$$$$$$$0,
-    "deco-sites/admin/actions/blocks/restore.ts": $$$$$$$$$1,
-    "deco-sites/admin/actions/blocks/safeDelete.ts": $$$$$$$$$2,
+    "deco-sites/admin/actions/blocks/delete.ts": $$$$$$$$$2,
+    "deco-sites/admin/actions/blocks/newRevision.ts": $$$$$$$$$1,
+    "deco-sites/admin/actions/blocks/publish.ts": $$$$$$$$$3,
+    "deco-sites/admin/actions/blocks/restore.ts": $$$$$$$$$4,
+    "deco-sites/admin/actions/blocks/safeDelete.ts": $$$$$$$$$0,
     "deco-sites/admin/actions/pages/publish.ts": $$$$$$$$$5,
   },
   "name": "deco-sites/admin",

--- a/algolia/manifest.gen.ts
+++ b/algolia/manifest.gen.ts
@@ -3,8 +3,8 @@
 // This file is automatically updated during development when running `dev.ts`.
 
 import * as $$$0 from "./loaders/product/listingPage.ts";
-import * as $$$1 from "./loaders/product/list.ts";
-import * as $$$2 from "./loaders/product/suggestions.ts";
+import * as $$$1 from "./loaders/product/suggestions.ts";
+import * as $$$2 from "./loaders/product/list.ts";
 import * as $$$$$$$$$0 from "./actions/setup.ts";
 import * as $$$$$$$$$1 from "./actions/index/product.ts";
 import * as $$$$$$$$$2 from "./actions/index/wait.ts";
@@ -12,9 +12,9 @@ import * as $$$$$$$$$$0 from "./workflows/index/product.ts";
 
 const manifest = {
   "loaders": {
-    "algolia/loaders/product/list.ts": $$$1,
+    "algolia/loaders/product/list.ts": $$$2,
     "algolia/loaders/product/listingPage.ts": $$$0,
-    "algolia/loaders/product/suggestions.ts": $$$2,
+    "algolia/loaders/product/suggestions.ts": $$$1,
   },
   "actions": {
     "algolia/actions/index/product.ts": $$$$$$$$$1,

--- a/compat/$live/manifest.gen.ts
+++ b/compat/$live/manifest.gen.ts
@@ -6,8 +6,8 @@ import * as $$$0 from "./loaders/state.ts";
 import * as $$$$0 from "./handlers/router.ts";
 import * as $$$$1 from "./handlers/devPage.ts";
 import * as $$$$$$0 from "./sections/Slot.tsx";
-import * as $$$$$$1 from "./sections/EmptySection.tsx";
-import * as $$$$$$2 from "./sections/PageInclude.tsx";
+import * as $$$$$$1 from "./sections/PageInclude.tsx";
+import * as $$$$$$2 from "./sections/EmptySection.tsx";
 
 const manifest = {
   "loaders": {
@@ -18,8 +18,8 @@ const manifest = {
     "$live/handlers/router.ts": $$$$0,
   },
   "sections": {
-    "$live/sections/EmptySection.tsx": $$$$$$1,
-    "$live/sections/PageInclude.tsx": $$$$$$2,
+    "$live/sections/EmptySection.tsx": $$$$$$2,
+    "$live/sections/PageInclude.tsx": $$$$$$1,
     "$live/sections/Slot.tsx": $$$$$$0,
   },
   "name": "$live",

--- a/compat/std/manifest.gen.ts
+++ b/compat/std/manifest.gen.ts
@@ -2,69 +2,70 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $0 from "./functions/vtexProductListingPage.ts";
-import * as $1 from "./functions/vtexLegacyProductDetailsPage.ts";
-import * as $2 from "./functions/vtexSuggestions.ts";
-import * as $3 from "./functions/vtexNavbar.ts";
-import * as $4 from "./functions/vtexWishlist.ts";
-import * as $5 from "./functions/vtexProductList.ts";
-import * as $6 from "./functions/vtexLegacyProductListingPage.ts";
-import * as $7 from "./functions/vtexProductDetailsPage.ts";
-import * as $8 from "./functions/vtexLegacyProductList.ts";
+import * as $0 from "./functions/vtexLegacyProductList.ts";
+import * as $1 from "./functions/vtexProductListingPage.ts";
+import * as $2 from "./functions/vtexProductList.ts";
+import * as $3 from "./functions/vtexWishlist.ts";
+import * as $4 from "./functions/requestToParam.ts";
+import * as $5 from "./functions/vtexSuggestions.ts";
+import * as $6 from "./functions/vtexLegacyProductDetailsPage.ts";
+import * as $7 from "./functions/vtexLegacyProductListingPage.ts";
+import * as $8 from "./functions/vtexProductDetailsPage.ts";
 import * as $9 from "./functions/vtexLegacyRelatedProductsLoader.ts";
-import * as $10 from "./functions/requestToParam.ts";
-import * as $$$0 from "./loaders/vtex/legacy/productList.ts";
+import * as $10 from "./functions/vtexNavbar.ts";
+import * as $$$0 from "./loaders/vtex/legacy/relatedProductsLoader.ts";
 import * as $$$1 from "./loaders/vtex/legacy/productDetailsPage.ts";
-import * as $$$2 from "./loaders/vtex/legacy/productListingPage.ts";
-import * as $$$3 from "./loaders/vtex/legacy/relatedProductsLoader.ts";
-import * as $$$4 from "./loaders/vtex/legacy/suggestions.ts";
+import * as $$$2 from "./loaders/vtex/legacy/productList.ts";
+import * as $$$3 from "./loaders/vtex/legacy/suggestions.ts";
+import * as $$$4 from "./loaders/vtex/legacy/productListingPage.ts";
 import * as $$$5 from "./loaders/vtex/navbar.ts";
 import * as $$$6 from "./loaders/vtex/proxy.ts";
-import * as $$$7 from "./loaders/vtex/intelligentSearch/productList.ts";
-import * as $$$8 from "./loaders/vtex/intelligentSearch/productDetailsPage.ts";
-import * as $$$9 from "./loaders/vtex/intelligentSearch/productListingPage.ts";
-import * as $$$10 from "./loaders/vtex/intelligentSearch/suggestions.ts";
+import * as $$$7 from "./loaders/vtex/intelligentSearch/productDetailsPage.ts";
+import * as $$$8 from "./loaders/vtex/intelligentSearch/productList.ts";
+import * as $$$9 from "./loaders/vtex/intelligentSearch/suggestions.ts";
+import * as $$$10 from "./loaders/vtex/intelligentSearch/productListingPage.ts";
 import * as $$$11 from "./loaders/x/redirects.ts";
 import * as $$$12 from "./loaders/x/font.ts";
 import * as $$$$$$0 from "./sections/SEOPLP.tsx";
-import * as $$$$$$1 from "./sections/Analytics.tsx";
-import * as $$$$$$2 from "./sections/VTEXPortalDataLayerCompatibility.tsx";
+import * as $$$$$$1 from "./sections/VTEXPortalDataLayerCompatibility.tsx";
+import * as $$$$$$2 from "./sections/Analytics.tsx";
 import * as $$$$$$3 from "./sections/SEOPDP.tsx";
 
 const manifest = {
   "functions": {
-    "deco-sites/std/functions/requestToParam.ts": $10,
-    "deco-sites/std/functions/vtexLegacyProductDetailsPage.ts": $1,
-    "deco-sites/std/functions/vtexLegacyProductList.ts": $8,
-    "deco-sites/std/functions/vtexLegacyProductListingPage.ts": $6,
+    "deco-sites/std/functions/requestToParam.ts": $4,
+    "deco-sites/std/functions/vtexLegacyProductDetailsPage.ts": $6,
+    "deco-sites/std/functions/vtexLegacyProductList.ts": $0,
+    "deco-sites/std/functions/vtexLegacyProductListingPage.ts": $7,
     "deco-sites/std/functions/vtexLegacyRelatedProductsLoader.ts": $9,
-    "deco-sites/std/functions/vtexNavbar.ts": $3,
-    "deco-sites/std/functions/vtexProductDetailsPage.ts": $7,
-    "deco-sites/std/functions/vtexProductList.ts": $5,
-    "deco-sites/std/functions/vtexProductListingPage.ts": $0,
-    "deco-sites/std/functions/vtexSuggestions.ts": $2,
-    "deco-sites/std/functions/vtexWishlist.ts": $4,
+    "deco-sites/std/functions/vtexNavbar.ts": $10,
+    "deco-sites/std/functions/vtexProductDetailsPage.ts": $8,
+    "deco-sites/std/functions/vtexProductList.ts": $2,
+    "deco-sites/std/functions/vtexProductListingPage.ts": $1,
+    "deco-sites/std/functions/vtexSuggestions.ts": $5,
+    "deco-sites/std/functions/vtexWishlist.ts": $3,
   },
   "loaders": {
-    "deco-sites/std/loaders/vtex/intelligentSearch/productDetailsPage.ts": $$$8,
-    "deco-sites/std/loaders/vtex/intelligentSearch/productList.ts": $$$7,
-    "deco-sites/std/loaders/vtex/intelligentSearch/productListingPage.ts": $$$9,
-    "deco-sites/std/loaders/vtex/intelligentSearch/suggestions.ts": $$$10,
+    "deco-sites/std/loaders/vtex/intelligentSearch/productDetailsPage.ts": $$$7,
+    "deco-sites/std/loaders/vtex/intelligentSearch/productList.ts": $$$8,
+    "deco-sites/std/loaders/vtex/intelligentSearch/productListingPage.ts":
+      $$$10,
+    "deco-sites/std/loaders/vtex/intelligentSearch/suggestions.ts": $$$9,
     "deco-sites/std/loaders/vtex/legacy/productDetailsPage.ts": $$$1,
-    "deco-sites/std/loaders/vtex/legacy/productList.ts": $$$0,
-    "deco-sites/std/loaders/vtex/legacy/productListingPage.ts": $$$2,
-    "deco-sites/std/loaders/vtex/legacy/relatedProductsLoader.ts": $$$3,
-    "deco-sites/std/loaders/vtex/legacy/suggestions.ts": $$$4,
+    "deco-sites/std/loaders/vtex/legacy/productList.ts": $$$2,
+    "deco-sites/std/loaders/vtex/legacy/productListingPage.ts": $$$4,
+    "deco-sites/std/loaders/vtex/legacy/relatedProductsLoader.ts": $$$0,
+    "deco-sites/std/loaders/vtex/legacy/suggestions.ts": $$$3,
     "deco-sites/std/loaders/vtex/navbar.ts": $$$5,
     "deco-sites/std/loaders/vtex/proxy.ts": $$$6,
     "deco-sites/std/loaders/x/font.ts": $$$12,
     "deco-sites/std/loaders/x/redirects.ts": $$$11,
   },
   "sections": {
-    "deco-sites/std/sections/Analytics.tsx": $$$$$$1,
+    "deco-sites/std/sections/Analytics.tsx": $$$$$$2,
     "deco-sites/std/sections/SEOPDP.tsx": $$$$$$3,
     "deco-sites/std/sections/SEOPLP.tsx": $$$$$$0,
-    "deco-sites/std/sections/VTEXPortalDataLayerCompatibility.tsx": $$$$$$2,
+    "deco-sites/std/sections/VTEXPortalDataLayerCompatibility.tsx": $$$$$$1,
   },
   "name": "deco-sites/std",
   "baseUrl": import.meta.url,

--- a/decohub/manifest.gen.ts
+++ b/decohub/manifest.gen.ts
@@ -2,33 +2,33 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$$$$$$$$$0 from "./apps/typesense.ts";
+import * as $$$$$$$$$$$0 from "./apps/vtex.ts";
 import * as $$$$$$$$$$$1 from "./apps/wake.ts";
-import * as $$$$$$$$$$$2 from "./apps/analytics.ts";
+import * as $$$$$$$$$$$2 from "./apps/shopify.ts";
 import * as $$$$$$$$$$$3 from "./apps/workflows.ts";
-import * as $$$$$$$$$$$4 from "./apps/vnda.ts";
-import * as $$$$$$$$$$$5 from "./apps/algolia.ts";
-import * as $$$$$$$$$$$6 from "./apps/admin.ts";
-import * as $$$$$$$$$$$7 from "./apps/linx.ts";
-import * as $$$$$$$$$$$8 from "./apps/vtex.ts";
-import * as $$$$$$$$$$$9 from "./apps/shopify.ts";
-import * as $$$$$$$$$$$10 from "./apps/handlebars.ts";
-import * as $$$$$$$$$$$11 from "./apps/verified-reviews.ts";
+import * as $$$$$$$$$$$4 from "./apps/linx.ts";
+import * as $$$$$$$$$$$5 from "./apps/verified-reviews.ts";
+import * as $$$$$$$$$$$6 from "./apps/algolia.ts";
+import * as $$$$$$$$$$$7 from "./apps/typesense.ts";
+import * as $$$$$$$$$$$8 from "./apps/analytics.ts";
+import * as $$$$$$$$$$$9 from "./apps/vnda.ts";
+import * as $$$$$$$$$$$10 from "./apps/admin.ts";
+import * as $$$$$$$$$$$11 from "./apps/handlebars.ts";
 import * as $$$$$$$$$$$12 from "./apps/power-reviews.ts";
 
 const manifest = {
   "apps": {
-    "decohub/apps/admin.ts": $$$$$$$$$$$6,
-    "decohub/apps/algolia.ts": $$$$$$$$$$$5,
-    "decohub/apps/analytics.ts": $$$$$$$$$$$2,
-    "decohub/apps/handlebars.ts": $$$$$$$$$$$10,
-    "decohub/apps/linx.ts": $$$$$$$$$$$7,
+    "decohub/apps/admin.ts": $$$$$$$$$$$10,
+    "decohub/apps/algolia.ts": $$$$$$$$$$$6,
+    "decohub/apps/analytics.ts": $$$$$$$$$$$8,
+    "decohub/apps/handlebars.ts": $$$$$$$$$$$11,
+    "decohub/apps/linx.ts": $$$$$$$$$$$4,
     "decohub/apps/power-reviews.ts": $$$$$$$$$$$12,
-    "decohub/apps/shopify.ts": $$$$$$$$$$$9,
-    "decohub/apps/typesense.ts": $$$$$$$$$$$0,
-    "decohub/apps/verified-reviews.ts": $$$$$$$$$$$11,
-    "decohub/apps/vnda.ts": $$$$$$$$$$$4,
-    "decohub/apps/vtex.ts": $$$$$$$$$$$8,
+    "decohub/apps/shopify.ts": $$$$$$$$$$$2,
+    "decohub/apps/typesense.ts": $$$$$$$$$$$7,
+    "decohub/apps/verified-reviews.ts": $$$$$$$$$$$5,
+    "decohub/apps/vnda.ts": $$$$$$$$$$$9,
+    "decohub/apps/vtex.ts": $$$$$$$$$$$0,
     "decohub/apps/wake.ts": $$$$$$$$$$$1,
     "decohub/apps/workflows.ts": $$$$$$$$$$$3,
   },

--- a/linx/manifest.gen.ts
+++ b/linx/manifest.gen.ts
@@ -2,33 +2,33 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/path.ts";
-import * as $$$1 from "./loaders/pages.ts";
-import * as $$$2 from "./loaders/product/listingPage.ts";
-import * as $$$3 from "./loaders/product/detailsPage.ts";
-import * as $$$4 from "./loaders/product/list.ts";
-import * as $$$5 from "./loaders/product/suggestions.ts";
-import * as $$$6 from "./loaders/page.ts";
-import * as $$$7 from "./loaders/cart.ts";
-import * as $$$$$$$$$0 from "./actions/cart/updateItem.ts";
+import * as $$$0 from "./loaders/product/detailsPage.ts";
+import * as $$$1 from "./loaders/product/listingPage.ts";
+import * as $$$2 from "./loaders/product/suggestions.ts";
+import * as $$$3 from "./loaders/product/list.ts";
+import * as $$$4 from "./loaders/path.ts";
+import * as $$$5 from "./loaders/page.ts";
+import * as $$$6 from "./loaders/cart.ts";
+import * as $$$7 from "./loaders/pages.ts";
+import * as $$$$$$$$$0 from "./actions/cart/addItem.ts";
 import * as $$$$$$$$$1 from "./actions/cart/addCoupon.ts";
-import * as $$$$$$$$$2 from "./actions/cart/addItem.ts";
+import * as $$$$$$$$$2 from "./actions/cart/updateItem.ts";
 
 const manifest = {
   "loaders": {
-    "linx/loaders/cart.ts": $$$7,
-    "linx/loaders/page.ts": $$$6,
-    "linx/loaders/pages.ts": $$$1,
-    "linx/loaders/path.ts": $$$0,
-    "linx/loaders/product/detailsPage.ts": $$$3,
-    "linx/loaders/product/list.ts": $$$4,
-    "linx/loaders/product/listingPage.ts": $$$2,
-    "linx/loaders/product/suggestions.ts": $$$5,
+    "linx/loaders/cart.ts": $$$6,
+    "linx/loaders/page.ts": $$$5,
+    "linx/loaders/pages.ts": $$$7,
+    "linx/loaders/path.ts": $$$4,
+    "linx/loaders/product/detailsPage.ts": $$$0,
+    "linx/loaders/product/list.ts": $$$3,
+    "linx/loaders/product/listingPage.ts": $$$1,
+    "linx/loaders/product/suggestions.ts": $$$2,
   },
   "actions": {
     "linx/actions/cart/addCoupon.ts": $$$$$$$$$1,
-    "linx/actions/cart/addItem.ts": $$$$$$$$$2,
-    "linx/actions/cart/updateItem.ts": $$$$$$$$$0,
+    "linx/actions/cart/addItem.ts": $$$$$$$$$0,
+    "linx/actions/cart/updateItem.ts": $$$$$$$$$2,
   },
   "name": "linx",
   "baseUrl": import.meta.url,

--- a/power-reviews/manifest.gen.ts
+++ b/power-reviews/manifest.gen.ts
@@ -2,8 +2,8 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/productList.ts";
-import * as $$$1 from "./loaders/productDetailsPage.ts";
+import * as $$$0 from "./loaders/productDetailsPage.ts";
+import * as $$$1 from "./loaders/productList.ts";
 import * as $$$2 from "./loaders/reviewForm.ts";
 import * as $$$3 from "./loaders/review.ts";
 import * as $$$4 from "./loaders/productListingPage.ts";
@@ -13,8 +13,8 @@ import * as $$$$$$$$$0 from "./actions/submitReview.ts";
 
 const manifest = {
   "loaders": {
-    "power-reviews/loaders/productDetailsPage.ts": $$$1,
-    "power-reviews/loaders/productList.ts": $$$0,
+    "power-reviews/loaders/productDetailsPage.ts": $$$0,
+    "power-reviews/loaders/productList.ts": $$$1,
     "power-reviews/loaders/productListingPage.ts": $$$4,
     "power-reviews/loaders/review.ts": $$$3,
     "power-reviews/loaders/reviewForm.ts": $$$2,

--- a/shopify/manifest.gen.ts
+++ b/shopify/manifest.gen.ts
@@ -2,23 +2,23 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/ProductList.ts";
+import * as $$$0 from "./loaders/ProductListingPage.ts";
 import * as $$$1 from "./loaders/ProductDetailsPage.ts";
-import * as $$$2 from "./loaders/ProductListingPage.ts";
+import * as $$$2 from "./loaders/cart.ts";
 import * as $$$3 from "./loaders/proxy.ts";
-import * as $$$4 from "./loaders/cart.ts";
+import * as $$$4 from "./loaders/ProductList.ts";
 import * as $$$$0 from "./handlers/sitemap.ts";
 import * as $$$$$$$$$0 from "./actions/order/draftOrderCalculate.ts";
-import * as $$$$$$$$$1 from "./actions/cart/updateCoupons.ts";
-import * as $$$$$$$$$2 from "./actions/cart/updateItems.ts";
+import * as $$$$$$$$$1 from "./actions/cart/updateItems.ts";
+import * as $$$$$$$$$2 from "./actions/cart/updateCoupons.ts";
 import * as $$$$$$$$$3 from "./actions/cart/addItems.ts";
 
 const manifest = {
   "loaders": {
-    "shopify/loaders/cart.ts": $$$4,
+    "shopify/loaders/cart.ts": $$$2,
     "shopify/loaders/ProductDetailsPage.ts": $$$1,
-    "shopify/loaders/ProductList.ts": $$$0,
-    "shopify/loaders/ProductListingPage.ts": $$$2,
+    "shopify/loaders/ProductList.ts": $$$4,
+    "shopify/loaders/ProductListingPage.ts": $$$0,
     "shopify/loaders/proxy.ts": $$$3,
   },
   "handlers": {
@@ -26,8 +26,8 @@ const manifest = {
   },
   "actions": {
     "shopify/actions/cart/addItems.ts": $$$$$$$$$3,
-    "shopify/actions/cart/updateCoupons.ts": $$$$$$$$$1,
-    "shopify/actions/cart/updateItems.ts": $$$$$$$$$2,
+    "shopify/actions/cart/updateCoupons.ts": $$$$$$$$$2,
+    "shopify/actions/cart/updateItems.ts": $$$$$$$$$1,
     "shopify/actions/order/draftOrderCalculate.ts": $$$$$$$$$0,
   },
   "name": "shopify",

--- a/verified-reviews/manifest.gen.ts
+++ b/verified-reviews/manifest.gen.ts
@@ -2,13 +2,13 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/productList.ts";
-import * as $$$1 from "./loaders/productDetailsPage.ts";
+import * as $$$0 from "./loaders/productDetailsPage.ts";
+import * as $$$1 from "./loaders/productList.ts";
 
 const manifest = {
   "loaders": {
-    "verified-reviews/loaders/productDetailsPage.ts": $$$1,
-    "verified-reviews/loaders/productList.ts": $$$0,
+    "verified-reviews/loaders/productDetailsPage.ts": $$$0,
+    "verified-reviews/loaders/productList.ts": $$$1,
   },
   "name": "verified-reviews",
   "baseUrl": import.meta.url,

--- a/vnda/manifest.gen.ts
+++ b/vnda/manifest.gen.ts
@@ -2,29 +2,29 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/productList.ts";
-import * as $$$1 from "./loaders/productDetailsPage.ts";
-import * as $$$2 from "./loaders/productListingPage.ts";
+import * as $$$0 from "./loaders/productDetailsPage.ts";
+import * as $$$1 from "./loaders/productList.ts";
+import * as $$$2 from "./loaders/cart.ts";
 import * as $$$3 from "./loaders/proxy.ts";
-import * as $$$4 from "./loaders/cart.ts";
-import * as $$$$$$$$$0 from "./actions/cart/updateItem.ts";
+import * as $$$4 from "./loaders/productListingPage.ts";
+import * as $$$$$$$$$0 from "./actions/cart/addItem.ts";
 import * as $$$$$$$$$1 from "./actions/cart/updateCart.ts";
-import * as $$$$$$$$$2 from "./actions/cart/addItem.ts";
+import * as $$$$$$$$$2 from "./actions/cart/updateItem.ts";
 import * as $$$$$$$$$3 from "./actions/cart/simulation.ts";
 
 const manifest = {
   "loaders": {
-    "vnda/loaders/cart.ts": $$$4,
-    "vnda/loaders/productDetailsPage.ts": $$$1,
-    "vnda/loaders/productList.ts": $$$0,
-    "vnda/loaders/productListingPage.ts": $$$2,
+    "vnda/loaders/cart.ts": $$$2,
+    "vnda/loaders/productDetailsPage.ts": $$$0,
+    "vnda/loaders/productList.ts": $$$1,
+    "vnda/loaders/productListingPage.ts": $$$4,
     "vnda/loaders/proxy.ts": $$$3,
   },
   "actions": {
-    "vnda/actions/cart/addItem.ts": $$$$$$$$$2,
+    "vnda/actions/cart/addItem.ts": $$$$$$$$$0,
     "vnda/actions/cart/simulation.ts": $$$$$$$$$3,
     "vnda/actions/cart/updateCart.ts": $$$$$$$$$1,
-    "vnda/actions/cart/updateItem.ts": $$$$$$$$$0,
+    "vnda/actions/cart/updateItem.ts": $$$$$$$$$2,
   },
   "name": "vnda",
   "baseUrl": import.meta.url,

--- a/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -299,7 +299,7 @@ const loader = async (
           ...params,
           facets: toPath(selected),
         },
-        { ...STALE,  headers: segment ? withSegmentCookie(segment) : undefined },
+        { ...STALE, headers: segment ? withSegmentCookie(segment) : undefined },
       ).then((res) => res.json()),
     vcsDeprecated["GET /api/io/_v/api/intelligent-search/facets/*facets"](
       {

--- a/vtex/loaders/legacy/productListingPage.ts
+++ b/vtex/loaders/legacy/productListingPage.ts
@@ -167,7 +167,7 @@ const loader = async (
   const missingParams = typeof maybeMap !== "string" || !maybeTerm;
   const [map, term] = missingParams
     ? getMapAndTerm(pageTypes)
-    : [maybeMap, maybeTerm];
+    : [maybeMap, maybeMap === "productClusterIds,c" ? maybeTerm.split("/").map((value, index) => (index === 1 ? pageTypes[0].id : value)).join("/") : maybeTerm];
 
   const fmap = url.searchParams.get("fmap") ?? map;
   const args = { map, _from, _to, O, ft, fq };

--- a/vtex/loaders/legacy/productListingPage.ts
+++ b/vtex/loaders/legacy/productListingPage.ts
@@ -165,9 +165,15 @@ const loader = async (
   }
 
   const missingParams = typeof maybeMap !== "string" || !maybeTerm;
-  const [map, term] = missingParams
-    ? getMapAndTerm(pageTypes)
-    : [maybeMap, maybeMap === "productClusterIds,c" ? maybeTerm.split("/").map((value, index) => (index === 1 ? pageTypes[0].id : value)).join("/") : maybeTerm];
+  const [map, term] = missingParams ? getMapAndTerm(pageTypes) : [
+    maybeMap,
+    maybeMap === "productClusterIds,c"
+      ? maybeTerm.split("/").map((
+        value,
+        index,
+      ) => (index === 1 ? pageTypes[0].id : value)).join("/")
+      : maybeTerm,
+  ];
 
   const fmap = url.searchParams.get("fmap") ?? map;
   const args = { map, _from, _to, O, ft, fq };

--- a/vtex/manifest.gen.ts
+++ b/vtex/manifest.gen.ts
@@ -2,90 +2,90 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/product.ts";
-import * as $$$1 from "./loaders/legacy/productList.ts";
-import * as $$$2 from "./loaders/legacy/productDetailsPage.ts";
-import * as $$$3 from "./loaders/legacy/productListingPage.ts";
-import * as $$$4 from "./loaders/legacy/relatedProductsLoader.ts";
-import * as $$$5 from "./loaders/legacy/suggestions.ts";
-import * as $$$6 from "./loaders/product/extensions/simulation/listingPage.ts";
-import * as $$$7 from "./loaders/product/extensions/simulation/detailsPage.ts";
-import * as $$$8 from "./loaders/product/extensions/simulation/list.ts";
-import * as $$$9 from "./loaders/wishlist.ts";
-import * as $$$10 from "./loaders/navbar.ts";
-import * as $$$11 from "./loaders/proxy.ts";
-import * as $$$12 from "./loaders/intelligentSearch/productList.ts";
+import * as $$$0 from "./loaders/product/extensions/simulation/detailsPage.ts";
+import * as $$$1 from "./loaders/product/extensions/simulation/listingPage.ts";
+import * as $$$2 from "./loaders/product/extensions/simulation/list.ts";
+import * as $$$3 from "./loaders/legacy/relatedProductsLoader.ts";
+import * as $$$4 from "./loaders/legacy/productDetailsPage.ts";
+import * as $$$5 from "./loaders/legacy/productList.ts";
+import * as $$$6 from "./loaders/legacy/suggestions.ts";
+import * as $$$7 from "./loaders/legacy/productListingPage.ts";
+import * as $$$8 from "./loaders/product.ts";
+import * as $$$9 from "./loaders/navbar.ts";
+import * as $$$10 from "./loaders/wishlist.ts";
+import * as $$$11 from "./loaders/cart.ts";
+import * as $$$12 from "./loaders/proxy.ts";
 import * as $$$13 from "./loaders/intelligentSearch/productDetailsPage.ts";
-import * as $$$14 from "./loaders/intelligentSearch/productListingPage.ts";
+import * as $$$14 from "./loaders/intelligentSearch/productList.ts";
 import * as $$$15 from "./loaders/intelligentSearch/suggestions.ts";
-import * as $$$16 from "./loaders/cart.ts";
+import * as $$$16 from "./loaders/intelligentSearch/productListingPage.ts";
 import * as $$$17 from "./loaders/user.ts";
 import * as $$$$0 from "./handlers/sitemap.ts";
 import * as $$$$$$$$$0 from "./actions/trigger.ts";
 import * as $$$$$$$$$1 from "./actions/notifyme.ts";
-import * as $$$$$$$$$2 from "./actions/cart/updateCoupons.ts";
-import * as $$$$$$$$$3 from "./actions/cart/updateAttachment.ts";
-import * as $$$$$$$$$4 from "./actions/cart/updateItems.ts";
-import * as $$$$$$$$$5 from "./actions/cart/updateItemAttachment.ts";
-import * as $$$$$$$$$6 from "./actions/cart/updateUser.ts";
-import * as $$$$$$$$$7 from "./actions/cart/addItems.ts";
-import * as $$$$$$$$$8 from "./actions/cart/removeItems.ts";
-import * as $$$$$$$$$9 from "./actions/cart/getInstallment.ts";
-import * as $$$$$$$$$10 from "./actions/cart/updateItemPrice.ts";
-import * as $$$$$$$$$11 from "./actions/cart/updateProfile.ts";
-import * as $$$$$$$$$12 from "./actions/cart/simulation.ts";
-import * as $$$$$$$$$13 from "./actions/cart/removeItemAttachment.ts";
-import * as $$$$$$$$$14 from "./actions/masterdata/createDocument.ts";
-import * as $$$$$$$$$15 from "./actions/newsletter/subscribe.ts";
-import * as $$$$$$$$$16 from "./actions/wishlist/removeItem.ts";
-import * as $$$$$$$$$17 from "./actions/wishlist/addItem.ts";
-import * as $$$$$$$$$18 from "./actions/analytics/sendEvent.ts";
+import * as $$$$$$$$$2 from "./actions/masterdata/createDocument.ts";
+import * as $$$$$$$$$3 from "./actions/wishlist/addItem.ts";
+import * as $$$$$$$$$4 from "./actions/wishlist/removeItem.ts";
+import * as $$$$$$$$$5 from "./actions/analytics/sendEvent.ts";
+import * as $$$$$$$$$6 from "./actions/cart/updateItems.ts";
+import * as $$$$$$$$$7 from "./actions/cart/getInstallment.ts";
+import * as $$$$$$$$$8 from "./actions/cart/updateItemAttachment.ts";
+import * as $$$$$$$$$9 from "./actions/cart/updateCoupons.ts";
+import * as $$$$$$$$$10 from "./actions/cart/updateProfile.ts";
+import * as $$$$$$$$$11 from "./actions/cart/removeItemAttachment.ts";
+import * as $$$$$$$$$12 from "./actions/cart/updateUser.ts";
+import * as $$$$$$$$$13 from "./actions/cart/addItems.ts";
+import * as $$$$$$$$$14 from "./actions/cart/removeItems.ts";
+import * as $$$$$$$$$15 from "./actions/cart/updateItemPrice.ts";
+import * as $$$$$$$$$16 from "./actions/cart/updateAttachment.ts";
+import * as $$$$$$$$$17 from "./actions/cart/simulation.ts";
+import * as $$$$$$$$$18 from "./actions/newsletter/subscribe.ts";
 import * as $$$$$$$$$$0 from "./workflows/events.ts";
 
 const manifest = {
   "loaders": {
-    "vtex/loaders/cart.ts": $$$16,
+    "vtex/loaders/cart.ts": $$$11,
     "vtex/loaders/intelligentSearch/productDetailsPage.ts": $$$13,
-    "vtex/loaders/intelligentSearch/productList.ts": $$$12,
-    "vtex/loaders/intelligentSearch/productListingPage.ts": $$$14,
+    "vtex/loaders/intelligentSearch/productList.ts": $$$14,
+    "vtex/loaders/intelligentSearch/productListingPage.ts": $$$16,
     "vtex/loaders/intelligentSearch/suggestions.ts": $$$15,
-    "vtex/loaders/legacy/productDetailsPage.ts": $$$2,
-    "vtex/loaders/legacy/productList.ts": $$$1,
-    "vtex/loaders/legacy/productListingPage.ts": $$$3,
-    "vtex/loaders/legacy/relatedProductsLoader.ts": $$$4,
-    "vtex/loaders/legacy/suggestions.ts": $$$5,
-    "vtex/loaders/navbar.ts": $$$10,
-    "vtex/loaders/product.ts": $$$0,
-    "vtex/loaders/product/extensions/simulation/detailsPage.ts": $$$7,
-    "vtex/loaders/product/extensions/simulation/list.ts": $$$8,
-    "vtex/loaders/product/extensions/simulation/listingPage.ts": $$$6,
-    "vtex/loaders/proxy.ts": $$$11,
+    "vtex/loaders/legacy/productDetailsPage.ts": $$$4,
+    "vtex/loaders/legacy/productList.ts": $$$5,
+    "vtex/loaders/legacy/productListingPage.ts": $$$7,
+    "vtex/loaders/legacy/relatedProductsLoader.ts": $$$3,
+    "vtex/loaders/legacy/suggestions.ts": $$$6,
+    "vtex/loaders/navbar.ts": $$$9,
+    "vtex/loaders/product.ts": $$$8,
+    "vtex/loaders/product/extensions/simulation/detailsPage.ts": $$$0,
+    "vtex/loaders/product/extensions/simulation/list.ts": $$$2,
+    "vtex/loaders/product/extensions/simulation/listingPage.ts": $$$1,
+    "vtex/loaders/proxy.ts": $$$12,
     "vtex/loaders/user.ts": $$$17,
-    "vtex/loaders/wishlist.ts": $$$9,
+    "vtex/loaders/wishlist.ts": $$$10,
   },
   "handlers": {
     "vtex/handlers/sitemap.ts": $$$$0,
   },
   "actions": {
-    "vtex/actions/analytics/sendEvent.ts": $$$$$$$$$18,
-    "vtex/actions/cart/addItems.ts": $$$$$$$$$7,
-    "vtex/actions/cart/getInstallment.ts": $$$$$$$$$9,
-    "vtex/actions/cart/removeItemAttachment.ts": $$$$$$$$$13,
-    "vtex/actions/cart/removeItems.ts": $$$$$$$$$8,
-    "vtex/actions/cart/simulation.ts": $$$$$$$$$12,
-    "vtex/actions/cart/updateAttachment.ts": $$$$$$$$$3,
-    "vtex/actions/cart/updateCoupons.ts": $$$$$$$$$2,
-    "vtex/actions/cart/updateItemAttachment.ts": $$$$$$$$$5,
-    "vtex/actions/cart/updateItemPrice.ts": $$$$$$$$$10,
-    "vtex/actions/cart/updateItems.ts": $$$$$$$$$4,
-    "vtex/actions/cart/updateProfile.ts": $$$$$$$$$11,
-    "vtex/actions/cart/updateUser.ts": $$$$$$$$$6,
-    "vtex/actions/masterdata/createDocument.ts": $$$$$$$$$14,
-    "vtex/actions/newsletter/subscribe.ts": $$$$$$$$$15,
+    "vtex/actions/analytics/sendEvent.ts": $$$$$$$$$5,
+    "vtex/actions/cart/addItems.ts": $$$$$$$$$13,
+    "vtex/actions/cart/getInstallment.ts": $$$$$$$$$7,
+    "vtex/actions/cart/removeItemAttachment.ts": $$$$$$$$$11,
+    "vtex/actions/cart/removeItems.ts": $$$$$$$$$14,
+    "vtex/actions/cart/simulation.ts": $$$$$$$$$17,
+    "vtex/actions/cart/updateAttachment.ts": $$$$$$$$$16,
+    "vtex/actions/cart/updateCoupons.ts": $$$$$$$$$9,
+    "vtex/actions/cart/updateItemAttachment.ts": $$$$$$$$$8,
+    "vtex/actions/cart/updateItemPrice.ts": $$$$$$$$$15,
+    "vtex/actions/cart/updateItems.ts": $$$$$$$$$6,
+    "vtex/actions/cart/updateProfile.ts": $$$$$$$$$10,
+    "vtex/actions/cart/updateUser.ts": $$$$$$$$$12,
+    "vtex/actions/masterdata/createDocument.ts": $$$$$$$$$2,
+    "vtex/actions/newsletter/subscribe.ts": $$$$$$$$$18,
     "vtex/actions/notifyme.ts": $$$$$$$$$1,
     "vtex/actions/trigger.ts": $$$$$$$$$0,
-    "vtex/actions/wishlist/addItem.ts": $$$$$$$$$17,
-    "vtex/actions/wishlist/removeItem.ts": $$$$$$$$$16,
+    "vtex/actions/wishlist/addItem.ts": $$$$$$$$$3,
+    "vtex/actions/wishlist/removeItem.ts": $$$$$$$$$4,
   },
   "workflows": {
     "vtex/workflows/events.ts": $$$$$$$$$$0,

--- a/wake/manifest.gen.ts
+++ b/wake/manifest.gen.ts
@@ -2,27 +2,27 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/productList.ts";
-import * as $$$1 from "./loaders/productDetailsPage.ts";
-import * as $$$2 from "./loaders/productListingPage.ts";
+import * as $$$0 from "./loaders/productDetailsPage.ts";
+import * as $$$1 from "./loaders/productList.ts";
+import * as $$$2 from "./loaders/cart.ts";
 import * as $$$3 from "./loaders/proxy.ts";
-import * as $$$4 from "./loaders/cart.ts";
-import * as $$$$$$$$$0 from "./actions/cart/addCoupon.ts";
-import * as $$$$$$$$$1 from "./actions/cart/addItem.ts";
+import * as $$$4 from "./loaders/productListingPage.ts";
+import * as $$$$$$$$$0 from "./actions/cart/addItem.ts";
+import * as $$$$$$$$$1 from "./actions/cart/addCoupon.ts";
 import * as $$$$$$$$$2 from "./actions/cart/updateItemQuantity.ts";
 import * as $$$$$$$$$3 from "./actions/cart/removeCoupon.ts";
 
 const manifest = {
   "loaders": {
-    "wake/loaders/cart.ts": $$$4,
-    "wake/loaders/productDetailsPage.ts": $$$1,
-    "wake/loaders/productList.ts": $$$0,
-    "wake/loaders/productListingPage.ts": $$$2,
+    "wake/loaders/cart.ts": $$$2,
+    "wake/loaders/productDetailsPage.ts": $$$0,
+    "wake/loaders/productList.ts": $$$1,
+    "wake/loaders/productListingPage.ts": $$$4,
     "wake/loaders/proxy.ts": $$$3,
   },
   "actions": {
-    "wake/actions/cart/addCoupon.ts": $$$$$$$$$0,
-    "wake/actions/cart/addItem.ts": $$$$$$$$$1,
+    "wake/actions/cart/addCoupon.ts": $$$$$$$$$1,
+    "wake/actions/cart/addItem.ts": $$$$$$$$$0,
     "wake/actions/cart/removeCoupon.ts": $$$$$$$$$3,
     "wake/actions/cart/updateItemQuantity.ts": $$$$$$$$$2,
   },

--- a/website/manifest.gen.ts
+++ b/website/manifest.gen.ts
@@ -3,45 +3,45 @@
 // This file is automatically updated during development when running `dev.ts`.
 
 import * as $0 from "./functions/requestToParam.ts";
-import * as $$$0 from "./loaders/image.ts";
-import * as $$$1 from "./loaders/redirectsFromCsv.ts";
-import * as $$$2 from "./loaders/secretString.ts";
-import * as $$$3 from "./loaders/extension.ts";
+import * as $$$0 from "./loaders/redirectsFromCsv.ts";
+import * as $$$1 from "./loaders/fonts/googleFonts.ts";
+import * as $$$2 from "./loaders/fonts/local.ts";
+import * as $$$3 from "./loaders/asset.ts";
 import * as $$$4 from "./loaders/secret.ts";
-import * as $$$5 from "./loaders/pages.ts";
-import * as $$$6 from "./loaders/asset.ts";
-import * as $$$7 from "./loaders/fonts/local.ts";
-import * as $$$8 from "./loaders/fonts/googleFonts.ts";
-import * as $$$$0 from "./handlers/router.ts";
-import * as $$$$1 from "./handlers/sitemap.ts";
+import * as $$$5 from "./loaders/image.ts";
+import * as $$$6 from "./loaders/extension.ts";
+import * as $$$7 from "./loaders/pages.ts";
+import * as $$$8 from "./loaders/secretString.ts";
+import * as $$$$0 from "./handlers/fresh.ts";
+import * as $$$$1 from "./handlers/router.ts";
 import * as $$$$2 from "./handlers/proxy.ts";
-import * as $$$$3 from "./handlers/fresh.ts";
+import * as $$$$3 from "./handlers/sitemap.ts";
 import * as $$$$4 from "./handlers/redirect.ts";
 import * as $$$$$0 from "./pages/Page.tsx";
-import * as $$$$$$0 from "./sections/Rendering/Deferred.tsx";
-import * as $$$$$$1 from "./sections/Seo/Seo.tsx";
-import * as $$$$$$2 from "./sections/Analytics/Analytics.tsx";
-import * as $$$$$$$0 from "./matchers/date.ts";
-import * as $$$$$$$1 from "./matchers/environment.ts";
-import * as $$$$$$$2 from "./matchers/site.ts";
-import * as $$$$$$$3 from "./matchers/location.ts";
-import * as $$$$$$$4 from "./matchers/cookie.ts";
-import * as $$$$$$$5 from "./matchers/random.ts";
-import * as $$$$$$$6 from "./matchers/multi.ts";
-import * as $$$$$$$7 from "./matchers/never.ts";
-import * as $$$$$$$8 from "./matchers/negate.ts";
-import * as $$$$$$$9 from "./matchers/cron.ts";
-import * as $$$$$$$10 from "./matchers/device.ts";
-import * as $$$$$$$11 from "./matchers/host.ts";
-import * as $$$$$$$12 from "./matchers/always.ts";
-import * as $$$$$$$13 from "./matchers/userAgent.ts";
-import * as $$$$$$$$0 from "./flags/multivariate/section.ts";
-import * as $$$$$$$$1 from "./flags/multivariate/page.ts";
-import * as $$$$$$$$2 from "./flags/multivariate/message.ts";
-import * as $$$$$$$$3 from "./flags/audience.ts";
-import * as $$$$$$$$4 from "./flags/multivariate.ts";
-import * as $$$$$$$$5 from "./flags/everyone.ts";
-import * as $$$$$$$$6 from "./flags/flag.ts";
+import * as $$$$$$0 from "./sections/Analytics/Analytics.tsx";
+import * as $$$$$$1 from "./sections/Rendering/Deferred.tsx";
+import * as $$$$$$2 from "./sections/Seo/Seo.tsx";
+import * as $$$$$$$0 from "./matchers/multi.ts";
+import * as $$$$$$$1 from "./matchers/random.ts";
+import * as $$$$$$$2 from "./matchers/cron.ts";
+import * as $$$$$$$3 from "./matchers/environment.ts";
+import * as $$$$$$$4 from "./matchers/host.ts";
+import * as $$$$$$$5 from "./matchers/negate.ts";
+import * as $$$$$$$6 from "./matchers/userAgent.ts";
+import * as $$$$$$$7 from "./matchers/date.ts";
+import * as $$$$$$$8 from "./matchers/cookie.ts";
+import * as $$$$$$$9 from "./matchers/always.ts";
+import * as $$$$$$$10 from "./matchers/never.ts";
+import * as $$$$$$$11 from "./matchers/device.ts";
+import * as $$$$$$$12 from "./matchers/location.ts";
+import * as $$$$$$$13 from "./matchers/site.ts";
+import * as $$$$$$$$0 from "./flags/audience.ts";
+import * as $$$$$$$$1 from "./flags/everyone.ts";
+import * as $$$$$$$$2 from "./flags/flag.ts";
+import * as $$$$$$$$3 from "./flags/multivariate.ts";
+import * as $$$$$$$$4 from "./flags/multivariate/message.ts";
+import * as $$$$$$$$5 from "./flags/multivariate/page.ts";
+import * as $$$$$$$$6 from "./flags/multivariate/section.ts";
 import * as $$$$$$$$$0 from "./actions/secrets/encrypt.ts";
 
 const manifest = {
@@ -49,55 +49,55 @@ const manifest = {
     "website/functions/requestToParam.ts": $0,
   },
   "loaders": {
-    "website/loaders/asset.ts": $$$6,
-    "website/loaders/extension.ts": $$$3,
-    "website/loaders/fonts/googleFonts.ts": $$$8,
-    "website/loaders/fonts/local.ts": $$$7,
-    "website/loaders/image.ts": $$$0,
-    "website/loaders/pages.ts": $$$5,
-    "website/loaders/redirectsFromCsv.ts": $$$1,
+    "website/loaders/asset.ts": $$$3,
+    "website/loaders/extension.ts": $$$6,
+    "website/loaders/fonts/googleFonts.ts": $$$1,
+    "website/loaders/fonts/local.ts": $$$2,
+    "website/loaders/image.ts": $$$5,
+    "website/loaders/pages.ts": $$$7,
+    "website/loaders/redirectsFromCsv.ts": $$$0,
     "website/loaders/secret.ts": $$$4,
-    "website/loaders/secretString.ts": $$$2,
+    "website/loaders/secretString.ts": $$$8,
   },
   "handlers": {
-    "website/handlers/fresh.ts": $$$$3,
+    "website/handlers/fresh.ts": $$$$0,
     "website/handlers/proxy.ts": $$$$2,
     "website/handlers/redirect.ts": $$$$4,
-    "website/handlers/router.ts": $$$$0,
-    "website/handlers/sitemap.ts": $$$$1,
+    "website/handlers/router.ts": $$$$1,
+    "website/handlers/sitemap.ts": $$$$3,
   },
   "pages": {
     "website/pages/Page.tsx": $$$$$0,
   },
   "sections": {
-    "website/sections/Analytics/Analytics.tsx": $$$$$$2,
-    "website/sections/Rendering/Deferred.tsx": $$$$$$0,
-    "website/sections/Seo/Seo.tsx": $$$$$$1,
+    "website/sections/Analytics/Analytics.tsx": $$$$$$0,
+    "website/sections/Rendering/Deferred.tsx": $$$$$$1,
+    "website/sections/Seo/Seo.tsx": $$$$$$2,
   },
   "matchers": {
-    "website/matchers/always.ts": $$$$$$$12,
-    "website/matchers/cookie.ts": $$$$$$$4,
-    "website/matchers/cron.ts": $$$$$$$9,
-    "website/matchers/date.ts": $$$$$$$0,
-    "website/matchers/device.ts": $$$$$$$10,
-    "website/matchers/environment.ts": $$$$$$$1,
-    "website/matchers/host.ts": $$$$$$$11,
-    "website/matchers/location.ts": $$$$$$$3,
-    "website/matchers/multi.ts": $$$$$$$6,
-    "website/matchers/negate.ts": $$$$$$$8,
-    "website/matchers/never.ts": $$$$$$$7,
-    "website/matchers/random.ts": $$$$$$$5,
-    "website/matchers/site.ts": $$$$$$$2,
-    "website/matchers/userAgent.ts": $$$$$$$13,
+    "website/matchers/always.ts": $$$$$$$9,
+    "website/matchers/cookie.ts": $$$$$$$8,
+    "website/matchers/cron.ts": $$$$$$$2,
+    "website/matchers/date.ts": $$$$$$$7,
+    "website/matchers/device.ts": $$$$$$$11,
+    "website/matchers/environment.ts": $$$$$$$3,
+    "website/matchers/host.ts": $$$$$$$4,
+    "website/matchers/location.ts": $$$$$$$12,
+    "website/matchers/multi.ts": $$$$$$$0,
+    "website/matchers/negate.ts": $$$$$$$5,
+    "website/matchers/never.ts": $$$$$$$10,
+    "website/matchers/random.ts": $$$$$$$1,
+    "website/matchers/site.ts": $$$$$$$13,
+    "website/matchers/userAgent.ts": $$$$$$$6,
   },
   "flags": {
-    "website/flags/audience.ts": $$$$$$$$3,
-    "website/flags/everyone.ts": $$$$$$$$5,
-    "website/flags/flag.ts": $$$$$$$$6,
-    "website/flags/multivariate.ts": $$$$$$$$4,
-    "website/flags/multivariate/message.ts": $$$$$$$$2,
-    "website/flags/multivariate/page.ts": $$$$$$$$1,
-    "website/flags/multivariate/section.ts": $$$$$$$$0,
+    "website/flags/audience.ts": $$$$$$$$0,
+    "website/flags/everyone.ts": $$$$$$$$1,
+    "website/flags/flag.ts": $$$$$$$$2,
+    "website/flags/multivariate.ts": $$$$$$$$3,
+    "website/flags/multivariate/message.ts": $$$$$$$$4,
+    "website/flags/multivariate/page.ts": $$$$$$$$5,
+    "website/flags/multivariate/section.ts": $$$$$$$$6,
   },
   "actions": {
     "website/actions/secrets/encrypt.ts": $$$$$$$$$0,

--- a/workflows/manifest.gen.ts
+++ b/workflows/manifest.gen.ts
@@ -2,25 +2,25 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/get.ts";
-import * as $$$1 from "./loaders/events.ts";
+import * as $$$0 from "./loaders/events.ts";
+import * as $$$1 from "./loaders/get.ts";
 import * as $$$$0 from "./handlers/workflowRunner.ts";
-import * as $$$$$$$$$0 from "./actions/start.ts";
-import * as $$$$$$$$$1 from "./actions/cancel.ts";
+import * as $$$$$$$$$0 from "./actions/cancel.ts";
+import * as $$$$$$$$$1 from "./actions/start.ts";
 import * as $$$$$$$$$2 from "./actions/signal.ts";
 
 const manifest = {
   "loaders": {
-    "workflows/loaders/events.ts": $$$1,
-    "workflows/loaders/get.ts": $$$0,
+    "workflows/loaders/events.ts": $$$0,
+    "workflows/loaders/get.ts": $$$1,
   },
   "handlers": {
     "workflows/handlers/workflowRunner.ts": $$$$0,
   },
   "actions": {
-    "workflows/actions/cancel.ts": $$$$$$$$$1,
+    "workflows/actions/cancel.ts": $$$$$$$$$0,
     "workflows/actions/signal.ts": $$$$$$$$$2,
-    "workflows/actions/start.ts": $$$$$$$$$0,
+    "workflows/actions/start.ts": $$$$$$$$$1,
   },
   "name": "workflows",
   "baseUrl": import.meta.url,


### PR DESCRIPTION
## Problem

![image](https://github.com/deco-cx/apps/assets/108771428/dbcaa8eb-bd45-47e1-a916-8af138fd0c87)

Before, in the loader (VTEX - PLP - LEGACY), the term in the link within the request was "/lancamento/Tinta-de-cabelo." Now, in the solution, the term is transformed into "/138/Tinta-de-cabelo." This change only applies to categories that are part of a product cluster.

## Solution

![image](https://github.com/deco-cx/apps/assets/108771428/4d930035-dc1f-4c27-93d7-588694b805ed)
