### PR TITLE
feat: implementing option to inject kit items in product list

### DIFF
--- a/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -299,7 +299,7 @@ const loader = async (
           ...params,
           facets: toPath(selected),
         },
-        { ...STALE,  headers: segment ? withSegmentCookie(segment) : undefined },
+        { ...STALE, headers: segment ? withSegmentCookie(segment) : undefined },
       ).then((res) => res.json()),
     vcsDeprecated["GET /api/io/_v/api/intelligent-search/facets/*facets"](
       {

--- a/vtex/utils/kitItems.ts
+++ b/vtex/utils/kitItems.ts
@@ -1,0 +1,102 @@
+import type { Product } from "../../commerce/types.ts";
+import type { AppContext } from "../mod.ts";
+import type { Sort } from "../utils/types.ts";
+
+import { getSegment, withSegmentCookie } from "../utils/segment.ts";
+import productListLoader from "../loaders/intelligentSearch/productList.ts";
+
+interface Params {
+  query: string;
+  page: number;
+  count: number;
+  sort: Sort;
+  fuzzy: string;
+  locale?: string;
+  hideUnavailableItems: boolean;
+}
+
+interface WithKitLookToProps {
+  products: Product[];
+  params: Params;
+  req: Request;
+  ctx: AppContext;
+}
+
+/** Retrieves VTEX products with Kitlook. */
+export async function withKitItems({
+  products,
+  params,
+  req,
+  ctx,
+}: WithKitLookToProps): Promise<Product[]> {
+  const { vcsDeprecated } = ctx;
+  const segment = getSegment(ctx);
+
+  const productIds = Array.from(
+    new Set(products.map((p) => p.isVariantOf?.productGroupID)),
+  );
+
+  const legacyProducts = await vcsDeprecated[
+    `GET /api/catalog_system/pub/products/search/:term?`
+  ](
+    {
+      ...params,
+      fq: productIds.map((productId) => `productId:${productId}`),
+    },
+    {
+      deco: { cache: "stale-while-revalidate" },
+      headers: withSegmentCookie(segment),
+    },
+  ).then((res) => res.json());
+
+  const productKitIds = Array.from(
+    new Set(
+      legacyProducts.flatMap(
+        (p) => p.items[0].kitItems?.map((i) => i.itemId) ?? [],
+      ),
+    ),
+  );
+
+  const kitProducts = await productListLoader(
+    {
+      props: {
+        ids: productKitIds,
+      },
+    },
+    req,
+    ctx,
+  );
+
+  const formattedProducts = products.map((product) => {
+    const legacyProduct = legacyProducts.find(
+      (p) => p.productId === product.isVariantOf?.productGroupID,
+    );
+
+    if (!legacyProduct) {
+      return { ...product, isAccessoryOrSparePartFor: [] };
+    }
+
+    const [legacyItem] = legacyProduct.items;
+
+    const kitItems = legacyItem?.kitItems?.flatMap((kitItem) => {
+      const kitProduct = kitProducts?.find(
+        (p) => p.productID === kitItem.itemId,
+      );
+
+      if (!kitProduct) {
+        return [];
+      }
+
+      return [kitProduct];
+    }) ?? [];
+
+    console.log({ kitItems });
+
+    return {
+      ...product,
+      isAccessoryOrSparePartFor: kitItems,
+    };
+  });
+
+  return formattedProducts;
+}


### PR DESCRIPTION
This PR aims to enable injecting VTEX's kit items into Intelligent Search's `productList` loader with full product data, not only the ids, using batch requests to the Catalog/Legacy API.
The kit items will be named as `isAccessoryOrSparePartFor`, just like Deco did in the `productDetailsPage` loader.

First the loader does the regular `productList` request to Intelligent Search's API, filters all the `productGroupIDs`, does a single request to Catalog/Legacy API that return all the kit items skus for all products, and finally calls the `productList` request again with those skus. Then it maps each initial product injecting its kit items as `isAccessoryOrSparePartFor`.

This PR was initially made by @jonathanwlopes (#98).