### PR TITLE
url path search match

### DIFF
--- a/vtex/utils/legacy.ts
+++ b/vtex/utils/legacy.ts
@@ -5,15 +5,14 @@ import { AppContext } from "../mod.ts";
 import { slugify } from "../utils/slugify.ts";
 import type { PageType, Segment } from "../utils/types.ts";
 
-export const toSegmentParams = (
-  segment: Partial<Segment>,
-) => (Object.fromEntries(
-  Object.entries({
-    utmi_campaign: segment.utmi_campaign ?? undefined,
-    utm_campaign: segment.utm_campaign ?? undefined,
-    utm_source: segment.utm_source ?? undefined,
-  }).filter(([_, v]) => v != undefined),
-));
+export const toSegmentParams = (segment: Partial<Segment>) =>
+  Object.fromEntries(
+    Object.entries({
+      utmi_campaign: segment.utmi_campaign ?? undefined,
+      utm_campaign: segment.utm_campaign ?? undefined,
+      utm_source: segment.utm_source ?? undefined,
+    }).filter(([_, v]) => v != undefined),
+  );
 
 const PAGE_TYPE_TO_MAP_PARAM = {
   Brand: "b",
@@ -30,33 +29,29 @@ const PAGE_TYPE_TO_MAP_PARAM = {
 
 const segmentsFromTerm = (term: string) => term.split("/").filter(Boolean);
 
-export const pageTypesFromPathname = async (
-  term: string,
-  ctx: AppContext,
-) => {
+export const pageTypesFromPathname = async (term: string, ctx: AppContext) => {
   const segments = segmentsFromTerm(term);
   const { vcsDeprecated } = ctx;
 
   const results = await Promise.all(
     segments.map((_, index) =>
-      vcsDeprecated["GET /api/catalog_system/pub/portal/pagetype/:term"]({
-        term: segments.slice(0, index + 1).join("/"),
-      }, STALE).then((res) => res.json())
+      vcsDeprecated["GET /api/catalog_system/pub/portal/pagetype/:term"](
+        {
+          term: segments.slice(0, index + 1).join("/"),
+        },
+        STALE,
+      ).then((res) => res.json())
     ),
   );
 
   return results.filter((result) => PAGE_TYPE_TO_MAP_PARAM[result.pageType]);
 };
 
-export const getMapAndTerm = (
-  pageTypes: PageType[],
-) => {
+export const getMapAndTerm = (pageTypes: PageType[]) => {
   const term = pageTypes
     .map((type, index) =>
       type.url
-        ? segmentsFromTerm(
-          new URL(`http://${type.url}`).pathname,
-        )[index]
+        ? segmentsFromTerm(new URL(`http://${type.url}`).pathname)[index]
         : null
     )
     .filter(Boolean)
@@ -74,22 +69,23 @@ export const pageTypesToBreadcrumbList = (
   pages: PageType[],
   baseUrl: string,
 ) => {
-  const filteredPages = pages
-    .filter(({ pageType }) =>
-      pageType === "Category" || pageType === "Department" ||
-      pageType === "SubCategory"
-    );
+  const filteredPages = pages.filter(
+    ({ pageType }) =>
+      pageType === "Category" ||
+      pageType === "Department" ||
+      pageType === "SubCategory",
+  );
 
   return filteredPages.map((page, index) => {
     const position = index + 1;
     const slug = filteredPages.slice(0, position).map((x) => slugify(x.name!));
 
-    return ({
+    return {
       "@type": "ListItem" as const,
       name: page.name!,
       item: new URL(`/${slug.join("/")}`, baseUrl).href,
       position,
-    });
+    };
   });
 };
 


### PR DESCRIPTION
Vtex understands unique path that not are a department as a search. This PRs prevents searchs wihtout query params that match as category or subcategory to be passed as `category-1`(department) and use term as search.

This PR also fix search path search when the vtex page type return is fulltex.

