### PR TITLE
feat: Change plausible Events

### DIFF
--- a/analytics/components/Plausible.tsx
+++ b/analytics/components/Plausible.tsx
@@ -22,6 +22,19 @@ const snippet = () => {
   // Flags and additional dimentions
   const props: Record<string, string> = {};
 
+  const trackPageview = () => window.plausible("pageview", { props });
+
+  // Attach pushState and popState listeners
+  const originalPushState = history.pushState;
+  if (originalPushState) {
+    history.pushState = function () {
+      // @ts-ignore monkey patch
+      originalPushState.apply(this, arguments);
+      trackPageview();
+    };
+    addEventListener("popstate", trackPageview);
+  }
+
   // setup plausible script and unsubscribe
   window.DECO.events.subscribe((event) => {
     if (!event || event.name !== "deco-flags") return;
@@ -32,7 +45,7 @@ const snippet = () => {
       }
     }
 
-    window.plausible("pageview", { props });
+    trackPageview();
   })();
 
   window.DECO.events.subscribe((event) => {

--- a/analytics/components/Plausible.tsx
+++ b/analytics/components/Plausible.tsx
@@ -1,18 +1,5 @@
 import { Head } from "$fresh/runtime.ts";
-import { useRouterContext } from "deco/routes/[...catchall].tsx";
-import { exclusionAndHashScript } from "../../utils/plausible_scripts.ts";
-import { dataURI, scriptAsDataURI } from "../../utils/dataURI.ts";
-
-const sanitizeTagAttribute = (inputString: string): string => {
-  const maxLength = 299; // plausible limit
-  let sanitizedString: string = inputString.replace(" ", "-").replace(".", "-")
-    .replace(
-      /[^\w-]/g,
-      "",
-    ).replace(/^\d+/, "");
-  sanitizedString = sanitizedString.slice(0, maxLength);
-  return sanitizedString;
-};
+import { scriptAsDataURI } from "../../utils/dataURI.ts";
 
 export interface Props {
   /**
@@ -30,18 +17,32 @@ declare global {
   }
 }
 
-const plausibleScript = exclusionAndHashScript;
-
 // This function should be self contained, because it is stringified!
 const snippet = () => {
+  // Flags and additional dimentions
+  const props: Record<string, string> = {};
+
+  // setup plausible script and unsubscribe
+  window.DECO.events.subscribe((event) => {
+    if (!event || event.name !== "deco-flags") return;
+
+    if (Array.isArray(event.params)) {
+      for (const flag of event.params) {
+        props[flag.name] = flag.value.toString();
+      }
+    }
+
+    window.plausible("pageview", { props });
+  })();
+
   window.DECO.events.subscribe((event) => {
     if (!event) return;
 
     const { name, params } = event;
 
-    if (!name || !params) return;
+    if (!name || !params || name === "deco-flags") return;
 
-    const values = {} as Record<string, string>;
+    const values = { ...props };
     for (const key in params) {
       // @ts-expect-error somehow typescript bugs
       const value = params[key];
@@ -58,15 +59,6 @@ const snippet = () => {
 };
 
 function Component({ exclude }: Props) {
-  const routerCtx = useRouterContext();
-  const flags: Record<string, string> | undefined = routerCtx?.flags.reduce(
-    (acc, flag) => {
-      acc[sanitizeTagAttribute(`event-${flag.name}`)] = flag.value.toString();
-      return acc;
-    },
-    {} as Record<string, string>,
-  );
-
   return (
     <Head>
       <link rel="dns-prefetch" href="https://plausible.io/api/event" />
@@ -79,8 +71,7 @@ function Component({ exclude }: Props) {
         defer
         data-exclude={`${"/proxy" + (exclude ? "," + exclude : "")}`}
         data-api="https://plausible.io/api/event"
-        {...flags}
-        src={dataURI("text/javascript", true, plausibleScript)}
+        src="https://plausible.io/js/script.manual.js"
       />
       <script defer src={scriptAsDataURI(snippet)} />
     </Head>

--- a/commerce/types.ts
+++ b/commerce/types.ts
@@ -1,3 +1,5 @@
+import { type Flag } from "deco/types.ts";
+
 /** Used at the top-level node to indicate the context for the JSON-LD objects used. The context provided in this type is compatible with the keys and URLs in the rest of this generated file. */
 export declare type WithContext<T extends Things> = T & {
   "@context": "https://schema.org";
@@ -717,6 +719,10 @@ export interface ViewPromotionEvent extends IEvent<ViewPromotionParams> {
   name: "view_promotion";
 }
 
+export interface DecoFlagsEvent extends IEvent<Flag[]> {
+  name: "deco-flags";
+}
+
 export type AnalyticsEvent =
   | AddShippingInfoEvent
   | AddToCartEvent
@@ -730,4 +736,5 @@ export type AnalyticsEvent =
   | ViewCartEvent
   | ViewItemEvent
   | ViewItemListEvent
-  | ViewPromotionEvent;
+  | ViewPromotionEvent
+  | DecoFlagsEvent;

--- a/website/components/Events.tsx
+++ b/website/components/Events.tsx
@@ -1,5 +1,6 @@
 import { Head } from "$fresh/runtime.ts";
-import { AnalyticsEvent } from "../../commerce/types.ts";
+import { type Flag } from "deco/types.ts";
+import { type AnalyticsEvent } from "../../commerce/types.ts";
 import { scriptAsDataURI } from "../../utils/dataURI.ts";
 
 type EventHandler = (event?: AnalyticsEvent) => void | Promise<void>;
@@ -28,7 +29,31 @@ declare global {
  * This function handles all ecommerce analytics events.
  * Add another ecommerce analytics modules here.
  */
-const snippet = () => {
+const snippet = (flags: Flag[]) => {
+  const appendSessionFlags = () => {
+    const knownFlags = new Set(flags.map((f) => f.name));
+    const cookies = document.cookie.split(";");
+
+    for (let i = 0; i < cookies.length; i++) {
+      const ck = cookies[i].trim();
+
+      if (ck.startsWith("deco_matcher_")) {
+        const name = atob(ck.slice(ck.indexOf("=") + 1, ck.indexOf("@")));
+        const value = ck.at(-1) === "1" ? true : false;
+
+        if (knownFlags.has(name)) continue;
+
+        flags.push({ name, value });
+      }
+    }
+  };
+
+  try {
+    appendSessionFlags();
+  } catch (error) {
+    console.error(error);
+  }
+
   const target = new EventTarget();
 
   const dispatch: EventsAPI["dispatch"] = (event: unknown) => {
@@ -38,6 +63,8 @@ const snippet = () => {
   const subscribe: EventsAPI["subscribe"] = (handler, opts) => {
     // deno-lint-ignore no-explicit-any
     const cb = ({ detail }: any) => handler(detail);
+
+    handler({ name: "deco-flags", params: flags });
 
     target.addEventListener("analytics", cb, opts);
 
@@ -53,10 +80,10 @@ const snippet = () => {
   };
 };
 
-function Events() {
+function Events({ flags }: { flags: Flag[] }) {
   return (
     <Head>
-      <script defer id="deco-events" src={scriptAsDataURI(snippet)} />
+      <script defer id="deco-events" src={scriptAsDataURI(snippet, flags)} />
     </Head>
   );
 }

--- a/website/pages/Page.tsx
+++ b/website/pages/Page.tsx
@@ -62,7 +62,6 @@ const renderSections = (
   isPreview = false,
 ) => (
   <>
-    <Events />
     {sections.map(renderSectionFor(isPreview))}
   </>
 );
@@ -94,6 +93,7 @@ function Page(
         page={{ id: pageId, pathTemplate: routerCtx?.pagePath }}
         flags={routerCtx?.flags}
       />
+      <Events flags={routerCtx?.flags ?? []} />
       {renderSections(props, false)}
     </>
   );
@@ -107,6 +107,7 @@ export function Preview(
       <Head>
         <meta name="robots" content="noindex, nofollow" />
       </Head>
+      <Events flags={[]} />
       {renderSections(props, true)}
     </>
   );


### PR DESCRIPTION
This PR changes how events are sent via plausible.

Currently, we are using only the server flags. This means we loose track of session flags (stored inside cookies). To keep track of dimensions stored inside cookies we need to manually trigger the pageView event or create the plausible tag on the client. 

I decided to go for the manual triggering since our frameowrk is server-based. Also, I copied from plausible the script part that raise pageview events on client-side navigation style