### PR TITLE
[vtex]: forward default sales channel

### DIFF
--- a/vtex/actions/cart/addItems.ts
+++ b/vtex/actions/cart/addItems.ts
@@ -1,6 +1,7 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
 import { parseCookie } from "../../utils/orderForm.ts";
+import { getSegmentFromBag } from "../../utils/segment.ts";
 import type { OrderForm } from "../../utils/types.ts";
 
 export interface Item {
@@ -31,12 +32,14 @@ const action = async (
   } = props;
   const { orderFormId } = parseCookie(req.headers);
   const cookie = req.headers.get("cookie") ?? "";
+  const segment = getSegmentFromBag(ctx);
 
   try {
     const response = await vcsDeprecated
       ["POST /api/checkout/pub/orderForm/:orderFormId/items"]({
         orderFormId,
         allowedOutdatedData,
+        sc: segment.channel,
       }, {
         body: { orderItems },
         headers: {

--- a/vtex/actions/cart/getInstallment.ts
+++ b/vtex/actions/cart/getInstallment.ts
@@ -2,6 +2,7 @@ import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
 import { parseCookie } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
+import { getSegmentFromBag } from "../../utils/segment.ts";
 
 export interface Props {
   paymentSystem: number;
@@ -19,10 +20,11 @@ const action = async (
   const { paymentSystem } = props;
   const { orderFormId } = parseCookie(req.headers);
   const cookie = req.headers.get("cookie") ?? "";
+  const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated
     ["GET /api/checkout/pub/orderForm/:orderFormId/installments"](
-      { orderFormId, paymentSystem },
+      { orderFormId, paymentSystem, sc: segment.channel },
       { headers: { accept: "application/json", cookie } },
     );
 

--- a/vtex/actions/cart/removeItemAttachment.ts
+++ b/vtex/actions/cart/removeItemAttachment.ts
@@ -51,7 +51,7 @@ const action = async (
 
   const response = await vcsDeprecated
     ["DELETE /api/checkout/pub/orderForm/:orderFormId/items/:index/attachments/:attachment"](
-      { orderFormId, attachment, index, sc: segment.channel, },
+      { orderFormId, attachment, index, sc: segment.channel },
       {
         body: { content, noSplitItem, expectedOrderFormSections },
         headers: {

--- a/vtex/actions/cart/removeItemAttachment.ts
+++ b/vtex/actions/cart/removeItemAttachment.ts
@@ -2,6 +2,7 @@ import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
 import { parseCookie } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
+import { getSegmentFromBag } from "../../utils/segment.ts";
 
 export interface Props {
   /** @description index of the item in the cart.items array you want to edit */
@@ -46,10 +47,11 @@ const action = async (
   } = props;
   const { orderFormId } = parseCookie(req.headers);
   const cookie = req.headers.get("cookie") ?? "";
+  const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated
     ["DELETE /api/checkout/pub/orderForm/:orderFormId/items/:index/attachments/:attachment"](
-      { orderFormId, attachment, index },
+      { orderFormId, attachment, index, sc: segment.channel, },
       {
         body: { content, noSplitItem, expectedOrderFormSections },
         headers: {

--- a/vtex/actions/cart/removeItems.ts
+++ b/vtex/actions/cart/removeItems.ts
@@ -2,6 +2,7 @@ import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
 import { parseCookie } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
+import { getSegmentFromBag } from "../../utils/segment.ts";
 
 /**
  * @docs https://developers.vtex.com/docs/api-reference/checkout-api#post-/api/checkout/pub/orderForm/-orderFormId-/items/removeAll
@@ -14,17 +15,19 @@ const action = async (
   const { vcsDeprecated } = ctx;
   const { orderFormId } = parseCookie(req.headers);
   const cookie = req.headers.get("cookie") ?? "";
+  const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated
-    ["POST /api/checkout/pub/orderForm/:orderFormId/items/removeAll"]({
-      orderFormId,
-    }, {
-      headers: {
-        "content-type": "application/json",
-        accept: "application/json",
-        cookie,
+    ["POST /api/checkout/pub/orderForm/:orderFormId/items/removeAll"](
+      { orderFormId, sc: segment.channel },
+      {
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json",
+          cookie,
+        },
       },
-    });
+    );
 
   proxySetCookie(response.headers, ctx.response.headers, req.url);
 

--- a/vtex/actions/cart/simulation.ts
+++ b/vtex/actions/cart/simulation.ts
@@ -1,5 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import type { SimulationOrderForm } from "../../utils/types.ts";
+import { getSegmentFromBag } from "../../utils/segment.ts";
 
 export interface Item {
   id: number;
@@ -25,12 +26,14 @@ const action = async (
   const cookie = req.headers.get("cookie") ?? "";
   const { vcsDeprecated } = ctx;
   const { items, postalCode, country, RnbBehavior = 1 } = props;
+  const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated[
     "POST /api/checkout/pub/orderForms/simulation"
   ](
     {
       RnbBehavior,
+      sc: segment.channel,
     },
     {
       body: { items, country, postalCode },

--- a/vtex/actions/cart/updateAttachment.ts
+++ b/vtex/actions/cart/updateAttachment.ts
@@ -3,6 +3,7 @@ import { proxySetCookie } from "../../utils/cookies.ts";
 import { parseCookie } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
 import { DEFAULT_EXPECTED_SECTIONS } from "./updateItemAttachment.ts";
+import { getSegmentFromBag } from "../../utils/segment.ts";
 
 export interface Props {
   attachment: string;
@@ -24,11 +25,13 @@ const action = async (
   } = props;
   const { orderFormId } = parseCookie(req.headers);
   const cookie = req.headers.get("cookie") ?? "";
+  const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated
     ["POST /api/checkout/pub/orderForm/:orderFormId/attachments/:attachment"]({
       orderFormId,
       attachment,
+      sc: segment.channel,
     }, {
       body: { expectedOrderFormSections, ...body },
       headers: {

--- a/vtex/actions/cart/updateCoupons.ts
+++ b/vtex/actions/cart/updateCoupons.ts
@@ -23,7 +23,10 @@ const action = async (
   const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated
-    ["POST /api/checkout/pub/orderForm/:orderFormId/coupons"]({ orderFormId, sc: segment.channel, }, {
+    ["POST /api/checkout/pub/orderForm/:orderFormId/coupons"]({
+      orderFormId,
+      sc: segment.channel,
+    }, {
       body: { text },
       headers: {
         accept: "application/json",

--- a/vtex/actions/cart/updateCoupons.ts
+++ b/vtex/actions/cart/updateCoupons.ts
@@ -2,6 +2,7 @@ import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
 import { parseCookie } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
+import { getSegmentFromBag } from "../../utils/segment.ts";
 
 export interface Props {
   text: string;
@@ -19,9 +20,10 @@ const action = async (
   const { text } = props;
   const cookie = req.headers.get("cookie") ?? "";
   const { orderFormId } = parseCookie(req.headers);
+  const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated
-    ["POST /api/checkout/pub/orderForm/:orderFormId/coupons"]({ orderFormId }, {
+    ["POST /api/checkout/pub/orderForm/:orderFormId/coupons"]({ orderFormId, sc: segment.channel, }, {
       body: { text },
       headers: {
         accept: "application/json",

--- a/vtex/actions/cart/updateItemAttachment.ts
+++ b/vtex/actions/cart/updateItemAttachment.ts
@@ -2,6 +2,7 @@ import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
 import { parseCookie } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
+import { getSegmentFromBag } from "../../utils/segment.ts";
 
 export interface Props {
   /** @description index of the item in the cart.items array you want to edit */
@@ -46,6 +47,7 @@ const action = async (
   } = props;
   const { orderFormId } = parseCookie(req.headers);
   const cookie = req.headers.get("cookie") ?? "";
+  const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated
     ["POST /api/checkout/pub/orderForm/:orderFormId/items/:index/attachments/:attachment"](
@@ -53,6 +55,7 @@ const action = async (
         orderFormId,
         attachment,
         index,
+        sc: segment.channel,
       },
       {
         body: { content, noSplitItem, expectedOrderFormSections },

--- a/vtex/actions/cart/updateItemPrice.ts
+++ b/vtex/actions/cart/updateItemPrice.ts
@@ -2,6 +2,7 @@ import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
 import { parseCookie } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
+import { getSegmentFromBag } from "../../utils/segment.ts";
 
 export interface Props {
   itemIndex: number;
@@ -23,11 +24,13 @@ const action = async (
   } = props;
   const { orderFormId } = parseCookie(req.headers);
   const cookie = req.headers.get("cookie") ?? "";
+  const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated
     ["PUT /api/checkout/pub/orderForm/:orderFormId/items/:index/price"]({
       orderFormId,
       index: itemIndex,
+      sc: segment.channel,
     }, {
       body: { price },
       headers: {

--- a/vtex/actions/cart/updateItems.ts
+++ b/vtex/actions/cart/updateItems.ts
@@ -1,6 +1,7 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
 import { parseCookie } from "../../utils/orderForm.ts";
+import { getSegmentFromBag } from "../../utils/segment.ts";
 import type { OrderForm } from "../../utils/types.ts";
 
 export interface Item {
@@ -28,11 +29,13 @@ const action = async (
   } = props;
   const { orderFormId } = parseCookie(req.headers);
   const cookie = req.headers.get("cookie") ?? "";
+  const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated
     ["POST /api/checkout/pub/orderForm/:orderFormId/items/update"]({
       orderFormId,
       allowedOutdatedData,
+      sc: segment.channel,
     }, {
       body: { orderItems },
       headers: {

--- a/vtex/actions/cart/updateProfile.ts
+++ b/vtex/actions/cart/updateProfile.ts
@@ -2,6 +2,7 @@ import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
 import { parseCookie } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
+import { getSegmentFromBag } from "../../utils/segment.ts";
 
 export interface Props {
   ignoreProfileData: boolean;
@@ -19,10 +20,11 @@ const action = async (
   const { ignoreProfileData } = props;
   const { orderFormId } = parseCookie(req.headers);
   const cookie = req.headers.get("cookie") ?? "";
+  const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated
     ["PATCH /api/checkout/pub/orderForm/:orderFormId/profile"]({
-      orderFormId,
+      orderFormId, sc: segment.channel,
     }, {
       body: { ignoreProfileData },
       headers: {

--- a/vtex/actions/cart/updateProfile.ts
+++ b/vtex/actions/cart/updateProfile.ts
@@ -24,7 +24,8 @@ const action = async (
 
   const response = await vcsDeprecated
     ["PATCH /api/checkout/pub/orderForm/:orderFormId/profile"]({
-      orderFormId, sc: segment.channel,
+      orderFormId,
+      sc: segment.channel,
     }, {
       body: { ignoreProfileData },
       headers: {

--- a/vtex/actions/cart/updateUser.ts
+++ b/vtex/actions/cart/updateUser.ts
@@ -2,6 +2,7 @@ import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
 import { parseCookie } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
+import { getSegmentFromBag } from "../../utils/segment.ts";
 
 /**
  * @docs https://developers.vtex.com/docs/api-reference/checkout-api#get-/checkout/changeToAnonymousUser/-orderFormId-
@@ -14,10 +15,12 @@ const action = async (
   const { vcsDeprecated } = ctx;
   const { orderFormId } = parseCookie(req.headers);
   const cookie = req.headers.get("cookie") ?? "";
+  const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated
     ["GET /api/checkout/changeToAnonymousUser/:orderFormId"]({
       orderFormId,
+      sc: segment.channel,
     }, {
       headers: {
         accept: "application/json",

--- a/vtex/loaders/cart.ts
+++ b/vtex/loaders/cart.ts
@@ -1,6 +1,7 @@
 import { AppContext } from "../mod.ts";
 import { proxySetCookie } from "../utils/cookies.ts";
 import { parseCookie } from "../utils/orderForm.ts";
+import { getSegmentFromBag } from "../utils/segment.ts";
 import type { OrderForm } from "../utils/types.ts";
 
 /**
@@ -13,10 +14,12 @@ const loader = async (
 ): Promise<OrderForm> => {
   const { vcsDeprecated } = ctx;
   const { cookie } = parseCookie(req.headers);
+  const segment = getSegmentFromBag(ctx);
 
-  const response = await vcsDeprecated["POST /api/checkout/pub/orderForm"]({}, {
-    headers: { cookie },
-  });
+  const response = await vcsDeprecated["POST /api/checkout/pub/orderForm"](
+    { sc: segment.channel },
+    { headers: { cookie } },
+  );
 
   proxySetCookie(response.headers, ctx.response.headers, req.url);
 

--- a/vtex/loaders/intelligentSearch/productDetailsPage.ts
+++ b/vtex/loaders/intelligentSearch/productDetailsPage.ts
@@ -49,9 +49,10 @@ const loader = async (
   const segment = getSegmentFromBag(ctx);
 
   const pageTypePromise = vcsDeprecated
-    ["GET /api/catalog_system/pub/portal/pagetype/:term"]({
-      term: `${slug}/p`,
-    }, { deco: { cache: "stale-while-revalidate" } }).then((res) => res.json());
+    ["GET /api/catalog_system/pub/portal/pagetype/:term"](
+      { term: `${slug}/p` },
+      STALE,
+    ).then((res) => res.json());
 
   const url = new URL(baseUrl);
   const skuId = url.searchParams.get("skuId");

--- a/vtex/middleware.ts
+++ b/vtex/middleware.ts
@@ -25,19 +25,22 @@ export const middleware = (
   req: Request,
   ctx: AppMiddlewareContext,
 ) => {
-  if (!ctx.bag.has(SEGMENT_ONCE_KEY)) {
-    ctx.bag.set(SEGMENT_ONCE_KEY, true);
+  const { bag, salesChannel, response } = ctx;
+
+  if (!bag.has(SEGMENT_ONCE_KEY)) {
+    bag.set(SEGMENT_ONCE_KEY, true);
 
     const segmentFromCookie = getSegmentFromCookie(req);
     const segmentFromRequest = buildSegmentCookie(req);
     const segment = {
+      channel: salesChannel,
       ...DEFAULT_SEGMENT,
       ...segmentFromCookie,
       ...segmentFromRequest,
     };
     setSegmentInBag(ctx, segment);
     if (!equal(segmentFromCookie, segment)) {
-      setSegmentCookie(segment, ctx.response.headers);
+      setSegmentCookie(segment, response.headers);
     }
   }
 

--- a/vtex/mod.ts
+++ b/vtex/mod.ts
@@ -46,11 +46,18 @@ export interface Props {
   appToken?: string;
 
   /**
+   * @title Default Sales Channel
+   * @description Default sales channel to use
+   * @default 1
+   */
+  salesChannel?: "1" | "2" | "3" | "4" | "5";
+
+  usePortalSitemap?: boolean;
+
+  /**
    * @description Use VTEX as backend platform
    */
   platform: "vtex";
-
-  usePortalSitemap?: boolean;
 }
 
 export const color = 0xF71963;
@@ -59,7 +66,7 @@ export const color = 0xF71963;
  * @title VTEX
  */
 export default function VTEX(
-  { appKey, appToken, account, ...props }: Props,
+  { appKey, appToken, account, salesChannel, ...props }: Props,
 ) {
   const headers = new Headers();
 
@@ -92,6 +99,7 @@ export default function VTEX(
 
   const state = {
     ...props,
+    salesChannel: salesChannel ?? "1",
     account,
     vcsDeprecated,
     sp,

--- a/vtex/utils/client.ts
+++ b/vtex/utils/client.ts
@@ -107,6 +107,7 @@ export interface VTEXCommerceStable {
 
   "GET /api/checkout/changeToAnonymousUser/:orderFormId": {
     response: OrderForm;
+    searchParams: { sc?: string };
   };
   "POST /api/checkout/pub/orderForms/simulation": {
     response: SimulationOrderForm;
@@ -116,23 +117,30 @@ export interface VTEXCommerceStable {
       country: string;
     };
   };
-  "POST /api/checkout/pub/orderForm": { response: OrderForm };
+  "POST /api/checkout/pub/orderForm": {
+    searchParams: { sc?: string };
+    response: OrderForm;
+  };
   "GET /api/checkout/pub/orderForm/:orderFormId/installments": {
     response: OrderForm;
-    searchParams: { paymentSystem: number };
+    searchParams: { paymentSystem: number; sc?: string };
   };
   "POST /api/checkout/pub/orderForm/:orderFormId/profile": {
     response: OrderForm;
+    searchParams: { sc?: string };
   };
   "PATCH /api/checkout/pub/orderForm/:orderFormId/profile": {
     response: OrderForm;
     body: { ignoreProfileData: boolean };
+    searchParams: { sc?: string };
   };
   "POST /api/checkout/pub/orderForm/:orderFormId/coupons": {
     response: OrderForm;
     body: { text: string };
+    searchParams: { sc?: string };
   };
   "POST /api/checkout/pub/orderForm/:orderFormId/attachments/:attachment": {
+    searchParams: { sc?: string };
     response: OrderForm;
     body: {
       expectedOrderFormSections: string[];
@@ -142,6 +150,7 @@ export interface VTEXCommerceStable {
   "POST /api/checkout/pub/orderForm/:orderFormId/items": {
     response: OrderForm;
     searchParams: {
+      sc?: string;
       allowedOutdatedData: "paymentData"[];
     };
     body: {
@@ -163,18 +172,22 @@ export interface VTEXCommerceStable {
       }>;
     };
     searchParams: {
+      sc?: string;
       allowedOutdatedData: "paymentData"[];
     };
   };
   "POST /api/checkout/pub/orderForm/:orderFormId/items/removeAll": {
     response: OrderForm;
+    searchParams: { sc?: string };
   };
   "PUT /api/checkout/pub/orderForm/:orderFormId/items/:index/price": {
+    searchParams: { sc?: string };
     response: OrderForm;
     body: { price: number };
   };
   "POST /api/checkout/pub/orderForm/:orderFormId/items/:index/attachments/:attachment":
     {
+      searchParams: { sc?: string };
       response: OrderForm;
       body: {
         content: Record<string, string>;
@@ -184,6 +197,7 @@ export interface VTEXCommerceStable {
     };
   "DELETE /api/checkout/pub/orderForm/:orderFormId/items/:index/attachments/:attachment":
     {
+      searchParams: { sc?: string };
       response: OrderForm;
       body: {
         content: Record<string, string>;


### PR DESCRIPTION
Adds the default Sales channel config into vtex app config and forwards it into orderform. I think we don't need to forward it in search since we are already forwarding it via segment cookie

<img width="589" alt="image" src="https://github.com/deco-cx/apps/assets/1753396/d85941a7-5fac-41cb-b153-c505d9306816">
