### PR TITLE
feat: add wishlist loader

### DIFF
--- a/analytics/manifest.gen.ts
+++ b/analytics/manifest.gen.ts
@@ -2,16 +2,18 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
+import * as $$$0 from "./loaders/DecoAnalyticsScript.ts";
 import * as $$$$$$0 from "./sections/Analytics/DecoAnalytics.tsx";
-import * as $$$$$$1 from "./loaders/DecoAnalyticsScript.ts";
 
 const manifest = {
+  "loaders": {
+    "analytics/loaders/DecoAnalyticsScript.ts": $$$0,
+  },
   "sections": {
     "analytics/sections/Analytics/DecoAnalytics.tsx": $$$$$$0,
   },
   "name": "analytics",
   "baseUrl": import.meta.url,
-  "loaders": { "analytics/loaders/DecoAnalyticsScript.ts": $$$$$$1 },
 };
 
 export type Manifest = typeof manifest;

--- a/vtex/loaders/product/wishlist.ts
+++ b/vtex/loaders/product/wishlist.ts
@@ -1,0 +1,50 @@
+import { Product, ProductListingPage } from "../../../commerce/types.ts";
+import { AppContext } from "../../mod.ts";
+import wishlistLoader from "../wishlist.ts";
+
+export interface Props {
+  /**
+   * @title Items per page
+   * @description Number of products per page to display
+   * @default 12
+   */
+  count: number;
+}
+
+/** @title VTEX Integration - Wishlist */
+const loader = async (
+  props: Props,
+  req: Request,
+  ctx: AppContext,
+): Promise<ProductListingPage | null> => {
+  const items = await wishlistLoader(props, req, ctx);
+
+  const products = items.map((i): Product => ({
+    "@type": "Product",
+    productID: i.sku,
+    inProductGroupWithID: i.productId,
+    sku: i.sku,
+  }));
+
+  return {
+    "@type": "ProductListingPage",
+    breadcrumb: {
+      "@type": "BreadcrumbList",
+      itemListElement: [],
+      numberOfItems: 0,
+    },
+    filters: [],
+    products,
+    pageInfo: {
+      currentPage: 0,
+      nextPage: undefined,
+      previousPage: undefined,
+      records: products.length,
+      recordPerPage: products.length,
+    },
+    sortOptions: [],
+    seo: null,
+  };
+};
+
+export default loader;

--- a/vtex/manifest.gen.ts
+++ b/vtex/manifest.gen.ts
@@ -11,15 +11,16 @@ import * as $$$5 from "./loaders/legacy/suggestions.ts";
 import * as $$$6 from "./loaders/product/extensions/listingPage.ts";
 import * as $$$7 from "./loaders/product/extensions/detailsPage.ts";
 import * as $$$8 from "./loaders/product/extensions/list.ts";
-import * as $$$9 from "./loaders/wishlist.ts";
-import * as $$$10 from "./loaders/navbar.ts";
-import * as $$$11 from "./loaders/proxy.ts";
-import * as $$$12 from "./loaders/intelligentSearch/productList.ts";
-import * as $$$13 from "./loaders/intelligentSearch/productDetailsPage.ts";
-import * as $$$14 from "./loaders/intelligentSearch/productListingPage.ts";
-import * as $$$15 from "./loaders/intelligentSearch/suggestions.ts";
-import * as $$$16 from "./loaders/cart.ts";
-import * as $$$17 from "./loaders/user.ts";
+import * as $$$9 from "./loaders/product/wishlist.ts";
+import * as $$$10 from "./loaders/wishlist.ts";
+import * as $$$11 from "./loaders/navbar.ts";
+import * as $$$12 from "./loaders/proxy.ts";
+import * as $$$13 from "./loaders/intelligentSearch/productList.ts";
+import * as $$$14 from "./loaders/intelligentSearch/productDetailsPage.ts";
+import * as $$$15 from "./loaders/intelligentSearch/productListingPage.ts";
+import * as $$$16 from "./loaders/intelligentSearch/suggestions.ts";
+import * as $$$17 from "./loaders/cart.ts";
+import * as $$$18 from "./loaders/user.ts";
 import * as $$$$0 from "./handlers/sitemap.ts";
 import * as $$$$$$$$$0 from "./actions/trigger.ts";
 import * as $$$$$$$$$1 from "./actions/notifyme.ts";
@@ -44,24 +45,25 @@ import * as $$$$$$$$$$0 from "./workflows/events.ts";
 
 const manifest = {
   "loaders": {
-    "vtex/loaders/cart.ts": $$$16,
-    "vtex/loaders/intelligentSearch/productDetailsPage.ts": $$$13,
-    "vtex/loaders/intelligentSearch/productList.ts": $$$12,
-    "vtex/loaders/intelligentSearch/productListingPage.ts": $$$14,
-    "vtex/loaders/intelligentSearch/suggestions.ts": $$$15,
+    "vtex/loaders/cart.ts": $$$17,
+    "vtex/loaders/intelligentSearch/productDetailsPage.ts": $$$14,
+    "vtex/loaders/intelligentSearch/productList.ts": $$$13,
+    "vtex/loaders/intelligentSearch/productListingPage.ts": $$$15,
+    "vtex/loaders/intelligentSearch/suggestions.ts": $$$16,
     "vtex/loaders/legacy/productDetailsPage.ts": $$$2,
     "vtex/loaders/legacy/productList.ts": $$$1,
     "vtex/loaders/legacy/productListingPage.ts": $$$3,
     "vtex/loaders/legacy/relatedProductsLoader.ts": $$$4,
     "vtex/loaders/legacy/suggestions.ts": $$$5,
-    "vtex/loaders/navbar.ts": $$$10,
+    "vtex/loaders/navbar.ts": $$$11,
     "vtex/loaders/product.ts": $$$0,
     "vtex/loaders/product/extensions/detailsPage.ts": $$$7,
     "vtex/loaders/product/extensions/list.ts": $$$8,
     "vtex/loaders/product/extensions/listingPage.ts": $$$6,
-    "vtex/loaders/proxy.ts": $$$11,
-    "vtex/loaders/user.ts": $$$17,
-    "vtex/loaders/wishlist.ts": $$$9,
+    "vtex/loaders/product/wishlist.ts": $$$9,
+    "vtex/loaders/proxy.ts": $$$12,
+    "vtex/loaders/user.ts": $$$18,
+    "vtex/loaders/wishlist.ts": $$$10,
   },
   "handlers": {
     "vtex/handlers/sitemap.ts": $$$$0,


### PR DESCRIPTION
This PR adds a new wishlist loader that returns a ProductListingPage, compatible to our usual search pages.

This new loader returns only the productID of items inside wishlist. To add other info required for rendering the wishlist page, this PR also adds a new "variants" toggle in our extension loader. This way we can compose these two loaders on the admin and fetch a full product from VTEX