### PR TITLE
feat (vtex): adding giftSkuIds available

### DIFF
--- a/commerce/types.ts
+++ b/commerce/types.ts
@@ -199,6 +199,8 @@ export interface Offer extends Omit<Thing, "@type"> {
   seller?: string;
   /** The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers. */
   sku?: string;
+  /** Used by some ecommerce sites to retrieve the sku of products that are part of the BuyAndWin promotion */
+  giftSkuIds?: string[];
   /** Used by some ecommerce providers (e.g: VTEX) to describe special promotions that depend on some conditions */
   teasers?: Teasers[];
 }

--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -492,6 +492,7 @@ const toOffer = ({ commertialOffer: offer, sellerId }: SellerVTEX): Offer => ({
   seller: sellerId,
   priceValidUntil: offer.PriceValidUntil,
   inventoryLevel: { value: offer.AvailableQuantity },
+  giftSkuIds: offer.giftSkuIds ?? [],
   teasers: offer.teasers ?? [],
   priceSpecification: [
     {

--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -492,7 +492,7 @@ const toOffer = ({ commertialOffer: offer, sellerId }: SellerVTEX): Offer => ({
   seller: sellerId,
   priceValidUntil: offer.PriceValidUntil,
   inventoryLevel: { value: offer.AvailableQuantity },
-  giftSkuIds: offer.giftSkuIds ?? [],
+  giftSkuIds: offer.GiftSkuIds ?? [],
   teasers: offer.teasers ?? [],
   priceSpecification: [
     {


### PR DESCRIPTION
## What is this PR for?

![image](https://github.com/yuriassuncx/expressots-api/assets/104099580/24450efa-55dc-4f7a-a5bd-dff73967a246)

Some e-commerce sites use the BuyAndWin promotion. The only information about Buy and Win products is in GiftSkuIds, which returns us the Skus of products that are part of this promotion. Aware of this, we intend to retrieve this information with this PR, making it possible to retrieve this product and make it appear in the frontend. In VTEX IO this is done through a feature called Product Gifts.

![image](https://github.com/yuriassuncx/expressots-api/assets/104099580/fe2e12fd-0b67-4f80-83e1-41d08bd8af4d)
Our loaders did not return this information, nor did it appear in the product Offers, which is where this information comes from, so it is intended that, with this PR, it will start to appear

vtex docs:
https://developers.vtex.com/docs/apps/vtex.product-gifts