### PR TITLE
feat: PLPs page numbers in canonical tags

### DIFF
--- a/commerce/sections/Seo/SeoPLP.tsx
+++ b/commerce/sections/Seo/SeoPLP.tsx
@@ -1,5 +1,6 @@
 import Seo, { Props as SeoProps } from "../../../website/components/Seo.tsx";
 import { ProductListingPage } from "../../types.ts";
+import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts";
 
 export type Props = {
   jsonLD: ProductListingPage | null;
@@ -12,7 +13,7 @@ function Section({ jsonLD, ...props }: Props) {
     ? jsonLD.seo.canonical
     : jsonLD?.breadcrumb
     ? canonicalFromBreadcrumblist(jsonLD?.breadcrumb)
-    : null;
+    : props.canonical;
 
   const noIndexing = !jsonLD || !jsonLD.products.length;
 
@@ -21,7 +22,7 @@ function Section({ jsonLD, ...props }: Props) {
       {...props}
       title={title || props.title}
       description={description || props.description}
-      canonical={props.canonical || canonical}
+      canonical={canonical}
       jsonLDs={[jsonLD]}
       noIndexing={noIndexing}
     />

--- a/commerce/sections/Seo/SeoPLP.tsx
+++ b/commerce/sections/Seo/SeoPLP.tsx
@@ -1,6 +1,5 @@
 import Seo, { Props as SeoProps } from "../../../website/components/Seo.tsx";
 import { ProductListingPage } from "../../types.ts";
-import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts";
 
 export type Props = {
   jsonLD: ProductListingPage | null;
@@ -22,7 +21,7 @@ function Section({ jsonLD, ...props }: Props) {
       {...props}
       title={title || props.title}
       description={description || props.description}
-      canonical={canonical || props.canonical}
+      canonical={props.canonical || canonical}
       jsonLDs={[jsonLD]}
       noIndexing={noIndexing}
     />

--- a/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -104,12 +104,6 @@ export interface Props {
   selectedFacets?: SelectedFacet[];
 
   /**
-   * @title Page number indexing
-   * @description Page number will be taken into account on indexing
-   */
-  pgNumberIndexing?: boolean;
-
-  /**
    * @title Hide Unavailable Items
    * @description Do not return out of stock items
    */
@@ -387,6 +381,8 @@ const loader = async (
     previousPage.set("page", (page + currentPageoffset - 1).toString());
   }
 
+  const currentPage = page + currentPageoffset;
+
   return {
     "@type": "ProductListingPage",
     breadcrumb: {
@@ -399,12 +395,16 @@ const loader = async (
     pageInfo: {
       nextPage: hasNextPage ? `?${nextPage}` : undefined,
       previousPage: hasPreviousPage ? `?${previousPage}` : undefined,
-      currentPage: page + currentPageoffset,
+      currentPage,
       records: recordsFiltered,
       recordPerPage: pagination.perPage,
     },
     sortOptions,
-    seo: pageTypesToSeo(pageTypes, req, props.pgNumberIndexing),
+    seo: pageTypesToSeo(
+      pageTypes,
+      req,
+      hasPreviousPage ? currentPage : undefined,
+    ),
   };
 };
 

--- a/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -104,6 +104,12 @@ export interface Props {
   selectedFacets?: SelectedFacet[];
 
   /**
+   * @title Page number indexing
+   * @description Page number will be taken into account on indexing
+   */
+  pgNumberIndexing?: boolean;
+
+  /**
    * @title Hide Unavailable Items
    * @description Do not return out of stock items
    */
@@ -398,7 +404,7 @@ const loader = async (
       recordPerPage: pagination.perPage,
     },
     sortOptions,
-    seo: pageTypesToSeo(pageTypes, req),
+    seo: pageTypesToSeo(pageTypes, req, props.pgNumberIndexing),
   };
 };
 

--- a/vtex/loaders/legacy/productListingPage.ts
+++ b/vtex/loaders/legacy/productListingPage.ts
@@ -290,6 +290,8 @@ const loader = async (
     previousPage.set("page", (page + currentPageoffset - 1).toString());
   }
 
+  const currentPage = page + currentPageoffset;
+
   return {
     "@type": "ProductListingPage",
     breadcrumb: {
@@ -302,12 +304,12 @@ const loader = async (
     pageInfo: {
       nextPage: hasNextPage ? `?${nextPage.toString()}` : undefined,
       previousPage: hasPreviousPage ? `?${previousPage.toString()}` : undefined,
-      currentPage: page + currentPageoffset,
+      currentPage,
       records: parseInt(_total, 10),
       recordPerPage: count,
     },
     sortOptions,
-    seo: pageTypesToSeo(pageTypes, req),
+    seo: pageTypesToSeo(pageTypes, req, previousPage ? currentPage : undefined),
   };
 };
 

--- a/vtex/utils/legacy.ts
+++ b/vtex/utils/legacy.ts
@@ -98,7 +98,11 @@ export const pageTypesToBreadcrumbList = (
   });
 };
 
-export const pageTypesToSeo = (pages: PageType[], req: Request): Seo | null => {
+export const pageTypesToSeo = (
+  pages: PageType[],
+  req: Request,
+  pgNumberIndexing?: boolean,
+): Seo | null => {
   const current = pages.at(-1);
 
   const url = new URL(req.url);
@@ -117,11 +121,20 @@ export const pageTypesToSeo = (pages: PageType[], req: Request): Seo | null => {
     return null;
   }
 
-  const [_, pathname] = current.url?.split(".vtexcommercestable.com.br") ?? [];
-
   return {
     title: current.title!,
     description: current.metaTagDescription!,
-    canonical: new URL(pathname, req.url).href,
+    canonical: buildCanonicalURL(pgNumberIndexing, req.url),
   };
 };
+
+function buildCanonicalURL(pgNumberIndexing = false, urlStr: string) {
+  const url = new URL(urlStr);
+  const { origin, pathname, searchParams } = url;
+
+  if (!pgNumberIndexing) return `${origin}${pathname}`;
+
+  const pgNumber = searchParams.get("page") ?? "1";
+
+  return `${origin}${pathname}?page=${pgNumber}`;
+}

--- a/vtex/utils/legacy.ts
+++ b/vtex/utils/legacy.ts
@@ -101,19 +101,18 @@ export const pageTypesToBreadcrumbList = (
 export const pageTypesToSeo = (
   pages: PageType[],
   req: Request,
-  pgNumberIndexing?: boolean,
+  currentPage?: number,
 ): Seo | null => {
   const current = pages.at(-1);
 
   const url = new URL(req.url);
-  const urlParams = url.searchParams;
-  const fullTextSearch = urlParams.get("q");
+  const fullTextSearch = url.searchParams.get("q");
 
   if (!current && fullTextSearch) {
     return {
       title: capitalize(fullTextSearch),
       description: capitalize(fullTextSearch),
-      canonical: new URL(req.url).href,
+      canonical: req.url,
     };
   }
 
@@ -124,17 +123,23 @@ export const pageTypesToSeo = (
   return {
     title: current.title!,
     description: current.metaTagDescription!,
-    canonical: buildCanonicalURL(pgNumberIndexing, req.url),
+    canonical: toCanonical(
+      new URL(
+        current.url
+          ? current.url.replace(/.+\.vtexcommercestable\.com\.br/, "")
+          : url,
+        url,
+      ),
+      currentPage,
+    ),
   };
 };
 
-function buildCanonicalURL(pgNumberIndexing = false, urlStr: string) {
-  const url = new URL(urlStr);
-  const { origin, pathname, searchParams } = url;
+// Warning! this modifies the parameter. Use it consciously
+function toCanonical(url: URL, page?: number) {
+  if (typeof page === "number") {
+    url.searchParams.set("page", `${page}`);
+  }
 
-  if (!pgNumberIndexing) return `${origin}${pathname}`;
-
-  const pgNumber = searchParams.get("page") ?? "1";
-
-  return `${origin}${pathname}?page=${pgNumber}`;
+  return url.href;
 }


### PR DESCRIPTION
From this change, it will be possible to decide whether the page number (PLPs) will be taken into account on indexing.

By default, the following pages would be indexed as the same page, that is, the same canonical tag would be generated for both:
`http://lojastorra.com.br/my-category?page=2`
`http://lojastorra.com.br/my-category?page=3`

However, when the user checks the `pgNumberIndexing` option, the above pages will be indexed separately.