### PR TITLE
fix: missing skus

### DIFF
--- a/vtex/loaders/legacy/productDetailsPage.ts
+++ b/vtex/loaders/legacy/productDetailsPage.ts
@@ -48,15 +48,17 @@ async function loader(
 
   const sku = pickSku(product, skuId?.toString());
 
-  const kitItems: LegacyProduct[] = sku.isKit && sku.kitItems
-    ? await vcsDeprecated["GET /api/catalog_system/pub/products/search/:term?"](
-      {
-        ...params,
-        fq: sku.kitItems.map((item) => `skuId:${item.itemId}`),
-      },
-      STALE,
-    ).then((res) => res.json())
-    : [];
+  const kitItems: LegacyProduct[] =
+    Array.isArray(sku.kitItems) && sku.kitItems.length > 0
+      ? await vcsDeprecated
+        ["GET /api/catalog_system/pub/products/search/:term?"](
+          {
+            ...params,
+            fq: sku.kitItems.map((item) => `skuId:${item.itemId}`),
+          },
+          STALE,
+        ).then((res) => res.json())
+      : [];
 
   const page = toProductPage(product, sku, kitItems, {
     baseUrl,

--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -105,16 +105,13 @@ const toAccessoryOrSparePartFor = <T extends ProductVTEX | LegacyProductVTEX>(
   return sku.kitItems?.map(({ itemId }) => {
     const product = productBySkuId.get(itemId);
 
-    if (!product) {
-      throw new Error(
-        `Expected product for skuId ${itemId} but it was not returned by the search engine`,
-      );
-    }
+    /** Sometimes VTEX does not return what I've asked for */
+    if (!product) return;
 
     const sku = pickSku(product, itemId);
 
     return toProduct(product, sku, 0, options);
-  });
+  }).filter((p): p is Product => typeof p !== "undefined");
 };
 
 export const toProductPage = <T extends ProductVTEX | LegacyProductVTEX>(
@@ -124,7 +121,7 @@ export const toProductPage = <T extends ProductVTEX | LegacyProductVTEX>(
   options: ProductOptions,
 ): Omit<ProductDetailsPage, "seo"> => {
   const partialProduct = toProduct(product, sku, 0, options);
-  // Get accessories in ProductPage only. I don't see where it's necessary outside this page for now
+  // This is deprecated. Compose this loader at loaders > product > extension > detailsPage.ts
   const isAccessoryOrSparePartFor = toAccessoryOrSparePartFor(
     sku,
     kitItems,


### PR DESCRIPTION
Sometimes, the item will say it's a kit, but the kit items will not be returned by VTEX. 

This PR relax the loader boundary conditions so we do not throw on these cases