### PR TITLE
feat: add deco event instead of flags

### DIFF
--- a/analytics/components/DecoAnalytics.tsx
+++ b/analytics/components/DecoAnalytics.tsx
@@ -35,14 +35,21 @@ const snippet = () => {
     addEventListener("popstate", trackPageview);
   }
 
+  // 2000 bytes limit
+  const truncate = (str: string) => `${str}`.slice(0, 990);
+
   // setup plausible script and unsubscribe
   window.DECO.events.subscribe((event) => {
-    if (!event || event.name !== "deco-flags") return;
+    if (!event || event.name !== "deco") return;
 
-    if (Array.isArray(event.params)) {
-      for (const flag of event.params) {
-        props[flag.name] = flag.value.toString();
+    if (event.params) {
+      const { flags, page } = event.params;
+      if (Array.isArray(flags)) {
+        for (const flag of flags) {
+          props[flag.name] = truncate(flag.value.toString());
+        }
       }
+      props["pageId"] = truncate(`${page.id}`);
     }
 
     trackPageview();
@@ -53,7 +60,7 @@ const snippet = () => {
 
     const { name, params } = event;
 
-    if (!name || !params || name === "deco-flags") return;
+    if (!name || !params || name === "deco") return;
 
     const values = { ...props };
     for (const key in params) {
@@ -61,9 +68,9 @@ const snippet = () => {
       const value = params[key];
 
       if (value !== null && value !== undefined) {
-        values[key] = (typeof value !== "object")
-          ? value
-          : JSON.stringify(value).slice(0, 990); // 2000 bytes limit
+        values[key] = truncate(
+          (typeof value !== "object") ? value : JSON.stringify(value),
+        );
       }
     }
 

--- a/commerce/types.ts
+++ b/commerce/types.ts
@@ -737,8 +737,18 @@ export interface ViewPromotionEvent extends IEvent<ViewPromotionParams> {
   name: "view_promotion";
 }
 
-export interface DecoFlagsEvent extends IEvent<Flag[]> {
-  name: "deco-flags";
+export interface Page {
+  id: string | number;
+  pathTemplate?: string;
+}
+
+export interface Deco {
+  flags: Flag[];
+  page: Page;
+}
+
+export interface DecoEvent extends IEvent<Deco> {
+  name: "deco";
 }
 
 export type AnalyticsEvent =
@@ -755,4 +765,4 @@ export type AnalyticsEvent =
   | ViewItemEvent
   | ViewItemListEvent
   | ViewPromotionEvent
-  | DecoFlagsEvent;
+  | DecoEvent;

--- a/sourei/sections/Analytics/Sourei.tsx
+++ b/sourei/sections/Analytics/Sourei.tsx
@@ -36,7 +36,7 @@ const snippet = () => {
       ? ({ item_id: `${item_group_id}_${item_id}`, ...rest })
       : ({ item_id, ...rest });
 
-  const fixPrice = (
+  const fixPrices = (
     { price, discount = 0, quantity = 1, ...rest }: any,
   ) => ({
     ...rest,
@@ -50,7 +50,7 @@ const snippet = () => {
   window.DECO.events.subscribe((event) => {
     if (!event) return;
 
-    if (event.name === "deco-flags") {
+    if (event.name === "deco") {
       window.dataLayer.push(event);
       return;
     }
@@ -60,8 +60,12 @@ const snippet = () => {
     if (ecommerce && Array.isArray(ecommerce.items)) {
       ecommerce.items = ecommerce.items
         .map(fixId)
-        .map(fixPrice)
+        .map(fixPrices)
         .map(fixIndex);
+    }
+
+    if (typeof ecommerce.value === "number") {
+      ecommerce.value = rounded(ecommerce.value);
     }
 
     window.dataLayer.push({ ecommerce: null });

--- a/website/components/Events.tsx
+++ b/website/components/Events.tsx
@@ -1,6 +1,5 @@
 import { Head } from "$fresh/runtime.ts";
-import { type Flag } from "deco/types.ts";
-import { type AnalyticsEvent } from "../../commerce/types.ts";
+import { type AnalyticsEvent, type Deco } from "../../commerce/types.ts";
 import { scriptAsDataURI } from "../../utils/dataURI.ts";
 
 type EventHandler = (event?: AnalyticsEvent) => void | Promise<void>;
@@ -29,7 +28,7 @@ declare global {
  * This function handles all ecommerce analytics events.
  * Add another ecommerce analytics modules here.
  */
-const snippet = (flags: Flag[]) => {
+const snippet = ({ flags, page }: Deco) => {
   const appendSessionFlags = () => {
     const knownFlags = new Set(flags.map((f) => f.name));
     const cookies = document.cookie.split(";");
@@ -64,7 +63,7 @@ const snippet = (flags: Flag[]) => {
     // deno-lint-ignore no-explicit-any
     const cb = ({ detail }: any) => handler(detail);
 
-    handler({ name: "deco-flags", params: flags });
+    handler({ name: "deco", params: { flags, page } });
 
     target.addEventListener("analytics", cb, opts);
 
@@ -80,10 +79,14 @@ const snippet = (flags: Flag[]) => {
   };
 };
 
-function Events({ flags }: { flags: Flag[] }) {
+function Events({ deco }: { deco: Deco }) {
   return (
     <Head>
-      <script defer id="deco-events" src={scriptAsDataURI(snippet, flags)} />
+      <script
+        defer
+        id="deco-events"
+        src={scriptAsDataURI(snippet, deco)}
+      />
     </Head>
   );
 }

--- a/website/components/_Controls.tsx
+++ b/website/components/_Controls.tsx
@@ -2,11 +2,7 @@ import { Head } from "$fresh/runtime.ts";
 import type { Flag, Site } from "deco/types.ts";
 import { context } from "deco/live.ts";
 import { scriptAsDataURI } from "../../utils/dataURI.ts";
-
-interface Page {
-  id: string | number;
-  pathTemplate?: string;
-}
+import { Page } from "../../commerce/types.ts";
 
 interface Live {
   page?: Page;

--- a/website/pages/Page.tsx
+++ b/website/pages/Page.tsx
@@ -33,34 +33,45 @@ export function renderSection(section: Props["sections"][number]) {
   return <Component {...props} />;
 }
 
-/**
- * @title Page
- */
-function Page({ sections }: Props): JSX.Element {
+const useDeco = () => {
   const metadata = useDecoPageContext()?.metadata;
   const routerCtx = useRouterContext();
   const pageId = pageIdFromMetadata(metadata);
 
+  return {
+    flags: routerCtx?.flags ?? [],
+    page: {
+      id: pageId,
+      pathTemplate: routerCtx?.pagePath,
+    },
+  };
+};
+
+/**
+ * @title Page
+ */
+function Page({ sections }: Props): JSX.Element {
+  const site = { id: context.siteId, name: context.site };
+  const deco = useDeco();
+
   return (
     <>
-      <LiveControls
-        site={{ id: context.siteId, name: context.site }}
-        page={{ id: pageId, pathTemplate: routerCtx?.pagePath }}
-        flags={routerCtx?.flags}
-      />
-      <Events flags={routerCtx?.flags ?? []} />
+      <LiveControls site={site} {...deco} />
+      <Events deco={deco} />
       {sections.map(renderSection)}
     </>
   );
 }
 
 export function Preview({ sections }: Props) {
+  const deco = useDeco();
+
   return (
     <>
       <Head>
         <meta name="robots" content="noindex, nofollow" />
       </Head>
-      <Events flags={[]} />
+      <Events deco={deco} />
       {sections.map(renderSection)}
     </>
   );


### PR DESCRIPTION
This PR:
1. removes deco-flags event in favor of deco event, including flags and page
2. make sourei app to format numbers before adding to datalayer