### PR TITLE
fix: optional items param select_promotion and coupon add_shipping_info

### DIFF
--- a/commerce/types.ts
+++ b/commerce/types.ts
@@ -596,7 +596,7 @@ export type AnalyticsItem = AnalyticsItemWithoutIdentifier & ItemIdentifier;
 export interface AddShippingInfoParams {
   currency?: Currency;
   value?: Value;
-  coupun?: string;
+  coupon?: string;
   shipping_tier?: string;
   items: AnalyticsItem[];
 }
@@ -683,7 +683,7 @@ export interface SelectPromotionParams {
   creative_slot?: string;
   promotion_id?: string;
   promotion_name?: string;
-  items: AnalyticsItem[];
+  items?: AnalyticsItem[];
 }
 
 /** @docs https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm#select_promotion */


### PR DESCRIPTION
Hello friends,

This PR corrects the items parameter of the select_promotion event so that it is optional, a necessary correction for correct operation in the frontend of typing in GA4 events

Also fixes the word 'coupon' in the add_shipping_info event

![image](https://github.com/deco-cx/apps/assets/65980571/2c199969-42d2-4fda-92c0-6017fe6376b7)

https://developers.google.com/gtagjs/reference/ga4-events?hl=pt-br


