### PR TITLE
Adding Control + X to activators

### DIFF
--- a/website/components/_Controls.tsx
+++ b/website/components/_Controls.tsx
@@ -30,8 +30,8 @@ const domInspectorModule = IS_LOCALHOST
   ? `
 const DomInspectorActivators = {
   Backquote: {
-    label: "\` (backtick)",
-    matchEvent: (event) => event.code === "Backquote",
+    label: "\` (backtick) or Ctrl + X",
+    matchEvent: (event) => event.code === "Backquote" || (event.ctrlKey && event.key === "x"),
   },
 };
 ${DomInspector.toString()}`


### PR DESCRIPTION
Adding Ctrl+X to the "go to code" activator will facilitate its use for ABNT keyboards.