### PR TITLE
Enhancement: Inclusion of "Suggested Retail Price" in Product Details

### DIFF
--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -502,6 +502,11 @@ const toOffer = ({ commertialOffer: offer, sellerId }: SellerVTEX): Offer => ({
       priceType: "https://schema.org/SalePrice",
       price: offer.Price,
     },
+    {
+      "@type": "UnitPriceSpecification",
+      priceType: "https://schema.org/SRP",
+      price: offer.PriceWithoutDiscount,
+    },
     ...offer.Installments.map(
       (installment): UnitPriceSpecification => ({
         "@type": "UnitPriceSpecification",


### PR DESCRIPTION
Submitting this pull request to ensure the preservation of the suggested retail price on products that undergo updates in their price table, as well as those featuring any enabled promotions on VTEX.

In the original product request on VTEX, there is a value for `PriceWithoutDiscount` that is currently typed but missing from the return provided by the product details loader. By adding this typed value as a Unit Price Specification for the suggested retail price, we can introduce a feature that displays the original price before any discounts from the price table, while still presenting the final price including all available promotions.

![image](https://github.com/deco-cx/apps/assets/58176249/438b6d7a-5d28-474d-83e1-807542e71f52)

Example image taken from https://secure.zeedog.com.br/api/catalog_system/pub/products/search/?fq=productId:5052709

