### PR TITLE
feat: add video in PDP

### DIFF
--- a/admin/manifest.gen.ts
+++ b/admin/manifest.gen.ts
@@ -2,55 +2,55 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/blocks/revision.ts";
-import * as $$$1 from "./loaders/blocks/published.ts";
-import * as $$$2 from "./loaders/blocks/latest.ts";
-import * as $$$3 from "./loaders/blocks/listRevisions.ts";
-import * as $$$4 from "./loaders/state.ts";
-import * as $$$5 from "./loaders/releases/blocks.ts";
-import * as $$$6 from "./loaders/platforms/forSite.ts";
-import * as $$$7 from "./loaders/deploy.ts";
+import * as $$$0 from "./loaders/deploy.ts";
+import * as $$$1 from "./loaders/releases/blocks.ts";
+import * as $$$2 from "./loaders/state.ts";
+import * as $$$3 from "./loaders/blocks/revision.ts";
+import * as $$$4 from "./loaders/blocks/published.ts";
+import * as $$$5 from "./loaders/blocks/latest.ts";
+import * as $$$6 from "./loaders/blocks/listRevisions.ts";
+import * as $$$7 from "./loaders/platforms/forSite.ts";
 import * as $$$8 from "./loaders/pages/list.ts";
-import * as $$$$$$$$$0 from "./actions/blocks/publish.ts";
-import * as $$$$$$$$$1 from "./actions/blocks/restore.ts";
+import * as $$$$$$$$$0 from "./actions/github/setStatus.ts";
+import * as $$$$$$$$$1 from "./actions/github/webhooks/broker.ts";
 import * as $$$$$$$$$2 from "./actions/blocks/safeDelete.ts";
 import * as $$$$$$$$$3 from "./actions/blocks/newRevision.ts";
 import * as $$$$$$$$$4 from "./actions/blocks/delete.ts";
-import * as $$$$$$$$$5 from "./actions/sites/linkRepo.ts";
-import * as $$$$$$$$$6 from "./actions/sites/newDomain.ts";
-import * as $$$$$$$$$7 from "./actions/sites/unlinkRepo.ts";
-import * as $$$$$$$$$8 from "./actions/github/setStatus.ts";
-import * as $$$$$$$$$9 from "./actions/github/webhooks/broker.ts";
-import * as $$$$$$$$$10 from "./actions/pages/publish.ts";
-import * as $$$$$$$$$11 from "./actions/pages/new.ts";
-import * as $$$$$$$$$12 from "./actions/pages/delete.ts";
+import * as $$$$$$$$$5 from "./actions/blocks/publish.ts";
+import * as $$$$$$$$$6 from "./actions/blocks/restore.ts";
+import * as $$$$$$$$$7 from "./actions/pages/delete.ts";
+import * as $$$$$$$$$8 from "./actions/pages/new.ts";
+import * as $$$$$$$$$9 from "./actions/pages/publish.ts";
+import * as $$$$$$$$$10 from "./actions/sites/unlinkRepo.ts";
+import * as $$$$$$$$$11 from "./actions/sites/newDomain.ts";
+import * as $$$$$$$$$12 from "./actions/sites/linkRepo.ts";
 
 const manifest = {
   "loaders": {
-    "deco-sites/admin/loaders/blocks/latest.ts": $$$2,
-    "deco-sites/admin/loaders/blocks/listRevisions.ts": $$$3,
-    "deco-sites/admin/loaders/blocks/published.ts": $$$1,
-    "deco-sites/admin/loaders/blocks/revision.ts": $$$0,
-    "deco-sites/admin/loaders/deploy.ts": $$$7,
+    "deco-sites/admin/loaders/blocks/latest.ts": $$$5,
+    "deco-sites/admin/loaders/blocks/listRevisions.ts": $$$6,
+    "deco-sites/admin/loaders/blocks/published.ts": $$$4,
+    "deco-sites/admin/loaders/blocks/revision.ts": $$$3,
+    "deco-sites/admin/loaders/deploy.ts": $$$0,
     "deco-sites/admin/loaders/pages/list.ts": $$$8,
-    "deco-sites/admin/loaders/platforms/forSite.ts": $$$6,
-    "deco-sites/admin/loaders/releases/blocks.ts": $$$5,
-    "deco-sites/admin/loaders/state.ts": $$$4,
+    "deco-sites/admin/loaders/platforms/forSite.ts": $$$7,
+    "deco-sites/admin/loaders/releases/blocks.ts": $$$1,
+    "deco-sites/admin/loaders/state.ts": $$$2,
   },
   "actions": {
     "deco-sites/admin/actions/blocks/delete.ts": $$$$$$$$$4,
     "deco-sites/admin/actions/blocks/newRevision.ts": $$$$$$$$$3,
-    "deco-sites/admin/actions/blocks/publish.ts": $$$$$$$$$0,
-    "deco-sites/admin/actions/blocks/restore.ts": $$$$$$$$$1,
+    "deco-sites/admin/actions/blocks/publish.ts": $$$$$$$$$5,
+    "deco-sites/admin/actions/blocks/restore.ts": $$$$$$$$$6,
     "deco-sites/admin/actions/blocks/safeDelete.ts": $$$$$$$$$2,
-    "deco-sites/admin/actions/github/setStatus.ts": $$$$$$$$$8,
-    "deco-sites/admin/actions/github/webhooks/broker.ts": $$$$$$$$$9,
-    "deco-sites/admin/actions/pages/delete.ts": $$$$$$$$$12,
-    "deco-sites/admin/actions/pages/new.ts": $$$$$$$$$11,
-    "deco-sites/admin/actions/pages/publish.ts": $$$$$$$$$10,
-    "deco-sites/admin/actions/sites/linkRepo.ts": $$$$$$$$$5,
-    "deco-sites/admin/actions/sites/newDomain.ts": $$$$$$$$$6,
-    "deco-sites/admin/actions/sites/unlinkRepo.ts": $$$$$$$$$7,
+    "deco-sites/admin/actions/github/setStatus.ts": $$$$$$$$$0,
+    "deco-sites/admin/actions/github/webhooks/broker.ts": $$$$$$$$$1,
+    "deco-sites/admin/actions/pages/delete.ts": $$$$$$$$$7,
+    "deco-sites/admin/actions/pages/new.ts": $$$$$$$$$8,
+    "deco-sites/admin/actions/pages/publish.ts": $$$$$$$$$9,
+    "deco-sites/admin/actions/sites/linkRepo.ts": $$$$$$$$$12,
+    "deco-sites/admin/actions/sites/newDomain.ts": $$$$$$$$$11,
+    "deco-sites/admin/actions/sites/unlinkRepo.ts": $$$$$$$$$10,
   },
   "name": "deco-sites/admin",
   "baseUrl": import.meta.url,

--- a/algolia/manifest.gen.ts
+++ b/algolia/manifest.gen.ts
@@ -3,8 +3,8 @@
 // This file is automatically updated during development when running `dev.ts`.
 
 import * as $$$0 from "./loaders/product/listingPage.ts";
-import * as $$$1 from "./loaders/product/list.ts";
-import * as $$$2 from "./loaders/product/suggestions.ts";
+import * as $$$1 from "./loaders/product/suggestions.ts";
+import * as $$$2 from "./loaders/product/list.ts";
 import * as $$$$$$0 from "./sections/Analytics/Algolia.tsx";
 import * as $$$$$$$$$0 from "./actions/setup.ts";
 import * as $$$$$$$$$1 from "./actions/index/product.ts";
@@ -13,9 +13,9 @@ import * as $$$$$$$$$$0 from "./workflows/index/product.ts";
 
 const manifest = {
   "loaders": {
-    "algolia/loaders/product/list.ts": $$$1,
+    "algolia/loaders/product/list.ts": $$$2,
     "algolia/loaders/product/listingPage.ts": $$$0,
-    "algolia/loaders/product/suggestions.ts": $$$2,
+    "algolia/loaders/product/suggestions.ts": $$$1,
   },
   "sections": {
     "algolia/sections/Analytics/Algolia.tsx": $$$$$$0,

--- a/commerce/manifest.gen.ts
+++ b/commerce/manifest.gen.ts
@@ -2,10 +2,10 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/product/extensions/listingPage.ts";
-import * as $$$1 from "./loaders/product/extensions/detailsPage.ts";
-import * as $$$2 from "./loaders/product/extensions/list.ts";
-import * as $$$3 from "./loaders/product/extensions/suggestions.ts";
+import * as $$$0 from "./loaders/product/extensions/detailsPage.ts";
+import * as $$$1 from "./loaders/product/extensions/listingPage.ts";
+import * as $$$2 from "./loaders/product/extensions/suggestions.ts";
+import * as $$$3 from "./loaders/product/extensions/list.ts";
 import * as $$$4 from "./loaders/product/productListingPage.ts";
 import * as $$$5 from "./loaders/product/products.ts";
 import * as $$$6 from "./loaders/extensions/productDetailsPage.ts";
@@ -21,10 +21,10 @@ const manifest = {
     "commerce/loaders/extensions/productListingPage.ts": $$$7,
     "commerce/loaders/extensions/products.ts": $$$8,
     "commerce/loaders/navbar.ts": $$$9,
-    "commerce/loaders/product/extensions/detailsPage.ts": $$$1,
-    "commerce/loaders/product/extensions/list.ts": $$$2,
-    "commerce/loaders/product/extensions/listingPage.ts": $$$0,
-    "commerce/loaders/product/extensions/suggestions.ts": $$$3,
+    "commerce/loaders/product/extensions/detailsPage.ts": $$$0,
+    "commerce/loaders/product/extensions/list.ts": $$$3,
+    "commerce/loaders/product/extensions/listingPage.ts": $$$1,
+    "commerce/loaders/product/extensions/suggestions.ts": $$$2,
     "commerce/loaders/product/productListingPage.ts": $$$4,
     "commerce/loaders/product/products.ts": $$$5,
   },

--- a/commerce/types.ts
+++ b/commerce/types.ts
@@ -48,7 +48,22 @@ export interface Thing {
   url?: string;
 }
 
-export interface ImageObject extends Omit<Thing, "@type"> {
+export interface MediaObject {
+  /** Media type typically expressed using a MIME format (see IANA site and MDN reference) */
+  encodingFormat: string;
+  /** A URL pointing to a player for a specific video. */
+  embedUrl?: string;
+  /** Actual bytes of the media object, for example the image file or video file. */
+  contentUrl?: string;
+}
+
+export interface CreativeWork {
+  /** A thumbnail image relevant to the Thing */
+  thumbnailUrl?: string;
+}
+
+export interface ImageObject
+  extends MediaObject, CreativeWork, Omit<Thing, "@type"> {
   "@type": "ImageObject";
 }
 

--- a/commerce/utils/constants.ts
+++ b/commerce/utils/constants.ts
@@ -2,6 +2,7 @@ import { ImageObject } from "../types.ts";
 
 export const DEFAULT_IMAGE: ImageObject = {
   "@type": "ImageObject",
+  encodingFormat: "image",
   alternateName: "Default Image Placeholder",
   url:
     "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1818/ff6bb37e-0eab-40e1-a454-86856efc278e",

--- a/compat/$live/manifest.gen.ts
+++ b/compat/$live/manifest.gen.ts
@@ -7,8 +7,8 @@ import * as $$$1 from "./loaders/secret.ts";
 import * as $$$$0 from "./handlers/router.ts";
 import * as $$$$1 from "./handlers/devPage.ts";
 import * as $$$$$$0 from "./sections/Slot.tsx";
-import * as $$$$$$1 from "./sections/EmptySection.tsx";
-import * as $$$$$$2 from "./sections/PageInclude.tsx";
+import * as $$$$$$1 from "./sections/PageInclude.tsx";
+import * as $$$$$$2 from "./sections/EmptySection.tsx";
 
 const manifest = {
   "loaders": {
@@ -20,8 +20,8 @@ const manifest = {
     "$live/handlers/router.ts": $$$$0,
   },
   "sections": {
-    "$live/sections/EmptySection.tsx": $$$$$$1,
-    "$live/sections/PageInclude.tsx": $$$$$$2,
+    "$live/sections/EmptySection.tsx": $$$$$$2,
+    "$live/sections/PageInclude.tsx": $$$$$$1,
     "$live/sections/Slot.tsx": $$$$$$0,
   },
   "name": "$live",

--- a/compat/std/manifest.gen.ts
+++ b/compat/std/manifest.gen.ts
@@ -2,69 +2,70 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $0 from "./functions/vtexProductListingPage.ts";
-import * as $1 from "./functions/vtexLegacyProductDetailsPage.ts";
-import * as $2 from "./functions/vtexSuggestions.ts";
-import * as $3 from "./functions/vtexNavbar.ts";
-import * as $4 from "./functions/vtexWishlist.ts";
-import * as $5 from "./functions/vtexProductList.ts";
-import * as $6 from "./functions/vtexLegacyProductListingPage.ts";
-import * as $7 from "./functions/vtexProductDetailsPage.ts";
-import * as $8 from "./functions/vtexLegacyProductList.ts";
+import * as $0 from "./functions/vtexLegacyProductList.ts";
+import * as $1 from "./functions/vtexProductListingPage.ts";
+import * as $2 from "./functions/vtexProductList.ts";
+import * as $3 from "./functions/vtexWishlist.ts";
+import * as $4 from "./functions/requestToParam.ts";
+import * as $5 from "./functions/vtexSuggestions.ts";
+import * as $6 from "./functions/vtexLegacyProductDetailsPage.ts";
+import * as $7 from "./functions/vtexLegacyProductListingPage.ts";
+import * as $8 from "./functions/vtexProductDetailsPage.ts";
 import * as $9 from "./functions/vtexLegacyRelatedProductsLoader.ts";
-import * as $10 from "./functions/requestToParam.ts";
-import * as $$$0 from "./loaders/vtex/legacy/productList.ts";
+import * as $10 from "./functions/vtexNavbar.ts";
+import * as $$$0 from "./loaders/vtex/legacy/relatedProductsLoader.ts";
 import * as $$$1 from "./loaders/vtex/legacy/productDetailsPage.ts";
-import * as $$$2 from "./loaders/vtex/legacy/productListingPage.ts";
-import * as $$$3 from "./loaders/vtex/legacy/relatedProductsLoader.ts";
-import * as $$$4 from "./loaders/vtex/legacy/suggestions.ts";
+import * as $$$2 from "./loaders/vtex/legacy/productList.ts";
+import * as $$$3 from "./loaders/vtex/legacy/suggestions.ts";
+import * as $$$4 from "./loaders/vtex/legacy/productListingPage.ts";
 import * as $$$5 from "./loaders/vtex/navbar.ts";
 import * as $$$6 from "./loaders/vtex/proxy.ts";
-import * as $$$7 from "./loaders/vtex/intelligentSearch/productList.ts";
-import * as $$$8 from "./loaders/vtex/intelligentSearch/productDetailsPage.ts";
-import * as $$$9 from "./loaders/vtex/intelligentSearch/productListingPage.ts";
-import * as $$$10 from "./loaders/vtex/intelligentSearch/suggestions.ts";
+import * as $$$7 from "./loaders/vtex/intelligentSearch/productDetailsPage.ts";
+import * as $$$8 from "./loaders/vtex/intelligentSearch/productList.ts";
+import * as $$$9 from "./loaders/vtex/intelligentSearch/suggestions.ts";
+import * as $$$10 from "./loaders/vtex/intelligentSearch/productListingPage.ts";
 import * as $$$11 from "./loaders/x/redirects.ts";
 import * as $$$12 from "./loaders/x/font.ts";
 import * as $$$$$$0 from "./sections/SEOPLP.tsx";
-import * as $$$$$$1 from "./sections/Analytics.tsx";
-import * as $$$$$$2 from "./sections/VTEXPortalDataLayerCompatibility.tsx";
+import * as $$$$$$1 from "./sections/VTEXPortalDataLayerCompatibility.tsx";
+import * as $$$$$$2 from "./sections/Analytics.tsx";
 import * as $$$$$$3 from "./sections/SEOPDP.tsx";
 
 const manifest = {
   "functions": {
-    "deco-sites/std/functions/requestToParam.ts": $10,
-    "deco-sites/std/functions/vtexLegacyProductDetailsPage.ts": $1,
-    "deco-sites/std/functions/vtexLegacyProductList.ts": $8,
-    "deco-sites/std/functions/vtexLegacyProductListingPage.ts": $6,
+    "deco-sites/std/functions/requestToParam.ts": $4,
+    "deco-sites/std/functions/vtexLegacyProductDetailsPage.ts": $6,
+    "deco-sites/std/functions/vtexLegacyProductList.ts": $0,
+    "deco-sites/std/functions/vtexLegacyProductListingPage.ts": $7,
     "deco-sites/std/functions/vtexLegacyRelatedProductsLoader.ts": $9,
-    "deco-sites/std/functions/vtexNavbar.ts": $3,
-    "deco-sites/std/functions/vtexProductDetailsPage.ts": $7,
-    "deco-sites/std/functions/vtexProductList.ts": $5,
-    "deco-sites/std/functions/vtexProductListingPage.ts": $0,
-    "deco-sites/std/functions/vtexSuggestions.ts": $2,
-    "deco-sites/std/functions/vtexWishlist.ts": $4,
+    "deco-sites/std/functions/vtexNavbar.ts": $10,
+    "deco-sites/std/functions/vtexProductDetailsPage.ts": $8,
+    "deco-sites/std/functions/vtexProductList.ts": $2,
+    "deco-sites/std/functions/vtexProductListingPage.ts": $1,
+    "deco-sites/std/functions/vtexSuggestions.ts": $5,
+    "deco-sites/std/functions/vtexWishlist.ts": $3,
   },
   "loaders": {
-    "deco-sites/std/loaders/vtex/intelligentSearch/productDetailsPage.ts": $$$8,
-    "deco-sites/std/loaders/vtex/intelligentSearch/productList.ts": $$$7,
-    "deco-sites/std/loaders/vtex/intelligentSearch/productListingPage.ts": $$$9,
-    "deco-sites/std/loaders/vtex/intelligentSearch/suggestions.ts": $$$10,
+    "deco-sites/std/loaders/vtex/intelligentSearch/productDetailsPage.ts": $$$7,
+    "deco-sites/std/loaders/vtex/intelligentSearch/productList.ts": $$$8,
+    "deco-sites/std/loaders/vtex/intelligentSearch/productListingPage.ts":
+      $$$10,
+    "deco-sites/std/loaders/vtex/intelligentSearch/suggestions.ts": $$$9,
     "deco-sites/std/loaders/vtex/legacy/productDetailsPage.ts": $$$1,
-    "deco-sites/std/loaders/vtex/legacy/productList.ts": $$$0,
-    "deco-sites/std/loaders/vtex/legacy/productListingPage.ts": $$$2,
-    "deco-sites/std/loaders/vtex/legacy/relatedProductsLoader.ts": $$$3,
-    "deco-sites/std/loaders/vtex/legacy/suggestions.ts": $$$4,
+    "deco-sites/std/loaders/vtex/legacy/productList.ts": $$$2,
+    "deco-sites/std/loaders/vtex/legacy/productListingPage.ts": $$$4,
+    "deco-sites/std/loaders/vtex/legacy/relatedProductsLoader.ts": $$$0,
+    "deco-sites/std/loaders/vtex/legacy/suggestions.ts": $$$3,
     "deco-sites/std/loaders/vtex/navbar.ts": $$$5,
     "deco-sites/std/loaders/vtex/proxy.ts": $$$6,
     "deco-sites/std/loaders/x/font.ts": $$$12,
     "deco-sites/std/loaders/x/redirects.ts": $$$11,
   },
   "sections": {
-    "deco-sites/std/sections/Analytics.tsx": $$$$$$1,
+    "deco-sites/std/sections/Analytics.tsx": $$$$$$2,
     "deco-sites/std/sections/SEOPDP.tsx": $$$$$$3,
     "deco-sites/std/sections/SEOPLP.tsx": $$$$$$0,
-    "deco-sites/std/sections/VTEXPortalDataLayerCompatibility.tsx": $$$$$$2,
+    "deco-sites/std/sections/VTEXPortalDataLayerCompatibility.tsx": $$$$$$1,
   },
   "name": "deco-sites/std",
   "baseUrl": import.meta.url,

--- a/decohub/manifest.gen.ts
+++ b/decohub/manifest.gen.ts
@@ -2,47 +2,47 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$$$$$$$$$0 from "./apps/typesense.ts";
-import * as $$$$$$$$$$$1 from "./apps/wake.ts";
-import * as $$$$$$$$$$$2 from "./apps/crux.ts";
-import * as $$$$$$$$$$$3 from "./apps/ai-assistants.ts";
-import * as $$$$$$$$$$$4 from "./apps/analytics.ts";
-import * as $$$$$$$$$$$5 from "./apps/workflows.ts";
-import * as $$$$$$$$$$$6 from "./apps/implementation.ts";
-import * as $$$$$$$$$$$7 from "./apps/vnda.ts";
+import * as $$$$$$$$$$$0 from "./apps/crux.ts";
+import * as $$$$$$$$$$$1 from "./apps/vtex.ts";
+import * as $$$$$$$$$$$2 from "./apps/wake.ts";
+import * as $$$$$$$$$$$3 from "./apps/shopify.ts";
+import * as $$$$$$$$$$$4 from "./apps/workflows.ts";
+import * as $$$$$$$$$$$5 from "./apps/linx.ts";
+import * as $$$$$$$$$$$6 from "./apps/ai-assistants.ts";
+import * as $$$$$$$$$$$7 from "./apps/verified-reviews.ts";
 import * as $$$$$$$$$$$8 from "./apps/algolia.ts";
 import * as $$$$$$$$$$$9 from "./apps/nuvemshop.ts";
-import * as $$$$$$$$$$$10 from "./apps/linx.ts";
-import * as $$$$$$$$$$$11 from "./apps/vtex.ts";
-import * as $$$$$$$$$$$12 from "./apps/weather.ts";
-import * as $$$$$$$$$$$13 from "./apps/brand-assistant.ts";
-import * as $$$$$$$$$$$14 from "./apps/sourei.ts";
-import * as $$$$$$$$$$$15 from "./apps/shopify.ts";
-import * as $$$$$$$$$$$16 from "./apps/handlebars.ts";
-import * as $$$$$$$$$$$17 from "./apps/verified-reviews.ts";
+import * as $$$$$$$$$$$10 from "./apps/brand-assistant.ts";
+import * as $$$$$$$$$$$11 from "./apps/typesense.ts";
+import * as $$$$$$$$$$$12 from "./apps/analytics.ts";
+import * as $$$$$$$$$$$13 from "./apps/vnda.ts";
+import * as $$$$$$$$$$$14 from "./apps/implementation.ts";
+import * as $$$$$$$$$$$15 from "./apps/weather.ts";
+import * as $$$$$$$$$$$16 from "./apps/sourei.ts";
+import * as $$$$$$$$$$$17 from "./apps/handlebars.ts";
 import * as $$$$$$$$$$$18 from "./apps/power-reviews.ts";
 
 const manifest = {
   "apps": {
-    "decohub/apps/ai-assistants.ts": $$$$$$$$$$$3,
+    "decohub/apps/ai-assistants.ts": $$$$$$$$$$$6,
     "decohub/apps/algolia.ts": $$$$$$$$$$$8,
-    "decohub/apps/analytics.ts": $$$$$$$$$$$4,
-    "decohub/apps/brand-assistant.ts": $$$$$$$$$$$13,
-    "decohub/apps/crux.ts": $$$$$$$$$$$2,
-    "decohub/apps/handlebars.ts": $$$$$$$$$$$16,
-    "decohub/apps/implementation.ts": $$$$$$$$$$$6,
-    "decohub/apps/linx.ts": $$$$$$$$$$$10,
+    "decohub/apps/analytics.ts": $$$$$$$$$$$12,
+    "decohub/apps/brand-assistant.ts": $$$$$$$$$$$10,
+    "decohub/apps/crux.ts": $$$$$$$$$$$0,
+    "decohub/apps/handlebars.ts": $$$$$$$$$$$17,
+    "decohub/apps/implementation.ts": $$$$$$$$$$$14,
+    "decohub/apps/linx.ts": $$$$$$$$$$$5,
     "decohub/apps/nuvemshop.ts": $$$$$$$$$$$9,
     "decohub/apps/power-reviews.ts": $$$$$$$$$$$18,
-    "decohub/apps/shopify.ts": $$$$$$$$$$$15,
-    "decohub/apps/sourei.ts": $$$$$$$$$$$14,
-    "decohub/apps/typesense.ts": $$$$$$$$$$$0,
-    "decohub/apps/verified-reviews.ts": $$$$$$$$$$$17,
-    "decohub/apps/vnda.ts": $$$$$$$$$$$7,
-    "decohub/apps/vtex.ts": $$$$$$$$$$$11,
-    "decohub/apps/wake.ts": $$$$$$$$$$$1,
-    "decohub/apps/weather.ts": $$$$$$$$$$$12,
-    "decohub/apps/workflows.ts": $$$$$$$$$$$5,
+    "decohub/apps/shopify.ts": $$$$$$$$$$$3,
+    "decohub/apps/sourei.ts": $$$$$$$$$$$16,
+    "decohub/apps/typesense.ts": $$$$$$$$$$$11,
+    "decohub/apps/verified-reviews.ts": $$$$$$$$$$$7,
+    "decohub/apps/vnda.ts": $$$$$$$$$$$13,
+    "decohub/apps/vtex.ts": $$$$$$$$$$$1,
+    "decohub/apps/wake.ts": $$$$$$$$$$$2,
+    "decohub/apps/weather.ts": $$$$$$$$$$$15,
+    "decohub/apps/workflows.ts": $$$$$$$$$$$4,
   },
   "name": "decohub",
   "baseUrl": import.meta.url,

--- a/linx/manifest.gen.ts
+++ b/linx/manifest.gen.ts
@@ -2,33 +2,33 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/path.ts";
-import * as $$$1 from "./loaders/pages.ts";
-import * as $$$2 from "./loaders/product/listingPage.ts";
-import * as $$$3 from "./loaders/product/detailsPage.ts";
-import * as $$$4 from "./loaders/product/list.ts";
-import * as $$$5 from "./loaders/product/suggestions.ts";
-import * as $$$6 from "./loaders/page.ts";
-import * as $$$7 from "./loaders/cart.ts";
-import * as $$$$$$$$$0 from "./actions/cart/updateItem.ts";
+import * as $$$0 from "./loaders/product/detailsPage.ts";
+import * as $$$1 from "./loaders/product/listingPage.ts";
+import * as $$$2 from "./loaders/product/suggestions.ts";
+import * as $$$3 from "./loaders/product/list.ts";
+import * as $$$4 from "./loaders/path.ts";
+import * as $$$5 from "./loaders/page.ts";
+import * as $$$6 from "./loaders/cart.ts";
+import * as $$$7 from "./loaders/pages.ts";
+import * as $$$$$$$$$0 from "./actions/cart/addItem.ts";
 import * as $$$$$$$$$1 from "./actions/cart/addCoupon.ts";
-import * as $$$$$$$$$2 from "./actions/cart/addItem.ts";
+import * as $$$$$$$$$2 from "./actions/cart/updateItem.ts";
 
 const manifest = {
   "loaders": {
-    "linx/loaders/cart.ts": $$$7,
-    "linx/loaders/page.ts": $$$6,
-    "linx/loaders/pages.ts": $$$1,
-    "linx/loaders/path.ts": $$$0,
-    "linx/loaders/product/detailsPage.ts": $$$3,
-    "linx/loaders/product/list.ts": $$$4,
-    "linx/loaders/product/listingPage.ts": $$$2,
-    "linx/loaders/product/suggestions.ts": $$$5,
+    "linx/loaders/cart.ts": $$$6,
+    "linx/loaders/page.ts": $$$5,
+    "linx/loaders/pages.ts": $$$7,
+    "linx/loaders/path.ts": $$$4,
+    "linx/loaders/product/detailsPage.ts": $$$0,
+    "linx/loaders/product/list.ts": $$$3,
+    "linx/loaders/product/listingPage.ts": $$$1,
+    "linx/loaders/product/suggestions.ts": $$$2,
   },
   "actions": {
     "linx/actions/cart/addCoupon.ts": $$$$$$$$$1,
-    "linx/actions/cart/addItem.ts": $$$$$$$$$2,
-    "linx/actions/cart/updateItem.ts": $$$$$$$$$0,
+    "linx/actions/cart/addItem.ts": $$$$$$$$$0,
+    "linx/actions/cart/updateItem.ts": $$$$$$$$$2,
   },
   "name": "linx",
   "baseUrl": import.meta.url,

--- a/linx/utils/transform.ts
+++ b/linx/utils/transform.ts
@@ -143,6 +143,7 @@ export const toProduct = (
 
   const toImage = (url: string) => ({
     "@type": "ImageObject" as const,
+    encodingFormat: "image",
     alternateName: product.Name,
     url: new URL(url, cdn).href,
   });

--- a/nuvemshop/manifest.gen.ts
+++ b/nuvemshop/manifest.gen.ts
@@ -2,21 +2,21 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/productList.ts";
-import * as $$$1 from "./loaders/productDetailsPage.ts";
-import * as $$$2 from "./loaders/productListingPage.ts";
+import * as $$$0 from "./loaders/productDetailsPage.ts";
+import * as $$$1 from "./loaders/productList.ts";
+import * as $$$2 from "./loaders/cart.ts";
 import * as $$$3 from "./loaders/proxy.ts";
-import * as $$$4 from "./loaders/cart.ts";
+import * as $$$4 from "./loaders/productListingPage.ts";
 import * as $$$$0 from "./handlers/sitemap.ts";
 import * as $$$$$$$$$0 from "./actions/cart/updateItems.ts";
 import * as $$$$$$$$$1 from "./actions/cart/addItems.ts";
 
 const manifest = {
   "loaders": {
-    "nuvemshop/loaders/cart.ts": $$$4,
-    "nuvemshop/loaders/productDetailsPage.ts": $$$1,
-    "nuvemshop/loaders/productList.ts": $$$0,
-    "nuvemshop/loaders/productListingPage.ts": $$$2,
+    "nuvemshop/loaders/cart.ts": $$$2,
+    "nuvemshop/loaders/productDetailsPage.ts": $$$0,
+    "nuvemshop/loaders/productList.ts": $$$1,
+    "nuvemshop/loaders/productListingPage.ts": $$$4,
     "nuvemshop/loaders/proxy.ts": $$$3,
   },
   "handlers": {

--- a/nuvemshop/utils/transform.ts
+++ b/nuvemshop/utils/transform.ts
@@ -75,6 +75,7 @@ function productVariantToProduct(
     ),
     image: images.map((image: ProductImage) => ({
       "@type": "ImageObject",
+      encodingFormat: "image",
       url: image.src,
     })),
     category: getPreferredLanguage(categories[0]?.name || ""), // Assuming there's only one category

--- a/platforms/kubernetes/manifest.gen.ts
+++ b/platforms/kubernetes/manifest.gen.ts
@@ -3,30 +3,30 @@
 // This file is automatically updated during development when running `dev.ts`.
 
 import * as $$$0 from "./loaders/siteState/get.ts";
-import * as $$$$$$$$$0 from "./actions/domains/create.ts";
-import * as $$$$$$$$$1 from "./actions/domains/delete.ts";
-import * as $$$$$$$$$2 from "./actions/sites/create.ts";
-import * as $$$$$$$$$3 from "./actions/sites/delete.ts";
-import * as $$$$$$$$$4 from "./actions/siteState/upsert.ts";
-import * as $$$$$$$$$5 from "./actions/deployments/rollout.ts";
-import * as $$$$$$$$$6 from "./actions/deployments/promote.ts";
-import * as $$$$$$$$$7 from "./actions/deployments/create.ts";
-import * as $$$$$$$$$8 from "./actions/build.ts";
+import * as $$$$$$$$$0 from "./actions/deployments/create.ts";
+import * as $$$$$$$$$1 from "./actions/deployments/promote.ts";
+import * as $$$$$$$$$2 from "./actions/deployments/rollout.ts";
+import * as $$$$$$$$$3 from "./actions/domains/create.ts";
+import * as $$$$$$$$$4 from "./actions/domains/delete.ts";
+import * as $$$$$$$$$5 from "./actions/build.ts";
+import * as $$$$$$$$$6 from "./actions/sites/create.ts";
+import * as $$$$$$$$$7 from "./actions/sites/delete.ts";
+import * as $$$$$$$$$8 from "./actions/siteState/upsert.ts";
 
 const manifest = {
   "loaders": {
     "kubernetes/loaders/siteState/get.ts": $$$0,
   },
   "actions": {
-    "kubernetes/actions/build.ts": $$$$$$$$$8,
-    "kubernetes/actions/deployments/create.ts": $$$$$$$$$7,
-    "kubernetes/actions/deployments/promote.ts": $$$$$$$$$6,
-    "kubernetes/actions/deployments/rollout.ts": $$$$$$$$$5,
-    "kubernetes/actions/domains/create.ts": $$$$$$$$$0,
-    "kubernetes/actions/domains/delete.ts": $$$$$$$$$1,
-    "kubernetes/actions/sites/create.ts": $$$$$$$$$2,
-    "kubernetes/actions/sites/delete.ts": $$$$$$$$$3,
-    "kubernetes/actions/siteState/upsert.ts": $$$$$$$$$4,
+    "kubernetes/actions/build.ts": $$$$$$$$$5,
+    "kubernetes/actions/deployments/create.ts": $$$$$$$$$0,
+    "kubernetes/actions/deployments/promote.ts": $$$$$$$$$1,
+    "kubernetes/actions/deployments/rollout.ts": $$$$$$$$$2,
+    "kubernetes/actions/domains/create.ts": $$$$$$$$$3,
+    "kubernetes/actions/domains/delete.ts": $$$$$$$$$4,
+    "kubernetes/actions/sites/create.ts": $$$$$$$$$6,
+    "kubernetes/actions/sites/delete.ts": $$$$$$$$$7,
+    "kubernetes/actions/siteState/upsert.ts": $$$$$$$$$8,
   },
   "name": "kubernetes",
   "baseUrl": import.meta.url,

--- a/power-reviews/manifest.gen.ts
+++ b/power-reviews/manifest.gen.ts
@@ -2,8 +2,8 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/productList.ts";
-import * as $$$1 from "./loaders/productDetailsPage.ts";
+import * as $$$0 from "./loaders/productDetailsPage.ts";
+import * as $$$1 from "./loaders/productList.ts";
 import * as $$$2 from "./loaders/reviewForm.ts";
 import * as $$$3 from "./loaders/review.ts";
 import * as $$$4 from "./loaders/productListingPage.ts";
@@ -13,8 +13,8 @@ import * as $$$$$$$$$0 from "./actions/submitReview.ts";
 
 const manifest = {
   "loaders": {
-    "power-reviews/loaders/productDetailsPage.ts": $$$1,
-    "power-reviews/loaders/productList.ts": $$$0,
+    "power-reviews/loaders/productDetailsPage.ts": $$$0,
+    "power-reviews/loaders/productList.ts": $$$1,
     "power-reviews/loaders/productListingPage.ts": $$$4,
     "power-reviews/loaders/review.ts": $$$3,
     "power-reviews/loaders/reviewForm.ts": $$$2,

--- a/shopify/manifest.gen.ts
+++ b/shopify/manifest.gen.ts
@@ -2,34 +2,34 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/ProductList.ts";
-import * as $$$1 from "./loaders/RelatedProducts.ts";
-import * as $$$2 from "./loaders/ProductDetailsPage.ts";
-import * as $$$3 from "./loaders/ProductListingPage.ts";
+import * as $$$0 from "./loaders/ProductListingPage.ts";
+import * as $$$1 from "./loaders/ProductDetailsPage.ts";
+import * as $$$2 from "./loaders/RelatedProducts.ts";
+import * as $$$3 from "./loaders/cart.ts";
 import * as $$$4 from "./loaders/proxy.ts";
-import * as $$$5 from "./loaders/cart.ts";
+import * as $$$5 from "./loaders/ProductList.ts";
 import * as $$$$0 from "./handlers/sitemap.ts";
 import * as $$$$$$$$$0 from "./actions/order/draftOrderCalculate.ts";
-import * as $$$$$$$$$1 from "./actions/cart/updateCoupons.ts";
-import * as $$$$$$$$$2 from "./actions/cart/updateItems.ts";
+import * as $$$$$$$$$1 from "./actions/cart/updateItems.ts";
+import * as $$$$$$$$$2 from "./actions/cart/updateCoupons.ts";
 import * as $$$$$$$$$3 from "./actions/cart/addItems.ts";
 
 const manifest = {
   "loaders": {
-    "shopify/loaders/cart.ts": $$$5,
-    "shopify/loaders/ProductDetailsPage.ts": $$$2,
-    "shopify/loaders/ProductList.ts": $$$0,
-    "shopify/loaders/ProductListingPage.ts": $$$3,
+    "shopify/loaders/cart.ts": $$$3,
+    "shopify/loaders/ProductDetailsPage.ts": $$$1,
+    "shopify/loaders/ProductList.ts": $$$5,
+    "shopify/loaders/ProductListingPage.ts": $$$0,
     "shopify/loaders/proxy.ts": $$$4,
-    "shopify/loaders/RelatedProducts.ts": $$$1,
+    "shopify/loaders/RelatedProducts.ts": $$$2,
   },
   "handlers": {
     "shopify/handlers/sitemap.ts": $$$$0,
   },
   "actions": {
     "shopify/actions/cart/addItems.ts": $$$$$$$$$3,
-    "shopify/actions/cart/updateCoupons.ts": $$$$$$$$$1,
-    "shopify/actions/cart/updateItems.ts": $$$$$$$$$2,
+    "shopify/actions/cart/updateCoupons.ts": $$$$$$$$$2,
+    "shopify/actions/cart/updateItems.ts": $$$$$$$$$1,
     "shopify/actions/order/draftOrderCalculate.ts": $$$$$$$$$0,
   },
   "name": "shopify",

--- a/shopify/utils/transform.ts
+++ b/shopify/utils/transform.ts
@@ -157,12 +157,14 @@ export const toProduct = (
       ],
       image: nonEmptyArray(images.nodes)?.map((img) => ({
         "@type": "ImageObject",
+        encodingFormat: "image",
         alternateName: img.altText ?? "",
         url: img.url,
       })),
     },
     image: skuImages?.map((img) => ({
       "@type": "ImageObject",
+      encodingFormat: "image",
       alternateName: img?.altText ?? "",
       url: img?.url,
     })) ?? [DEFAULT_IMAGE],

--- a/verified-reviews/manifest.gen.ts
+++ b/verified-reviews/manifest.gen.ts
@@ -2,13 +2,13 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/productList.ts";
-import * as $$$1 from "./loaders/productDetailsPage.ts";
+import * as $$$0 from "./loaders/productDetailsPage.ts";
+import * as $$$1 from "./loaders/productList.ts";
 
 const manifest = {
   "loaders": {
-    "verified-reviews/loaders/productDetailsPage.ts": $$$1,
-    "verified-reviews/loaders/productList.ts": $$$0,
+    "verified-reviews/loaders/productDetailsPage.ts": $$$0,
+    "verified-reviews/loaders/productList.ts": $$$1,
   },
   "name": "verified-reviews",
   "baseUrl": import.meta.url,

--- a/vnda/loaders/productDetailsPageVideo.ts
+++ b/vnda/loaders/productDetailsPageVideo.ts
@@ -1,0 +1,28 @@
+import { AppContext } from "../mod.ts";
+import { ExtensionOf } from "../../website/loaders/extension.ts";
+import { ProductDetailsPage } from "../../commerce/types.ts";
+import { addVideoToProduct } from "../utils/transform.ts";
+import { STALE } from "../../utils/fetch.ts";
+
+export default function productDetailsPageVideo(
+  _props: unknown,
+  _req: Request,
+  ctx: AppContext,
+): ExtensionOf<ProductDetailsPage | null> {
+  const { api } = ctx;
+  return async (productDetailsPage: ProductDetailsPage | null) => {
+    if (!productDetailsPage) {
+      return null;
+    }
+    const { product } = productDetailsPage;
+    const { inProductGroupWithID } = product;
+    const videos = await api["GET /api/v2/products/:productId/videos"]({
+      productId: inProductGroupWithID as string,
+    }, STALE).then((r) => r.json()).catch(() => null);
+    const productWithVideo = addVideoToProduct(product, videos);
+    return {
+      ...productDetailsPage,
+      product: productWithVideo,
+    };
+  };
+}

--- a/vnda/manifest.gen.ts
+++ b/vnda/manifest.gen.ts
@@ -2,29 +2,29 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/productList.ts";
-import * as $$$1 from "./loaders/productDetailsPage.ts";
-import * as $$$2 from "./loaders/productListingPage.ts";
+import * as $$$0 from "./loaders/productDetailsPage.ts";
+import * as $$$1 from "./loaders/productList.ts";
+import * as $$$2 from "./loaders/cart.ts";
 import * as $$$3 from "./loaders/proxy.ts";
-import * as $$$4 from "./loaders/cart.ts";
-import * as $$$$$$$$$0 from "./actions/cart/updateItem.ts";
+import * as $$$4 from "./loaders/productListingPage.ts";
+import * as $$$$$$$$$0 from "./actions/cart/addItem.ts";
 import * as $$$$$$$$$1 from "./actions/cart/updateCart.ts";
-import * as $$$$$$$$$2 from "./actions/cart/addItem.ts";
+import * as $$$$$$$$$2 from "./actions/cart/updateItem.ts";
 import * as $$$$$$$$$3 from "./actions/cart/simulation.ts";
 
 const manifest = {
   "loaders": {
-    "vnda/loaders/cart.ts": $$$4,
-    "vnda/loaders/productDetailsPage.ts": $$$1,
-    "vnda/loaders/productList.ts": $$$0,
-    "vnda/loaders/productListingPage.ts": $$$2,
+    "vnda/loaders/cart.ts": $$$2,
+    "vnda/loaders/productDetailsPage.ts": $$$0,
+    "vnda/loaders/productList.ts": $$$1,
+    "vnda/loaders/productListingPage.ts": $$$4,
     "vnda/loaders/proxy.ts": $$$3,
   },
   "actions": {
-    "vnda/actions/cart/addItem.ts": $$$$$$$$$2,
+    "vnda/actions/cart/addItem.ts": $$$$$$$$$0,
     "vnda/actions/cart/simulation.ts": $$$$$$$$$3,
     "vnda/actions/cart/updateCart.ts": $$$$$$$$$1,
-    "vnda/actions/cart/updateItem.ts": $$$$$$$$$0,
+    "vnda/actions/cart/updateItem.ts": $$$$$$$$$2,
   },
   "name": "vnda",
   "baseUrl": import.meta.url,

--- a/vnda/manifest.gen.ts
+++ b/vnda/manifest.gen.ts
@@ -2,11 +2,12 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/productDetailsPage.ts";
-import * as $$$1 from "./loaders/productList.ts";
-import * as $$$2 from "./loaders/cart.ts";
-import * as $$$3 from "./loaders/proxy.ts";
-import * as $$$4 from "./loaders/productListingPage.ts";
+import * as $$$0 from "./loaders/productDetailsPageVideo.ts";
+import * as $$$1 from "./loaders/productDetailsPage.ts";
+import * as $$$2 from "./loaders/productList.ts";
+import * as $$$3 from "./loaders/cart.ts";
+import * as $$$4 from "./loaders/proxy.ts";
+import * as $$$5 from "./loaders/productListingPage.ts";
 import * as $$$$$$$$$0 from "./actions/cart/addItem.ts";
 import * as $$$$$$$$$1 from "./actions/cart/updateCart.ts";
 import * as $$$$$$$$$2 from "./actions/cart/updateItem.ts";
@@ -14,11 +15,12 @@ import * as $$$$$$$$$3 from "./actions/cart/simulation.ts";
 
 const manifest = {
   "loaders": {
-    "vnda/loaders/cart.ts": $$$2,
-    "vnda/loaders/productDetailsPage.ts": $$$0,
-    "vnda/loaders/productList.ts": $$$1,
-    "vnda/loaders/productListingPage.ts": $$$4,
-    "vnda/loaders/proxy.ts": $$$3,
+    "vnda/loaders/cart.ts": $$$3,
+    "vnda/loaders/productDetailsPage.ts": $$$1,
+    "vnda/loaders/productDetailsPageVideo.ts": $$$0,
+    "vnda/loaders/productList.ts": $$$2,
+    "vnda/loaders/productListingPage.ts": $$$5,
+    "vnda/loaders/proxy.ts": $$$4,
   },
   "actions": {
     "vnda/actions/cart/addItem.ts": $$$$$$$$$0,

--- a/vnda/utils/openapi/vnda.openapi.gen.ts
+++ b/vnda/utils/openapi/vnda.openapi.gen.ts
@@ -9,6 +9,16 @@
 
 
 export interface OpenAPI {
+"GET /api/v2/products/:productId/videos": {
+response: {
+id?: number
+url?: string
+embed_url?: string
+thumbnail_url?: string
+updated_at?: number
+variant_ids?: number
+}[]
+}
 "GET /api/v2/seo_data": {
 searchParams: {
 resource_type?: string

--- a/vnda/utils/openapi/vnda.openapi.json
+++ b/vnda/utils/openapi/vnda.openapi.json
@@ -24,6 +24,55 @@
     }
   ],
   "paths": {
+    "/api/v2/products/{product_id}/videos": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "product_id",
+          "in": "path",
+          "required": true
+        }
+      ],
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Retorna os videos do produto",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer"
+                      },
+                      "url": {
+                        "type": "string"
+                      },
+                      "embed_url": {
+                        "type": "string"
+                      },
+                      "thumbnail_url": {
+                        "type": "string"
+                      },
+                      "updated_at": {
+                        "type": "integer"
+                      },
+                      "variant_ids": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/seo_data": {
       "get": {
         "responses": {

--- a/vnda/utils/transform.ts
+++ b/vnda/utils/transform.ts
@@ -1,5 +1,6 @@
 import {
   Filter,
+  ImageObject,
   Offer,
   Product,
   PropertyValue,
@@ -211,6 +212,17 @@ const normalizeVariants = (
   variants.flatMap((v) =>
     isProductVariant(v) ? [v] : Object.values(v) as VNDAProduct[]
   );
+
+const toImageObjectVideo = (
+  video: OpenAPI["GET /api/v2/products/:productId/videos"]["response"],
+): ImageObject[] =>
+  video?.map(({ url, embed_url, thumbnail_url }) => ({
+    "@type": "ImageObject",
+    encodingFormat: "video",
+    contentUrl: url,
+    thumbnailUrl: thumbnail_url,
+    embedUrl: embed_url,
+  } as ImageObject));
 
 export const toProduct = (
   product: VNDAProductGroup,
@@ -427,3 +439,14 @@ export const typeTagExtractor = (url: URL, tags: { type?: string }[]) => {
     cleanUrl,
   };
 };
+
+export const addVideoToProduct = (
+  product: Product,
+  video: OpenAPI["GET /api/v2/products/:productId/videos"]["response"] | null,
+): Product => ({
+  ...product,
+  image: [
+    ...(product?.image ?? []),
+    ...(video ? toImageObjectVideo(video) : []),
+  ],
+});

--- a/vnda/utils/transform.ts
+++ b/vnda/utils/transform.ts
@@ -267,12 +267,14 @@ export const toProduct = (
     image: product.images?.length ?? 0 > 1
       ? product.images?.map((img) => ({
         "@type": "ImageObject" as const,
+        encodingFormat: "image",
         alternateName: `${img.url}`,
         url: toURL(img.url!),
       }))
       : [
         {
           "@type": "ImageObject",
+          encodingFormat: "image",
           alternateName: product.name ?? "",
           url: toURL(product.image_url ?? ""),
         },

--- a/vtex/loaders/workflow/product.ts
+++ b/vtex/loaders/workflow/product.ts
@@ -164,6 +164,7 @@ const loader = async (
     gtin: sku.AlternateIds.Ean,
     image: sku.Images.map((img) => ({
       "@type": "ImageObject",
+      encodingFormat: "image",
       alternateName: img.ImageName ?? img.FileId,
       url: img.ImageUrl,
     })),

--- a/vtex/manifest.gen.ts
+++ b/vtex/manifest.gen.ts
@@ -2,109 +2,109 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/paths/PLPDefaultPath.ts";
-import * as $$$1 from "./loaders/paths/PDPDefaultPath.ts";
-import * as $$$2 from "./loaders/legacy/productList.ts";
-import * as $$$3 from "./loaders/legacy/productDetailsPage.ts";
-import * as $$$4 from "./loaders/legacy/productListingPage.ts";
-import * as $$$5 from "./loaders/legacy/relatedProductsLoader.ts";
-import * as $$$6 from "./loaders/legacy/suggestions.ts";
-import * as $$$7 from "./loaders/product/extensions/listingPage.ts";
-import * as $$$8 from "./loaders/product/extensions/detailsPage.ts";
-import * as $$$9 from "./loaders/product/extensions/list.ts";
-import * as $$$10 from "./loaders/product/extensions/suggestions.ts";
-import * as $$$11 from "./loaders/product/wishlist.ts";
-import * as $$$12 from "./loaders/product/extend.ts";
-import * as $$$13 from "./loaders/wishlist.ts";
-import * as $$$14 from "./loaders/navbar.ts";
-import * as $$$15 from "./loaders/workflow/product.ts";
-import * as $$$16 from "./loaders/workflow/products.ts";
-import * as $$$17 from "./loaders/proxy.ts";
-import * as $$$18 from "./loaders/intelligentSearch/productList.ts";
-import * as $$$19 from "./loaders/intelligentSearch/productDetailsPage.ts";
-import * as $$$20 from "./loaders/intelligentSearch/topsearches.ts";
-import * as $$$21 from "./loaders/intelligentSearch/productListingPage.ts";
+import * as $$$0 from "./loaders/product/extensions/detailsPage.ts";
+import * as $$$1 from "./loaders/product/extensions/listingPage.ts";
+import * as $$$2 from "./loaders/product/extensions/suggestions.ts";
+import * as $$$3 from "./loaders/product/extensions/list.ts";
+import * as $$$4 from "./loaders/product/extend.ts";
+import * as $$$5 from "./loaders/product/wishlist.ts";
+import * as $$$6 from "./loaders/legacy/relatedProductsLoader.ts";
+import * as $$$7 from "./loaders/legacy/productDetailsPage.ts";
+import * as $$$8 from "./loaders/legacy/productList.ts";
+import * as $$$9 from "./loaders/legacy/suggestions.ts";
+import * as $$$10 from "./loaders/legacy/productListingPage.ts";
+import * as $$$11 from "./loaders/paths/PLPDefaultPath.ts";
+import * as $$$12 from "./loaders/paths/PDPDefaultPath.ts";
+import * as $$$13 from "./loaders/navbar.ts";
+import * as $$$14 from "./loaders/workflow/product.ts";
+import * as $$$15 from "./loaders/workflow/products.ts";
+import * as $$$16 from "./loaders/wishlist.ts";
+import * as $$$17 from "./loaders/categories/tree.ts";
+import * as $$$18 from "./loaders/cart.ts";
+import * as $$$19 from "./loaders/proxy.ts";
+import * as $$$20 from "./loaders/intelligentSearch/productDetailsPage.ts";
+import * as $$$21 from "./loaders/intelligentSearch/productList.ts";
 import * as $$$22 from "./loaders/intelligentSearch/suggestions.ts";
-import * as $$$23 from "./loaders/cart.ts";
-import * as $$$24 from "./loaders/categories/tree.ts";
+import * as $$$23 from "./loaders/intelligentSearch/productListingPage.ts";
+import * as $$$24 from "./loaders/intelligentSearch/topsearches.ts";
 import * as $$$25 from "./loaders/user.ts";
 import * as $$$$0 from "./handlers/sitemap.ts";
 import * as $$$$$$$$$0 from "./actions/trigger.ts";
 import * as $$$$$$$$$1 from "./actions/notifyme.ts";
-import * as $$$$$$$$$2 from "./actions/cart/updateCoupons.ts";
-import * as $$$$$$$$$3 from "./actions/cart/updateAttachment.ts";
-import * as $$$$$$$$$4 from "./actions/cart/updateItems.ts";
-import * as $$$$$$$$$5 from "./actions/cart/updateGifts.ts";
-import * as $$$$$$$$$6 from "./actions/cart/updateItemAttachment.ts";
-import * as $$$$$$$$$7 from "./actions/cart/updateUser.ts";
-import * as $$$$$$$$$8 from "./actions/cart/addItems.ts";
-import * as $$$$$$$$$9 from "./actions/cart/removeItems.ts";
-import * as $$$$$$$$$10 from "./actions/cart/getInstallment.ts";
-import * as $$$$$$$$$11 from "./actions/cart/updateItemPrice.ts";
-import * as $$$$$$$$$12 from "./actions/cart/updateProfile.ts";
-import * as $$$$$$$$$13 from "./actions/cart/simulation.ts";
-import * as $$$$$$$$$14 from "./actions/cart/removeItemAttachment.ts";
-import * as $$$$$$$$$15 from "./actions/masterdata/createDocument.ts";
-import * as $$$$$$$$$16 from "./actions/newsletter/subscribe.ts";
-import * as $$$$$$$$$17 from "./actions/wishlist/removeItem.ts";
-import * as $$$$$$$$$18 from "./actions/wishlist/addItem.ts";
-import * as $$$$$$$$$19 from "./actions/analytics/sendEvent.ts";
+import * as $$$$$$$$$2 from "./actions/masterdata/createDocument.ts";
+import * as $$$$$$$$$3 from "./actions/wishlist/addItem.ts";
+import * as $$$$$$$$$4 from "./actions/wishlist/removeItem.ts";
+import * as $$$$$$$$$5 from "./actions/analytics/sendEvent.ts";
+import * as $$$$$$$$$6 from "./actions/cart/updateItems.ts";
+import * as $$$$$$$$$7 from "./actions/cart/getInstallment.ts";
+import * as $$$$$$$$$8 from "./actions/cart/updateItemAttachment.ts";
+import * as $$$$$$$$$9 from "./actions/cart/updateCoupons.ts";
+import * as $$$$$$$$$10 from "./actions/cart/updateProfile.ts";
+import * as $$$$$$$$$11 from "./actions/cart/removeItemAttachment.ts";
+import * as $$$$$$$$$12 from "./actions/cart/updateUser.ts";
+import * as $$$$$$$$$13 from "./actions/cart/addItems.ts";
+import * as $$$$$$$$$14 from "./actions/cart/updateGifts.ts";
+import * as $$$$$$$$$15 from "./actions/cart/removeItems.ts";
+import * as $$$$$$$$$16 from "./actions/cart/updateItemPrice.ts";
+import * as $$$$$$$$$17 from "./actions/cart/updateAttachment.ts";
+import * as $$$$$$$$$18 from "./actions/cart/simulation.ts";
+import * as $$$$$$$$$19 from "./actions/newsletter/subscribe.ts";
 import * as $$$$$$$$$$0 from "./workflows/product/index.ts";
 import * as $$$$$$$$$$1 from "./workflows/events.ts";
 
 const manifest = {
   "loaders": {
-    "vtex/loaders/cart.ts": $$$23,
-    "vtex/loaders/categories/tree.ts": $$$24,
-    "vtex/loaders/intelligentSearch/productDetailsPage.ts": $$$19,
-    "vtex/loaders/intelligentSearch/productList.ts": $$$18,
-    "vtex/loaders/intelligentSearch/productListingPage.ts": $$$21,
+    "vtex/loaders/cart.ts": $$$18,
+    "vtex/loaders/categories/tree.ts": $$$17,
+    "vtex/loaders/intelligentSearch/productDetailsPage.ts": $$$20,
+    "vtex/loaders/intelligentSearch/productList.ts": $$$21,
+    "vtex/loaders/intelligentSearch/productListingPage.ts": $$$23,
     "vtex/loaders/intelligentSearch/suggestions.ts": $$$22,
-    "vtex/loaders/intelligentSearch/topsearches.ts": $$$20,
-    "vtex/loaders/legacy/productDetailsPage.ts": $$$3,
-    "vtex/loaders/legacy/productList.ts": $$$2,
-    "vtex/loaders/legacy/productListingPage.ts": $$$4,
-    "vtex/loaders/legacy/relatedProductsLoader.ts": $$$5,
-    "vtex/loaders/legacy/suggestions.ts": $$$6,
-    "vtex/loaders/navbar.ts": $$$14,
-    "vtex/loaders/paths/PDPDefaultPath.ts": $$$1,
-    "vtex/loaders/paths/PLPDefaultPath.ts": $$$0,
-    "vtex/loaders/product/extend.ts": $$$12,
-    "vtex/loaders/product/extensions/detailsPage.ts": $$$8,
-    "vtex/loaders/product/extensions/list.ts": $$$9,
-    "vtex/loaders/product/extensions/listingPage.ts": $$$7,
-    "vtex/loaders/product/extensions/suggestions.ts": $$$10,
-    "vtex/loaders/product/wishlist.ts": $$$11,
-    "vtex/loaders/proxy.ts": $$$17,
+    "vtex/loaders/intelligentSearch/topsearches.ts": $$$24,
+    "vtex/loaders/legacy/productDetailsPage.ts": $$$7,
+    "vtex/loaders/legacy/productList.ts": $$$8,
+    "vtex/loaders/legacy/productListingPage.ts": $$$10,
+    "vtex/loaders/legacy/relatedProductsLoader.ts": $$$6,
+    "vtex/loaders/legacy/suggestions.ts": $$$9,
+    "vtex/loaders/navbar.ts": $$$13,
+    "vtex/loaders/paths/PDPDefaultPath.ts": $$$12,
+    "vtex/loaders/paths/PLPDefaultPath.ts": $$$11,
+    "vtex/loaders/product/extend.ts": $$$4,
+    "vtex/loaders/product/extensions/detailsPage.ts": $$$0,
+    "vtex/loaders/product/extensions/list.ts": $$$3,
+    "vtex/loaders/product/extensions/listingPage.ts": $$$1,
+    "vtex/loaders/product/extensions/suggestions.ts": $$$2,
+    "vtex/loaders/product/wishlist.ts": $$$5,
+    "vtex/loaders/proxy.ts": $$$19,
     "vtex/loaders/user.ts": $$$25,
-    "vtex/loaders/wishlist.ts": $$$13,
-    "vtex/loaders/workflow/product.ts": $$$15,
-    "vtex/loaders/workflow/products.ts": $$$16,
+    "vtex/loaders/wishlist.ts": $$$16,
+    "vtex/loaders/workflow/product.ts": $$$14,
+    "vtex/loaders/workflow/products.ts": $$$15,
   },
   "handlers": {
     "vtex/handlers/sitemap.ts": $$$$0,
   },
   "actions": {
-    "vtex/actions/analytics/sendEvent.ts": $$$$$$$$$19,
-    "vtex/actions/cart/addItems.ts": $$$$$$$$$8,
-    "vtex/actions/cart/getInstallment.ts": $$$$$$$$$10,
-    "vtex/actions/cart/removeItemAttachment.ts": $$$$$$$$$14,
-    "vtex/actions/cart/removeItems.ts": $$$$$$$$$9,
-    "vtex/actions/cart/simulation.ts": $$$$$$$$$13,
-    "vtex/actions/cart/updateAttachment.ts": $$$$$$$$$3,
-    "vtex/actions/cart/updateCoupons.ts": $$$$$$$$$2,
-    "vtex/actions/cart/updateGifts.ts": $$$$$$$$$5,
-    "vtex/actions/cart/updateItemAttachment.ts": $$$$$$$$$6,
-    "vtex/actions/cart/updateItemPrice.ts": $$$$$$$$$11,
-    "vtex/actions/cart/updateItems.ts": $$$$$$$$$4,
-    "vtex/actions/cart/updateProfile.ts": $$$$$$$$$12,
-    "vtex/actions/cart/updateUser.ts": $$$$$$$$$7,
-    "vtex/actions/masterdata/createDocument.ts": $$$$$$$$$15,
-    "vtex/actions/newsletter/subscribe.ts": $$$$$$$$$16,
+    "vtex/actions/analytics/sendEvent.ts": $$$$$$$$$5,
+    "vtex/actions/cart/addItems.ts": $$$$$$$$$13,
+    "vtex/actions/cart/getInstallment.ts": $$$$$$$$$7,
+    "vtex/actions/cart/removeItemAttachment.ts": $$$$$$$$$11,
+    "vtex/actions/cart/removeItems.ts": $$$$$$$$$15,
+    "vtex/actions/cart/simulation.ts": $$$$$$$$$18,
+    "vtex/actions/cart/updateAttachment.ts": $$$$$$$$$17,
+    "vtex/actions/cart/updateCoupons.ts": $$$$$$$$$9,
+    "vtex/actions/cart/updateGifts.ts": $$$$$$$$$14,
+    "vtex/actions/cart/updateItemAttachment.ts": $$$$$$$$$8,
+    "vtex/actions/cart/updateItemPrice.ts": $$$$$$$$$16,
+    "vtex/actions/cart/updateItems.ts": $$$$$$$$$6,
+    "vtex/actions/cart/updateProfile.ts": $$$$$$$$$10,
+    "vtex/actions/cart/updateUser.ts": $$$$$$$$$12,
+    "vtex/actions/masterdata/createDocument.ts": $$$$$$$$$2,
+    "vtex/actions/newsletter/subscribe.ts": $$$$$$$$$19,
     "vtex/actions/notifyme.ts": $$$$$$$$$1,
     "vtex/actions/trigger.ts": $$$$$$$$$0,
-    "vtex/actions/wishlist/addItem.ts": $$$$$$$$$18,
-    "vtex/actions/wishlist/removeItem.ts": $$$$$$$$$17,
+    "vtex/actions/wishlist/addItem.ts": $$$$$$$$$3,
+    "vtex/actions/wishlist/removeItem.ts": $$$$$$$$$4,
   },
   "workflows": {
     "vtex/workflows/events.ts": $$$$$$$$$$1,

--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -378,8 +378,15 @@ export const toProduct = <P extends LegacyProductVTEX | ProductVTEX>(
       const url = imagesByKey.get(getImageKey(imageUrl)) ?? imageUrl;
       const alternateName = imageText || imageLabel || "";
       const name = imageLabel || "";
+      const encodingFormat = "image";
 
-      return { "@type": "ImageObject" as const, alternateName, url, name };
+      return {
+        "@type": "ImageObject" as const,
+        alternateName,
+        url,
+        name,
+        encodingFormat,
+      };
     }) ?? [DEFAULT_IMAGE],
     offers: aggregateOffers(offers, priceCurrency),
   };

--- a/wake/manifest.gen.ts
+++ b/wake/manifest.gen.ts
@@ -2,55 +2,55 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/productList.ts";
-import * as $$$1 from "./loaders/shop.ts";
+import * as $$$0 from "./loaders/shop.ts";
+import * as $$$1 from "./loaders/wishlist.ts";
 import * as $$$2 from "./loaders/productDetailsPage.ts";
-import * as $$$3 from "./loaders/wishlist.ts";
-import * as $$$4 from "./loaders/productListingPage.ts";
-import * as $$$5 from "./loaders/recommendations.ts";
+import * as $$$3 from "./loaders/suggestion.ts";
+import * as $$$4 from "./loaders/productList.ts";
+import * as $$$5 from "./loaders/cart.ts";
 import * as $$$6 from "./loaders/proxy.ts";
-import * as $$$7 from "./loaders/suggestion.ts";
-import * as $$$8 from "./loaders/cart.ts";
-import * as $$$9 from "./loaders/user.ts";
-import * as $$$$$$$$$0 from "./actions/submmitForm.ts";
+import * as $$$7 from "./loaders/productListingPage.ts";
+import * as $$$8 from "./loaders/user.ts";
+import * as $$$9 from "./loaders/recommendations.ts";
+import * as $$$$$$$$$0 from "./actions/shippingSimulation.ts";
 import * as $$$$$$$$$1 from "./actions/notifyme.ts";
-import * as $$$$$$$$$2 from "./actions/review/create.ts";
-import * as $$$$$$$$$3 from "./actions/cart/addCoupon.ts";
-import * as $$$$$$$$$4 from "./actions/cart/addItem.ts";
-import * as $$$$$$$$$5 from "./actions/cart/addItems.ts";
-import * as $$$$$$$$$6 from "./actions/cart/updateItemQuantity.ts";
-import * as $$$$$$$$$7 from "./actions/cart/removeCoupon.ts";
-import * as $$$$$$$$$8 from "./actions/newsletter/register.ts";
-import * as $$$$$$$$$9 from "./actions/shippingSimulation.ts";
-import * as $$$$$$$$$10 from "./actions/wishlist/removeProduct.ts";
-import * as $$$$$$$$$11 from "./actions/wishlist/addProduct.ts";
+import * as $$$$$$$$$2 from "./actions/submmitForm.ts";
+import * as $$$$$$$$$3 from "./actions/review/create.ts";
+import * as $$$$$$$$$4 from "./actions/wishlist/addProduct.ts";
+import * as $$$$$$$$$5 from "./actions/wishlist/removeProduct.ts";
+import * as $$$$$$$$$6 from "./actions/cart/addItem.ts";
+import * as $$$$$$$$$7 from "./actions/cart/addCoupon.ts";
+import * as $$$$$$$$$8 from "./actions/cart/updateItemQuantity.ts";
+import * as $$$$$$$$$9 from "./actions/cart/addItems.ts";
+import * as $$$$$$$$$10 from "./actions/cart/removeCoupon.ts";
+import * as $$$$$$$$$11 from "./actions/newsletter/register.ts";
 
 const manifest = {
   "loaders": {
-    "wake/loaders/cart.ts": $$$8,
+    "wake/loaders/cart.ts": $$$5,
     "wake/loaders/productDetailsPage.ts": $$$2,
-    "wake/loaders/productList.ts": $$$0,
-    "wake/loaders/productListingPage.ts": $$$4,
+    "wake/loaders/productList.ts": $$$4,
+    "wake/loaders/productListingPage.ts": $$$7,
     "wake/loaders/proxy.ts": $$$6,
-    "wake/loaders/recommendations.ts": $$$5,
-    "wake/loaders/shop.ts": $$$1,
-    "wake/loaders/suggestion.ts": $$$7,
-    "wake/loaders/user.ts": $$$9,
-    "wake/loaders/wishlist.ts": $$$3,
+    "wake/loaders/recommendations.ts": $$$9,
+    "wake/loaders/shop.ts": $$$0,
+    "wake/loaders/suggestion.ts": $$$3,
+    "wake/loaders/user.ts": $$$8,
+    "wake/loaders/wishlist.ts": $$$1,
   },
   "actions": {
-    "wake/actions/cart/addCoupon.ts": $$$$$$$$$3,
-    "wake/actions/cart/addItem.ts": $$$$$$$$$4,
-    "wake/actions/cart/addItems.ts": $$$$$$$$$5,
-    "wake/actions/cart/removeCoupon.ts": $$$$$$$$$7,
-    "wake/actions/cart/updateItemQuantity.ts": $$$$$$$$$6,
-    "wake/actions/newsletter/register.ts": $$$$$$$$$8,
+    "wake/actions/cart/addCoupon.ts": $$$$$$$$$7,
+    "wake/actions/cart/addItem.ts": $$$$$$$$$6,
+    "wake/actions/cart/addItems.ts": $$$$$$$$$9,
+    "wake/actions/cart/removeCoupon.ts": $$$$$$$$$10,
+    "wake/actions/cart/updateItemQuantity.ts": $$$$$$$$$8,
+    "wake/actions/newsletter/register.ts": $$$$$$$$$11,
     "wake/actions/notifyme.ts": $$$$$$$$$1,
-    "wake/actions/review/create.ts": $$$$$$$$$2,
-    "wake/actions/shippingSimulation.ts": $$$$$$$$$9,
-    "wake/actions/submmitForm.ts": $$$$$$$$$0,
-    "wake/actions/wishlist/addProduct.ts": $$$$$$$$$11,
-    "wake/actions/wishlist/removeProduct.ts": $$$$$$$$$10,
+    "wake/actions/review/create.ts": $$$$$$$$$3,
+    "wake/actions/shippingSimulation.ts": $$$$$$$$$0,
+    "wake/actions/submmitForm.ts": $$$$$$$$$2,
+    "wake/actions/wishlist/addProduct.ts": $$$$$$$$$4,
+    "wake/actions/wishlist/removeProduct.ts": $$$$$$$$$5,
   },
   "name": "wake",
   "baseUrl": import.meta.url,

--- a/wake/utils/transform.ts
+++ b/wake/utils/transform.ts
@@ -233,6 +233,7 @@ export const toProduct = (
 ): Product => {
   const images = variant.images?.map((image) => ({
     "@type": "ImageObject" as const,
+    encodingFormat: "image",
     url: image?.url ?? "",
     alternateName: image?.fileName ?? "",
   }));
@@ -275,6 +276,7 @@ export const toProduct = (
         image: promotion!.fullStampUrl
           ? [{
             "@type": "ImageObject",
+            encodingFormat: "image",
             url: promotion!.fullStampUrl,
           }]
           : undefined,

--- a/website/manifest.gen.ts
+++ b/website/manifest.gen.ts
@@ -4,47 +4,47 @@
 
 import * as $0 from "./functions/requestToParam.ts";
 import * as $$$0 from "./loaders/options/urlParams.ts";
-import * as $$$1 from "./loaders/image.ts";
+import * as $$$1 from "./loaders/redirects.ts";
 import * as $$$2 from "./loaders/redirectsFromCsv.ts";
-import * as $$$3 from "./loaders/secretString.ts";
-import * as $$$4 from "./loaders/extension.ts";
-import * as $$$5 from "./loaders/secret.ts";
-import * as $$$6 from "./loaders/redirects.ts";
-import * as $$$7 from "./loaders/pages.ts";
-import * as $$$8 from "./loaders/redirect.ts";
-import * as $$$9 from "./loaders/asset.ts";
-import * as $$$10 from "./loaders/fonts/local.ts";
-import * as $$$11 from "./loaders/fonts/googleFonts.ts";
-import * as $$$$0 from "./handlers/router.ts";
-import * as $$$$1 from "./handlers/sitemap.ts";
+import * as $$$3 from "./loaders/fonts/googleFonts.ts";
+import * as $$$4 from "./loaders/fonts/local.ts";
+import * as $$$5 from "./loaders/asset.ts";
+import * as $$$6 from "./loaders/secret.ts";
+import * as $$$7 from "./loaders/image.ts";
+import * as $$$8 from "./loaders/extension.ts";
+import * as $$$9 from "./loaders/redirect.ts";
+import * as $$$10 from "./loaders/pages.ts";
+import * as $$$11 from "./loaders/secretString.ts";
+import * as $$$$0 from "./handlers/fresh.ts";
+import * as $$$$1 from "./handlers/router.ts";
 import * as $$$$2 from "./handlers/proxy.ts";
-import * as $$$$3 from "./handlers/fresh.ts";
+import * as $$$$3 from "./handlers/sitemap.ts";
 import * as $$$$4 from "./handlers/redirect.ts";
 import * as $$$$$0 from "./pages/Page.tsx";
-import * as $$$$$$0 from "./sections/Rendering/Deferred.tsx";
-import * as $$$$$$1 from "./sections/Seo/Seo.tsx";
-import * as $$$$$$2 from "./sections/Analytics/Analytics.tsx";
-import * as $$$$$$$0 from "./matchers/date.ts";
-import * as $$$$$$$1 from "./matchers/environment.ts";
-import * as $$$$$$$2 from "./matchers/site.ts";
-import * as $$$$$$$3 from "./matchers/location.ts";
-import * as $$$$$$$4 from "./matchers/cookie.ts";
-import * as $$$$$$$5 from "./matchers/random.ts";
-import * as $$$$$$$6 from "./matchers/multi.ts";
-import * as $$$$$$$7 from "./matchers/never.ts";
-import * as $$$$$$$8 from "./matchers/negate.ts";
-import * as $$$$$$$9 from "./matchers/cron.ts";
-import * as $$$$$$$10 from "./matchers/device.ts";
-import * as $$$$$$$11 from "./matchers/host.ts";
-import * as $$$$$$$12 from "./matchers/always.ts";
-import * as $$$$$$$13 from "./matchers/userAgent.ts";
-import * as $$$$$$$$0 from "./flags/multivariate/section.ts";
-import * as $$$$$$$$1 from "./flags/multivariate/page.ts";
-import * as $$$$$$$$2 from "./flags/multivariate/message.ts";
-import * as $$$$$$$$3 from "./flags/audience.ts";
-import * as $$$$$$$$4 from "./flags/multivariate.ts";
-import * as $$$$$$$$5 from "./flags/everyone.ts";
-import * as $$$$$$$$6 from "./flags/flag.ts";
+import * as $$$$$$0 from "./sections/Analytics/Analytics.tsx";
+import * as $$$$$$1 from "./sections/Rendering/Deferred.tsx";
+import * as $$$$$$2 from "./sections/Seo/Seo.tsx";
+import * as $$$$$$$0 from "./matchers/multi.ts";
+import * as $$$$$$$1 from "./matchers/random.ts";
+import * as $$$$$$$2 from "./matchers/cron.ts";
+import * as $$$$$$$3 from "./matchers/environment.ts";
+import * as $$$$$$$4 from "./matchers/host.ts";
+import * as $$$$$$$5 from "./matchers/negate.ts";
+import * as $$$$$$$6 from "./matchers/userAgent.ts";
+import * as $$$$$$$7 from "./matchers/date.ts";
+import * as $$$$$$$8 from "./matchers/cookie.ts";
+import * as $$$$$$$9 from "./matchers/always.ts";
+import * as $$$$$$$10 from "./matchers/never.ts";
+import * as $$$$$$$11 from "./matchers/device.ts";
+import * as $$$$$$$12 from "./matchers/location.ts";
+import * as $$$$$$$13 from "./matchers/site.ts";
+import * as $$$$$$$$0 from "./flags/audience.ts";
+import * as $$$$$$$$1 from "./flags/everyone.ts";
+import * as $$$$$$$$2 from "./flags/flag.ts";
+import * as $$$$$$$$3 from "./flags/multivariate.ts";
+import * as $$$$$$$$4 from "./flags/multivariate/message.ts";
+import * as $$$$$$$$5 from "./flags/multivariate/page.ts";
+import * as $$$$$$$$6 from "./flags/multivariate/section.ts";
 import * as $$$$$$$$$0 from "./actions/secrets/encrypt.ts";
 
 const manifest = {
@@ -52,58 +52,58 @@ const manifest = {
     "website/functions/requestToParam.ts": $0,
   },
   "loaders": {
-    "website/loaders/asset.ts": $$$9,
-    "website/loaders/extension.ts": $$$4,
-    "website/loaders/fonts/googleFonts.ts": $$$11,
-    "website/loaders/fonts/local.ts": $$$10,
-    "website/loaders/image.ts": $$$1,
+    "website/loaders/asset.ts": $$$5,
+    "website/loaders/extension.ts": $$$8,
+    "website/loaders/fonts/googleFonts.ts": $$$3,
+    "website/loaders/fonts/local.ts": $$$4,
+    "website/loaders/image.ts": $$$7,
     "website/loaders/options/urlParams.ts": $$$0,
-    "website/loaders/pages.ts": $$$7,
-    "website/loaders/redirect.ts": $$$8,
-    "website/loaders/redirects.ts": $$$6,
+    "website/loaders/pages.ts": $$$10,
+    "website/loaders/redirect.ts": $$$9,
+    "website/loaders/redirects.ts": $$$1,
     "website/loaders/redirectsFromCsv.ts": $$$2,
-    "website/loaders/secret.ts": $$$5,
-    "website/loaders/secretString.ts": $$$3,
+    "website/loaders/secret.ts": $$$6,
+    "website/loaders/secretString.ts": $$$11,
   },
   "handlers": {
-    "website/handlers/fresh.ts": $$$$3,
+    "website/handlers/fresh.ts": $$$$0,
     "website/handlers/proxy.ts": $$$$2,
     "website/handlers/redirect.ts": $$$$4,
-    "website/handlers/router.ts": $$$$0,
-    "website/handlers/sitemap.ts": $$$$1,
+    "website/handlers/router.ts": $$$$1,
+    "website/handlers/sitemap.ts": $$$$3,
   },
   "pages": {
     "website/pages/Page.tsx": $$$$$0,
   },
   "sections": {
-    "website/sections/Analytics/Analytics.tsx": $$$$$$2,
-    "website/sections/Rendering/Deferred.tsx": $$$$$$0,
-    "website/sections/Seo/Seo.tsx": $$$$$$1,
+    "website/sections/Analytics/Analytics.tsx": $$$$$$0,
+    "website/sections/Rendering/Deferred.tsx": $$$$$$1,
+    "website/sections/Seo/Seo.tsx": $$$$$$2,
   },
   "matchers": {
-    "website/matchers/always.ts": $$$$$$$12,
-    "website/matchers/cookie.ts": $$$$$$$4,
-    "website/matchers/cron.ts": $$$$$$$9,
-    "website/matchers/date.ts": $$$$$$$0,
-    "website/matchers/device.ts": $$$$$$$10,
-    "website/matchers/environment.ts": $$$$$$$1,
-    "website/matchers/host.ts": $$$$$$$11,
-    "website/matchers/location.ts": $$$$$$$3,
-    "website/matchers/multi.ts": $$$$$$$6,
-    "website/matchers/negate.ts": $$$$$$$8,
-    "website/matchers/never.ts": $$$$$$$7,
-    "website/matchers/random.ts": $$$$$$$5,
-    "website/matchers/site.ts": $$$$$$$2,
-    "website/matchers/userAgent.ts": $$$$$$$13,
+    "website/matchers/always.ts": $$$$$$$9,
+    "website/matchers/cookie.ts": $$$$$$$8,
+    "website/matchers/cron.ts": $$$$$$$2,
+    "website/matchers/date.ts": $$$$$$$7,
+    "website/matchers/device.ts": $$$$$$$11,
+    "website/matchers/environment.ts": $$$$$$$3,
+    "website/matchers/host.ts": $$$$$$$4,
+    "website/matchers/location.ts": $$$$$$$12,
+    "website/matchers/multi.ts": $$$$$$$0,
+    "website/matchers/negate.ts": $$$$$$$5,
+    "website/matchers/never.ts": $$$$$$$10,
+    "website/matchers/random.ts": $$$$$$$1,
+    "website/matchers/site.ts": $$$$$$$13,
+    "website/matchers/userAgent.ts": $$$$$$$6,
   },
   "flags": {
-    "website/flags/audience.ts": $$$$$$$$3,
-    "website/flags/everyone.ts": $$$$$$$$5,
-    "website/flags/flag.ts": $$$$$$$$6,
-    "website/flags/multivariate.ts": $$$$$$$$4,
-    "website/flags/multivariate/message.ts": $$$$$$$$2,
-    "website/flags/multivariate/page.ts": $$$$$$$$1,
-    "website/flags/multivariate/section.ts": $$$$$$$$0,
+    "website/flags/audience.ts": $$$$$$$$0,
+    "website/flags/everyone.ts": $$$$$$$$1,
+    "website/flags/flag.ts": $$$$$$$$2,
+    "website/flags/multivariate.ts": $$$$$$$$3,
+    "website/flags/multivariate/message.ts": $$$$$$$$4,
+    "website/flags/multivariate/page.ts": $$$$$$$$5,
+    "website/flags/multivariate/section.ts": $$$$$$$$6,
   },
   "actions": {
     "website/actions/secrets/encrypt.ts": $$$$$$$$$0,

--- a/workflows/manifest.gen.ts
+++ b/workflows/manifest.gen.ts
@@ -2,25 +2,25 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/get.ts";
-import * as $$$1 from "./loaders/events.ts";
+import * as $$$0 from "./loaders/events.ts";
+import * as $$$1 from "./loaders/get.ts";
 import * as $$$$0 from "./handlers/workflowRunner.ts";
-import * as $$$$$$$$$0 from "./actions/start.ts";
-import * as $$$$$$$$$1 from "./actions/cancel.ts";
+import * as $$$$$$$$$0 from "./actions/cancel.ts";
+import * as $$$$$$$$$1 from "./actions/start.ts";
 import * as $$$$$$$$$2 from "./actions/signal.ts";
 
 const manifest = {
   "loaders": {
-    "workflows/loaders/events.ts": $$$1,
-    "workflows/loaders/get.ts": $$$0,
+    "workflows/loaders/events.ts": $$$0,
+    "workflows/loaders/get.ts": $$$1,
   },
   "handlers": {
     "workflows/handlers/workflowRunner.ts": $$$$0,
   },
   "actions": {
-    "workflows/actions/cancel.ts": $$$$$$$$$1,
+    "workflows/actions/cancel.ts": $$$$$$$$$0,
     "workflows/actions/signal.ts": $$$$$$$$$2,
-    "workflows/actions/start.ts": $$$$$$$$$0,
+    "workflows/actions/start.ts": $$$$$$$$$1,
   },
   "name": "workflows",
   "baseUrl": import.meta.url,


### PR DESCRIPTION
Now you can find videos in the PDP on VNDA. They come from ImageObject.

This is the end-point: GET /api/v2/products/:productId/videos

I edit all loaders in deco to support this new key in ImageObject.

https://schema.org/ImageObject

![image](https://github.com/deco-cx/apps/assets/108771428/2947f6c9-65c4-4667-a426-c0b20469fd67)

![image](https://github.com/deco-cx/apps/assets/108771428/f1f0182b-aa79-456e-9e53-ee9ea02c9c08)
