### PR TITLE
fix: get cart installments shoudnt update cart context

### DIFF
--- a/vtex/actions/cart/getInstallment.ts
+++ b/vtex/actions/cart/getInstallment.ts
@@ -1,7 +1,7 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
 import { parseCookie } from "../../utils/orderForm.ts";
-import type { OrderForm } from "../../utils/types.ts";
+import type { InstallmentOption } from "../../utils/types.ts";
 import { getSegmentFromBag } from "../../utils/segment.ts";
 
 export interface Props {
@@ -15,7 +15,7 @@ const action = async (
   props: Props,
   req: Request,
   ctx: AppContext,
-): Promise<OrderForm> => {
+): Promise<InstallmentOption> => {
   const { vcsDeprecated } = ctx;
   const { paymentSystem } = props;
   const { orderFormId } = parseCookie(req.headers);

--- a/vtex/hooks/useCart.ts
+++ b/vtex/hooks/useCart.ts
@@ -82,7 +82,7 @@ const state = {
   addItems: enqueue("vtex/actions/cart/addItems.ts"),
   addCouponsToCart: enqueue("vtex/actions/cart/updateCoupons.ts"),
   changePrice: enqueue("vtex/actions/cart/updateItemPrice.ts"),
-  getCartInstallments: enqueue("vtex/actions/cart/getInstallment.ts"),
+  getCartInstallments: invoke.vtex.actions.cart.getInstallment,
   ignoreProfileData: enqueue("vtex/actions/cart/updateProfile.ts"),
   removeAllPersonalData: enqueue("vtex/actions/cart/updateUser.ts"),
   addItemAttachment: enqueue("vtex/actions/cart/updateItemAttachment.ts"),

--- a/vtex/utils/client.ts
+++ b/vtex/utils/client.ts
@@ -2,6 +2,7 @@ import {
   Category,
   CreateNewDocument,
   FacetSearchResult,
+  InstallmentOption,
   LegacyFacets,
   LegacyProduct,
   LegacySort,
@@ -122,7 +123,7 @@ export interface VTEXCommerceStable {
     response: OrderForm;
   };
   "GET /api/checkout/pub/orderForm/:orderFormId/installments": {
-    response: OrderForm;
+    response: InstallmentOption;
     searchParams: { paymentSystem: number; sc?: string };
   };
   "POST /api/checkout/pub/orderForm/:orderFormId/profile": {


### PR DESCRIPTION
The getCartInstallments doesn't return a orderform, so this dosen't has to be on enqueue function to not update context cart signal

this PR fix:  
- getCartInstallments action return type
- remove getCartInstallments from enqueue
 
ref: https://developers.vtex.com/docs/api-reference/checkout-api#get-/api/checkout/pub/orderForm/-orderFormId-/installments