### PR TITLE
Prefer canonical prop over response

### DIFF
--- a/commerce/sections/Seo/SeoPDP.tsx
+++ b/commerce/sections/Seo/SeoPDP.tsx
@@ -23,7 +23,7 @@ function Section({ jsonLD, ...props }: Props) {
       title={title || props.title}
       description={description || props.description}
       image={image || props.image}
-      canonical={canonical || props.canonical}
+      canonical={(props.canonical || canonical) ?? undefined}
       jsonLDs={[jsonLD]}
       noIndexing={noIndexing}
     />

--- a/commerce/sections/Seo/SeoPDP.tsx
+++ b/commerce/sections/Seo/SeoPDP.tsx
@@ -14,7 +14,7 @@ function Section({ jsonLD, ...props }: Props) {
     ? jsonLD.seo.canonical
     : jsonLD?.breadcrumbList
     ? canonicalFromBreadcrumblist(jsonLD?.breadcrumbList)
-    : null;
+    : undefined;
   const noIndexing = !jsonLD;
 
   return (
@@ -23,7 +23,7 @@ function Section({ jsonLD, ...props }: Props) {
       title={title || props.title}
       description={description || props.description}
       image={image || props.image}
-      canonical={(props.canonical || canonical) ?? undefined}
+      canonical={props.canonical || canonical}
       jsonLDs={[jsonLD]}
       noIndexing={noIndexing}
     />

--- a/commerce/sections/Seo/SeoPLP.tsx
+++ b/commerce/sections/Seo/SeoPLP.tsx
@@ -9,11 +9,13 @@ export type Props = {
 function Section({ jsonLD, ...props }: Props) {
   const title = jsonLD?.seo?.title;
   const description = jsonLD?.seo?.description;
-  const canonical = jsonLD?.seo?.canonical
+  const canonical = props.canonical?.trim()
+    ? props.canonical.trim()
+    : jsonLD?.seo?.canonical
     ? jsonLD.seo.canonical
     : jsonLD?.breadcrumb
     ? canonicalFromBreadcrumblist(jsonLD?.breadcrumb)
-    : props.canonical;
+    : undefined;
 
   const noIndexing = !jsonLD || !jsonLD.products.length;
 

--- a/commerce/sections/Seo/SeoPLP.tsx
+++ b/commerce/sections/Seo/SeoPLP.tsx
@@ -9,8 +9,8 @@ export type Props = {
 function Section({ jsonLD, ...props }: Props) {
   const title = jsonLD?.seo?.title;
   const description = jsonLD?.seo?.description;
-  const canonical = props.canonical?.trim()
-    ? props.canonical.trim()
+  const canonical = props.canonical
+    ? props.canonical
     : jsonLD?.seo?.canonical
     ? jsonLD.seo.canonical
     : jsonLD?.breadcrumb


### PR DESCRIPTION
Canonical prop when set on SEO components will now be used instead of seo from loader.

It is not possible to currently override canonical from backend which can not be a desired effect on page.