### PR TITLE
Fix: Removes hardcoded price currency code and locale info in Vtex Product Loaders

### DIFF
--- a/vtex/loaders/intelligentSearch/productDetailsPage.ts
+++ b/vtex/loaders/intelligentSearch/productDetailsPage.ts
@@ -111,7 +111,7 @@ const loader = async (
 
   const page = toProductPage(product, sku, kitItems, {
     baseUrl,
-    priceCurrency: "BRL", // config!.defaultPriceCurrency, TODO: fix currency
+    priceCurrency: segment.currencyCode ?? "BRL",
   });
 
   return {

--- a/vtex/loaders/intelligentSearch/productList.ts
+++ b/vtex/loaders/intelligentSearch/productList.ts
@@ -131,7 +131,7 @@ const loader = async (
 
   const options = {
     baseUrl: url,
-    priceCurrency: "BRL", // config!.defaultPriceCurrency, // TOO
+    priceCurrency: segment.currencyCode ?? "BRL",
   };
 
   // Transform VTEX product format into schema.org's compatible format

--- a/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -327,7 +327,7 @@ const loader = async (
             misspelled: productsResult.correction?.misspelled ?? false,
             match: productsResult.recordsFiltered,
             operator: productsResult.operator,
-            locale: "pt-BR", // config?.defaultLocale, // TODO
+            locale: segment.cultureInfo ?? "pt-BR", 
           },
           req,
           ctx,
@@ -351,7 +351,7 @@ const loader = async (
       .map((p) =>
         toProduct(p, p.items[0], 0, {
           baseUrl: baseUrl,
-          priceCurrency: "BRL", // config!.defaultPriceCurrency, // TODO
+          priceCurrency: segment.currencyCode ?? "BRL",
         })
       )
       .map((product) =>

--- a/vtex/loaders/intelligentSearch/suggestions.ts
+++ b/vtex/loaders/intelligentSearch/suggestions.ts
@@ -77,7 +77,7 @@ const loaders = async (
 
   const options = {
     baseUrl: url,
-    priceCurrency: "BRL", // config!.defaultPriceCurrency, // TODO
+    priceCurrency: segment.currencyCode ?? "BRL",
   };
 
   return {

--- a/vtex/loaders/legacy/productDetailsPage.ts
+++ b/vtex/loaders/legacy/productDetailsPage.ts
@@ -68,7 +68,7 @@ async function loader(
 
   const page = toProductPage(product, sku, kitItems, {
     baseUrl,
-    priceCurrency: "BRL", //  config!.defaultPriceCurrency, // TODO: fix currency
+    priceCurrency: segment.currencyCode ?? "BRL",
   });
 
   return {

--- a/vtex/loaders/legacy/productList.ts
+++ b/vtex/loaders/legacy/productList.ts
@@ -183,7 +183,7 @@ const loader = async (
   const products = vtexProducts.map((p) =>
     toProduct(p, p.items[0], 0, {
       baseUrl: baseUrl,
-      priceCurrency: "BRL", // config!.defaultPriceCurrency, // TODO fix currency
+      priceCurrency: segment.currencyCode ?? "BRL",
     })
   );
 

--- a/vtex/loaders/legacy/productListingPage.ts
+++ b/vtex/loaders/legacy/productListingPage.ts
@@ -232,7 +232,7 @@ const loader = async (
       .map((p) =>
         toProduct(p, p.items[0], 0, {
           baseUrl,
-          priceCurrency: "BRL", // config!.defaultPriceCurrency, // TODO: fix currency
+          priceCurrency: segment.currencyCode ?? "BRL",
         })
       )
       .map((product) =>


### PR DESCRIPTION
This pull request addresses an issue where currency code and locale info were hardcoded. This change replaces the hardcoded info with segment information sourced from VTEX App Configuration.