### PR TITLE
feat: support dark mode

### DIFF
--- a/website/components/Theme.tsx
+++ b/website/components/Theme.tsx
@@ -14,9 +14,13 @@ export type Font = {
 export interface Props {
   variables?: Variable[];
   fonts?: Font[];
+  colorScheme?: "light" | "dark";
 }
 
-function Theme({ fonts = [], variables = [] }: Props) {
+const withPrefersColorScheme = (scheme: "light" | "dark", css: string) =>
+  `@media (prefers-color-scheme: ${scheme}) { ${css} }`;
+
+function Theme({ fonts = [], variables = [], colorScheme }: Props) {
   const id = useId();
 
   const family = fonts.reduce(
@@ -24,12 +28,15 @@ function Theme({ fonts = [], variables = [] }: Props) {
     "",
   );
 
-  const css = [
+  const vars = [
     { name: "--font-family", value: family },
     ...variables,
   ]
     .map(({ name, value }) => `${name}: ${value}`)
     .join(";");
+
+  const css = `* {${vars}}`;
+  const html = colorScheme ? withPrefersColorScheme(colorScheme, css) : css;
 
   return (
     <Head>
@@ -42,9 +49,7 @@ function Theme({ fonts = [], variables = [] }: Props) {
       <style
         type="text/css"
         id={`__DESIGN_SYSTEM_VARS-${id}`}
-        dangerouslySetInnerHTML={{
-          __html: `* {${css}}`,
-        }}
+        dangerouslySetInnerHTML={{ __html: html }}
       />
     </Head>
   );


### PR DESCRIPTION
This PR adds the support for `@media prefers-color-scheme` media query so we can add dark mode to websites built on top of deco.cx

The idea is to have multiple instances of this theme section, one for each color scheme.