### PR TITLE
Add descriptionHtml to additionalProperty

### DIFF
--- a/shopify/utils/transform.ts
+++ b/shopify/utils/transform.ts
@@ -97,7 +97,14 @@ export const toProduct = (
     compareAtPrice,
   } = sku;
 
-  const additionalProperty = selectedOptions.map(toPropertyValue);
+  const descriptionHtml: PropertyValue = {
+    "@type": "PropertyValue",
+    "name": "descriptionHtml",
+    "value": product.descriptionHtml,
+  };
+  const additionalProperty: PropertyValue[] = selectedOptions.map(
+    toPropertyValue,
+  ).concat(descriptionHtml);  
   const skuImages = nonEmptyArray([image]);
   const hasVariant = level < 1 &&
     variants.nodes.map((variant) => toProduct(product, variant, url, 1));


### PR DESCRIPTION
Added the descriptionHtml field from the "ProductShopify" item into the AdditionalProperty variable of the Products. A follow up PR was made to the storefront repo as to omit the "descriptionHtml" property from the "useVariantSelector" component.