### PR TITLE
VNDA - Use appropriate variant images

### DIFF
--- a/vnda/loaders/productDetailsPage.ts
+++ b/vnda/loaders/productDetailsPage.ts
@@ -6,6 +6,7 @@ import { parseSlug, toProduct } from "../utils/transform.ts";
 
 export interface Props {
   slug: RequestURLParam;
+  useVariantImages?: boolean;
 }
 
 /**
@@ -18,7 +19,7 @@ async function loader(
   ctx: AppContext,
 ): Promise<ProductDetailsPage | null> {
   const url = new URL(req.url);
-  const { slug } = props;
+  const { slug, useVariantImages } = props;
   const { api } = ctx;
 
   if (!slug) return null;
@@ -40,6 +41,7 @@ async function loader(
   const product = toProduct(maybeProduct, variantId, {
     url,
     priceCurrency: "BRL",
+    useVariantImages,
   });
 
   const segments = url.pathname.slice(1).split("/");


### PR DESCRIPTION
I implemented a flag (`useVariantImages`) that will change the way the images are attached to each variant.
Currently, all images are attached to all variants (witch is not right at all, I think). Anyway, with the flag set to `true`, each variant will be associated only with the appropriate images.

See the same product in both ways:

---

`useVariantImages = false`
`https://deco-sites-vip-capas.deno.dev/produto/produto-teste-10354?skuId=04`
![image](https://github.com/deco-cx/apps/assets/23545318/f028f9a9-dba2-4d21-a8dd-4f5365a6350a)

---

`useVariantImages = true`
`http://localhost:8000/produto/produto-teste-10354?skuId=04`
![image](https://github.com/deco-cx/apps/assets/23545318/7d279432-776b-4f15-a0e5-76ec227ddefe)
