### PR TITLE
Fix: VNDA - Ignore products with empty variants array

### DIFF
--- a/vnda/loaders/productDetailsPage.ts
+++ b/vnda/loaders/productDetailsPage.ts
@@ -32,8 +32,10 @@ async function loader(
   }, STALE)
     .then((r) => r.json()).catch(() => null);
 
+  const variantsLength = maybeProduct?.variants?.length ?? 0;
+
   // 404: product not found
-  if (!maybeProduct) {
+  if (!maybeProduct || variantsLength === 0) {
     return null;
   }
 

--- a/vnda/loaders/productList.ts
+++ b/vnda/loaders/productList.ts
@@ -35,21 +35,28 @@ const productListLoader = async (
   const url = new URL(req.url);
   const { api } = ctx;
 
-  const search = await api["GET /api/v2/products/search"]({
-    term: props?.term,
-    wildcard: props?.wildcard,
-    sort: props?.sort,
-    per_page: props?.count,
-    "tags[]": props?.tags,
-    "ids[]": props?.ids,
-  }, STALE).then((res) => res.json());
+  const { results: searchResults = [] } = await api
+    ["GET /api/v2/products/search"]({
+      term: props?.term,
+      wildcard: props?.wildcard,
+      sort: props?.sort,
+      per_page: props?.count,
+      "tags[]": props?.tags,
+      "ids[]": props?.ids,
+    }, STALE).then((res) => res.json());
 
-  return search.results?.map((product) =>
-    toProduct(product, null, {
+  const validProducts = searchResults.filter(({ variants }) => {
+    return variants.length !== 0;
+  });
+
+  if (validProducts.length === 0) return null;
+
+  return validProducts.map((product) => {
+    return toProduct(product, null, {
       url,
       priceCurrency: "BRL",
-    })
-  ) ?? null;
+    });
+  });
 };
 
 export default productListLoader;

--- a/vnda/loaders/productListingPage.ts
+++ b/vnda/loaders/productListingPage.ts
@@ -149,14 +149,18 @@ const searchLoader = async (
 
   const search = await response.json();
 
-  const { results: searchResults } = search;
+  const { results: searchResults = [] } = search;
 
-  const products = searchResults?.map((product) =>
-    toProduct(product, null, {
+  const validProducts = searchResults.filter(({ variants }) => {
+    return variants.length !== 0;
+  });
+
+  const products = validProducts.map((product) => {
+    return toProduct(product, null, {
       url,
       priceCurrency: "BRL",
-    })
-  );
+    });
+  });
 
   const nextPage = new URLSearchParams(url.searchParams);
   const previousPage = new URLSearchParams(url.searchParams);
@@ -180,7 +184,7 @@ const searchLoader = async (
       }
       : getBreadcrumbList(categories, url),
     filters: toFilters(search.aggregations, typeTags, cleanUrl),
-    products: products ?? [],
+    products,
     pageInfo: {
       nextPage: pagination?.next_page ? `?${nextPage}` : undefined,
       previousPage: pagination?.prev_page ? `?${previousPage}` : undefined,


### PR DESCRIPTION
If a product is created without variants, the VNDA api will return it as a [VNDAProductGroup](https://github.com/deco-cx/apps/blob/3325d94bc2c8261280a65d796b3f2e6cfc13df8a/vnda/utils/transform.ts#L19) with an empty `variants` array.

A product in this condition should be ignored by the product loaders because it is missing important data like price and availability. Besides, ignore it will prevent errors as expecting `variants` to have at least one variant.