### PR TITLE
 Allow Selection of Sales Channels Above 5 in VTEX App

### DIFF
--- a/vtex/mod.ts
+++ b/vtex/mod.ts
@@ -62,7 +62,7 @@ export interface Props {
    * @default 1
    * @deprecated
    */
-  salesChannel?: "1" | "2" | "3" | "4" | "5";
+  salesChannel?: string;
 
   /**
    * @title Default Segment


### PR DESCRIPTION
Description:
The sales channel selection in the VTEX app was previously restricted to the range of 1 to 5, preventing the selection of environments with sales channels greater than 5, as illustrated in the attached image.

![image](https://github.com/deco-cx/apps/assets/78617863/6ae2d9be-bbdf-4260-bb9c-f100dca8dd92)

Changes Made:
I have modified the property to a string type, enabling the selection of sales channels above 5.

