### PR TITLE
website/Deferred - Providing aria-label for Deferred section (button)

### DIFF
--- a/website/sections/Rendering/Deferred.tsx
+++ b/website/sections/Rendering/Deferred.tsx
@@ -76,7 +76,12 @@ const Deferred = (props: Props) => {
 
   return (
     <>
-      <button {...partial} id={buttonId} data-deferred />
+      <button
+        {...partial}
+        id={buttonId}
+        data-deferred
+        aria-label={`Deferred Section - ${useId()}`}
+      />
       <script
         defer
         src={scriptAsDataURI(

--- a/website/sections/Rendering/Deferred.tsx
+++ b/website/sections/Rendering/Deferred.tsx
@@ -61,7 +61,8 @@ const script = (
 
 const Deferred = (props: Props) => {
   const { sections, display, behavior } = props;
-  const buttonId = `deffered-${useId()}`;
+  const sectionID = useId();
+  const buttonId = `deffered-${sectionID}`;
   const partial = usePartialSection<typeof Deferred>({
     props: { display: true },
   });
@@ -80,7 +81,7 @@ const Deferred = (props: Props) => {
         {...partial}
         id={buttonId}
         data-deferred
-        aria-label={`Deferred Section - ${useId()}`}
+        aria-label={`Deferred Section - ${sectionID}`}
       />
       <script
         defer


### PR DESCRIPTION
The Deferred section renders a button without an `aria-label` and it causes an accessibility fault in Lighthouse.
Adding an `aria-label` to the button, solves the problem.

![image](https://github.com/deco-cx/apps/assets/23545318/bce7f775-fe10-492e-8a25-f36defefc46a)

---

Before:
![image](https://github.com/deco-cx/apps/assets/23545318/84fe0329-453a-4789-8f51-5d3479409c73)

---

After:
![image](https://github.com/deco-cx/apps/assets/23545318/b8d37e9d-276b-4a65-9f15-672b6870cfc7)
