### PR TITLE
Do not persist default site state and use kubernetes watch (deno 1.39.2 fixes the watch bug)

### DIFF
--- a/ai-assistants/chat/messages.ts
+++ b/ai-assistants/chat/messages.ts
@@ -7,9 +7,9 @@ import { threadMessageToReply, Tokens } from "../loaders/messages.ts";
 
 import { JSONSchema7 } from "deco/deps.ts";
 import { genSchemas } from "deco/engine/schema/reader.ts";
-import { context } from "deco/live.ts";
+import { Context } from "deco/live.ts";
 import { AppManifest } from "deco/mod.ts";
-import { mschema } from "deco/routes/live/_meta.ts";
+import { mschema } from "deco/runtime/fresh/routes/_meta.ts";
 import { ChatMessage, FunctionCallReply } from "../actions/chat.ts";
 import { AIAssistant, AppContext } from "../mod.ts";
 import { dereferenceJsonSchema } from "../schema.ts";
@@ -48,7 +48,7 @@ const pickFunctions = (
 const appTools = (assistant: AIAssistant): Promise<
   AssistantCreateParams.AssistantToolsFunction[]
 > => {
-  return tools ??= context.runtime!.then(async (runtime) => {
+  return tools ??= Context.active().runtime!.then(async (runtime) => {
     const manifest = assistant.availableFunctions
       ? pickFunctions(assistant.availableFunctions, runtime.manifest)
       : runtime.manifest;

--- a/ai-assistants/mod.ts
+++ b/ai-assistants/mod.ts
@@ -1,10 +1,7 @@
 import { asResolved, isDeferred } from "deco/engine/core/resolver.ts";
 import { isAwaitable } from "deco/engine/core/utils.ts";
 import type { App, AppContext as AC } from "deco/mod.ts";
-import {
-  AvailableActions,
-  AvailableLoaders,
-} from "deco/utils/invoke.types.ts";
+import { AvailableActions, AvailableLoaders } from "deco/utils/invoke.types.ts";
 import { AppManifest } from "deco/types.ts";
 import { deferred } from "std/async/deferred.ts";
 import openai, {

--- a/ai-assistants/mod.ts
+++ b/ai-assistants/mod.ts
@@ -4,7 +4,7 @@ import type { App, AppContext as AC } from "deco/mod.ts";
 import {
   AvailableActions,
   AvailableLoaders,
-} from "deco/routes/live/invoke/index.ts";
+} from "deco/utils/invoke.types.ts";
 import { AppManifest } from "deco/types.ts";
 import { deferred } from "std/async/deferred.ts";
 import openai, {

--- a/compat/$live/loaders/state.ts
+++ b/compat/$live/loaders/state.ts
@@ -5,7 +5,7 @@ import { Page } from "deco/blocks/page.tsx";
 import { Section } from "deco/blocks/section.ts";
 import { Resolvable } from "deco/engine/core/resolver.ts";
 import { Apps, LoaderContext } from "deco/mod.ts";
-import { MiddlewareConfig } from "deco/routes/_middleware.ts";
+import { MiddlewareConfig } from "deco/runtime/fresh/middlewares/3_main.ts";
 
 /**
  * @titleBy key

--- a/deno.json
+++ b/deno.json
@@ -9,7 +9,7 @@
     "std/": "https://deno.land/std@0.204.0/",
     "partytown/": "https://deno.land/x/partytown@0.4.8/",
     "deco-sites/std/": "https://denopkg.com/deco-sites/std@1.22.11/",
-    "deco/": "https://denopkg.com/deco-cx/deco@1.50.3/"
+    "deco/": "https://denopkg.com/deco-cx/deco@c56cb952f5fcf6beffa33e62376551356f921e17/"
   },
   "lock": false,
   "tasks": {

--- a/deno.json
+++ b/deno.json
@@ -9,7 +9,7 @@
     "std/": "https://deno.land/std@0.204.0/",
     "partytown/": "https://deno.land/x/partytown@0.4.8/",
     "deco-sites/std/": "https://denopkg.com/deco-sites/std@1.22.11/",
-    "deco/": "https://denopkg.com/deco-cx/deco@c56cb952f5fcf6beffa33e62376551356f921e17/"
+    "deco/": "https://denopkg.com/deco-cx/deco@8dfc4c99fe322ef6f46167b2d7028eda32c2eea4/"
   },
   "lock": false,
   "tasks": {

--- a/deno.json
+++ b/deno.json
@@ -9,7 +9,7 @@
     "std/": "https://deno.land/std@0.204.0/",
     "partytown/": "https://deno.land/x/partytown@0.4.8/",
     "deco-sites/std/": "https://denopkg.com/deco-sites/std@1.22.11/",
-    "deco/": "https://denopkg.com/deco-cx/deco@8dfc4c99fe322ef6f46167b2d7028eda32c2eea4/"
+    "deco/": "https://denopkg.com/deco-cx/deco@1.51.0/"
   },
   "lock": false,
   "tasks": {

--- a/platforms/kubernetes/actions/deployments/create.ts
+++ b/platforms/kubernetes/actions/deployments/create.ts
@@ -1,12 +1,13 @@
 import { shortcircuit } from "deco/engine/errors.ts";
 import { badRequest } from "deco/mod.ts";
 import ShortUniqueId from "https://esm.sh/v135/short-unique-id@v4.4.2";
+import { Deployment } from "../../../../admin/platform.ts";
 import runScript from "../../common/cmds/run.ts";
 import { routeOf } from "../../common/knative/route.ts";
 import { ignoreIfExists, upsertObject } from "../../common/objects.ts";
 import { k8s } from "../../deps.ts";
 import { ServiceScaling, SiteState } from "../../loaders/siteState/get.ts";
-import { AppContext } from "../../mod.ts";
+import { AppContext, CONTROL_PLANE_DOMAIN } from "../../mod.ts";
 import { SourceBinder, SrcBinder } from "../build.ts";
 
 const uid = new ShortUniqueId({ length: 10, dictionary: "alpha_lower" });
@@ -21,6 +22,7 @@ export interface Props {
   deploymentId: string;
   runnerImage?: string;
   siteState: SiteState;
+  build?: boolean;
 }
 
 export interface EnvVar {
@@ -200,26 +202,43 @@ const IMMUTABLE_ANNOTATIONS = ["serving.knative.dev/creator"];
  */
 export default async function newDeployment(
   {
+    build = true,
     site,
     deploymentId,
     labels,
     runnerImage,
-    siteState,
-    siteState: { source },
-    scaling = { initialScale: 0, maxScale: 3, minScale: 0 },
+    siteState: desiredState,
+    scaling: _scaling,
   }: Props,
   _req: Request,
   ctx: AppContext,
-) {
+): Promise<Deployment> {
+  const siteState = ctx.withDefaults(desiredState);
+  const { source, scaling = _scaling } = siteState;
   if (!source) {
     badRequest({ message: "source is required" });
-    return;
   }
-  const { owner, repo, commitSha } = source;
+
+  const { owner, repo, commitSha } = source!;
+  if (build) {
+    // when code has changed so we need to build it.
+    const buildResult = await ctx.invoke.kubernetes.actions.build({
+      commitSha,
+      repo,
+      owner,
+      builderImage: siteState.builderImage,
+      site,
+    });
+    const status = await buildResult.wait(300_000);
+
+    if (status !== "succeed") {
+      badRequest({ message: `unexpected build status ${status}` });
+    }
+  }
+
   const runnerImg = runnerImage ?? siteState?.runnerImage;
   if (!runnerImg) {
     badRequest({ message: "runner image is required" });
-    return;
   }
   const k8sApi = ctx.kc.makeApiClient(k8s.CustomObjectsApi);
   const revisionName = `${site}-site-${deploymentId}`;
@@ -238,7 +257,7 @@ export default async function newDeployment(
     namespace: site,
     deploymentId,
     labels,
-    scaling,
+    scaling: scaling ?? { initialScale: 0, maxScale: 3, minScale: 0 },
     runnerImage: runnerImg!,
     revisionName,
     serviceAccountName: siteState?.useServiceAccount ? `site-sa` : undefined,
@@ -291,4 +310,10 @@ export default async function newDeployment(
       ),
     );
   });
+
+  const domains = [{
+    url: `https://sites-${site}-${deploymentId}.${CONTROL_PLANE_DOMAIN}`,
+    production: false,
+  }];
+  return { id: deploymentId, domains };
 }

--- a/platforms/kubernetes/actions/sites/create.ts
+++ b/platforms/kubernetes/actions/sites/create.ts
@@ -92,8 +92,7 @@ export default async function newSite(
     }).catch(ignoreIfExists),
   ]);
   const state = {
-    ...ctx.defaultSiteState,
-    envVars: [...ctx.defaultSiteState?.envVars ?? [], secretEnvVar],
+    envVars: [secretEnvVar],
   };
   await ctx.invoke.kubernetes.actions.siteState.upsert({
     site,

--- a/platforms/kubernetes/common/jobs.ts
+++ b/platforms/kubernetes/common/jobs.ts
@@ -19,9 +19,9 @@ export async function watchJobStatus(
   const req = await watcher.watch(
     `/apis/batch/v1/namespaces/${namespace}/jobs`,
     { fieldSelector },
-    (type, obj) => {
+    (_type, obj) => {
       lastSeenJob = obj;
-      if (type === "MODIFIED" && obj.status && obj.status.conditions) {
+      if (obj.status && obj.status.conditions) {
         const conditions = obj.status.conditions;
         const condition: k8s.V1JobCondition = (conditions ?? []).find((
           cond: k8s.V1JobCondition,

--- a/platforms/kubernetes/loaders/siteState/get.ts
+++ b/platforms/kubernetes/loaders/siteState/get.ts
@@ -100,5 +100,5 @@ export default async function getSiteState(
     }
     throw err;
   });
-  return secret ? State.fromSecret(secret.body) : ctx.defaultSiteState;
+  return secret ? State.fromSecret(secret.body) : undefined;
 }

--- a/website/pages/Page.tsx
+++ b/website/pages/Page.tsx
@@ -5,7 +5,7 @@ import { context } from "deco/live.ts";
 import {
   usePageContext as useDecoPageContext,
   useRouterContext,
-} from "deco/routes/[...catchall].tsx";
+} from "deco/runtime/fresh/routes/entrypoint.tsx";
 import { JSX } from "preact";
 import Events from "../components/Events.tsx";
 import LiveControls from "../components/_Controls.tsx";

--- a/workflows/actions/start.ts
+++ b/workflows/actions/start.ts
@@ -3,7 +3,6 @@ import { Workflow, WorkflowFn } from "deco/blocks/workflow.ts";
 import { Arg, RuntimeParameters, WorkflowExecutionBase } from "deco/deps.ts";
 import { BlockFromKey, BlockFunc, BlockKeys } from "deco/engine/block.ts";
 import { Resolvable } from "deco/engine/core/resolver.ts";
-import { Manifest } from "deco/live.gen.ts";
 import { context } from "deco/live.ts";
 import { AppManifest } from "deco/mod.ts";
 import { start } from "../initializer.ts"; // side-effect initialize
@@ -27,7 +26,7 @@ export interface AnyWorkflow extends CommonProps {
 
 export type WorkflowProps<
   key extends string = string,
-  TManifest extends AppManifest = Manifest,
+  TManifest extends AppManifest = AppManifest,
   block extends BlockFromKey<key, TManifest> = BlockFromKey<key, TManifest>,
 > = key extends BlockKeys<TManifest> & `${string}/workflows/${string}`
   ? BlockFunc<key, TManifest, block> extends
@@ -39,7 +38,7 @@ export type WorkflowProps<
 
 const fromWorkflowProps = <
   key extends string = string,
-  TManifest extends AppManifest = Manifest,
+  TManifest extends AppManifest = AppManifest,
   block extends BlockFromKey<key, TManifest> = BlockFromKey<key, TManifest>,
 >(
   props: WorkflowProps<key, TManifest, block> | AnyWorkflow,
@@ -78,7 +77,7 @@ export const WorkflowQS = {
  */
 export default async function startWorkflow<
   key extends string = string,
-  TManifest extends AppManifest = Manifest,
+  TManifest extends AppManifest = AppManifest,
   block extends BlockFromKey<key, TManifest> = BlockFromKey<key, TManifest>,
 >(
   props: WorkflowProps<key, TManifest, block> | AnyWorkflow,


### PR DESCRIPTION
The major change here is how to default with default site state used when site is not created yet.

Previously:

The "defaultSiteState" passed as a prop of kubernetes app is being persistent on site creation.

The problem with that is because once the site state is saved, if the default site state changed, the new changes will be overwritten by the saved version, causing props not being updated with their new default values.

The ideal scenario is: Use site-specific value when persistent otherwise use default value, but since the default site state is being persisted, so there's no differentiation between default site state and specific site configuration.

Now:

Site state is merged with default when necessary but not persisted.