### PR TITLE
[Website] - Fix deferred firing unnecessary requests

### DIFF
--- a/website/sections/Rendering/Deferred.tsx
+++ b/website/sections/Rendering/Deferred.tsx
@@ -44,6 +44,7 @@ const script = (
     addEventListener(
       "scroll",
       () => setTimeout(() => element.click(), Number(payload) || 200),
+      { once: true },
     );
   }
 


### PR DESCRIPTION
The "website" app has a component called "Deferred" that renders certain components based on the scroll or screen intersection. When we set it to render based on the scroll, the component executes several requests as we scroll until the first request finishes. To resolve this, I set the [`once`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#once) property in the eventlistener, which causes the event callback be executed only once.

Without once: 
![image](https://github.com/deco-cx/apps/assets/32278696/1dc69ed9-8ee2-4ecd-b1d3-38ecd28c3dc5)

With once true:
![image](https://github.com/deco-cx/apps/assets/32278696/40ee1318-bde7-47a4-96ba-0f32eb234fb9)
