### PR TITLE
fix filter wake plp page

### DIFF
--- a/wake/loaders/productListingPage.ts
+++ b/wake/loaders/productListingPage.ts
@@ -89,25 +89,18 @@ export interface Props {
 const OUTSIDE_ATTRIBUTES_FILTERS = ["precoPor"];
 
 const filtersFromParams = (searchParams: URLSearchParams) => {
-  const mapped = searchParams.getAll(FILTER_PARAM).reduce((acc, value) => {
-    const test = /.*:.*/;
+  const filters: Array<{ field: string; values: string[] }> = [];
 
-    // todo validar
+  searchParams.getAll(FILTER_PARAM).forEach((value) => {
+    const test = /.*:.*/;
     const [field, val] = test.test(value)
       ? value.split(":")
       : value.split("__");
 
-    if (OUTSIDE_ATTRIBUTES_FILTERS.includes(field)) return acc;
-
-    if (!acc.has(field)) acc.set(field, []);
-    acc.get(field)?.push(val);
-    return acc;
-  }, new Map<string, string[]>());
-
-  const filters: Array<{ field: string; values: string[] }> = [];
-  for (const [field, values] of mapped.entries()) {
-    filters.push({ field, values });
-  }
+    if (!OUTSIDE_ATTRIBUTES_FILTERS.includes(field)) {
+      filters.push({ field, values: [val] });
+    }
+  });
 
   return filters;
 };


### PR DESCRIPTION
O problema eram filtros duplicados do mesmo tipo, a página não retornava nada.
![image](https://github.com/deco-cx/apps/assets/76620866/eaf2f72c-c60b-4f07-b08e-796d168ba18b)

O objeto de filters era enviado assim:
``` [ { field: "Aroma", values: [ "Uva", "Vinho" ] } ]```
 
 mudei para:
``` [ { field: "Aroma", values: [ "Uva"] }, { field: "Aroma", values: [ "Uva"] } ]```
 
 passou a funcionar.