### PR TITLE
FIX/PLP (Search)

### DIFF
--- a/vnda/loaders/productListingPage.ts
+++ b/vnda/loaders/productListingPage.ts
@@ -126,8 +126,12 @@ const searchLoader = async (
     ? resolvedTagNames
     : undefined;
 
+  // TODO: Ensure continued functionality for pages like s?q=, and verify that search functionality works with paths like /example.
+  const preference = (categoryTagsToFilter ? term : qQueryString) ??
+    url.pathname.slice(1);
+
   const response = await api["GET /api/v2/products/search"]({
-    term,
+    term: term ?? preference,
     sort,
     page,
     per_page: count,

--- a/vnda/loaders/productListingPage.ts
+++ b/vnda/loaders/productListingPage.ts
@@ -127,8 +127,9 @@ const searchLoader = async (
     : undefined;
 
   // TODO: Ensure continued functionality for pages like s?q=, and verify that search functionality works with paths like /example.
-  const preference = (categoryTagsToFilter ? term : qQueryString) ??
-    url.pathname.slice(1);
+  const preference = categoryTagsToFilter
+    ? term
+    : qQueryString ?? url.pathname.slice(1);
 
   const response = await api["GET /api/v2/products/search"]({
     term: term ?? preference,


### PR DESCRIPTION
This fix was to bring up the 404 pages in the VNDA app. 

Routes without "q" parameter don't work the search in vnda, so I fix it in this PR. 

Now you can search in pages like /example.

![image](https://github.com/deco-cx/apps/assets/108771428/0e55ce68-4972-430f-9dd7-3650184f5cff)
