### PR TITLE
[Shopify] - Use origin instead of host to build product url

### DIFF
--- a/shopify/utils/transform.ts
+++ b/shopify/utils/transform.ts
@@ -145,7 +145,7 @@ export const toProduct = (
       "@type": "ProductGroup",
       productGroupID,
       hasVariant: hasVariant || [],
-      url: `${url.host}${getPath(product)}`,
+      url: `${url.origin}${getPath(product)}`,
       name: product.title,
       additionalProperty: [
         ...product.tags?.map((value) =>


### PR DESCRIPTION
if we use url.host, the url is constructed without the protocol, e.g. `localhost:8000/...` When using url.origin, the url is built with the protocol, e.g: `http://localhost:8000/...`