### PR TITLE
[VTEX] 'fuzzy' property added in productList loader

### DIFF
--- a/vtex/loaders/intelligentSearch/productList.ts
+++ b/vtex/loaders/intelligentSearch/productList.ts
@@ -10,6 +10,10 @@ import { getSegmentFromBag, withSegmentCookie } from "../../utils/segment.ts";
 import { withIsSimilarTo } from "../../utils/similars.ts";
 import { toProduct } from "../../utils/transform.ts";
 import type { ProductID, Sort } from "../../utils/types.ts";
+import {
+  LabelledFuzzy,
+  mapLabelledFuzzyToFuzzy,
+} from "./productListingPage.ts";
 
 export interface CollectionProps extends CommonProps {
   // TODO: pattern property isn't being handled by RJSF
@@ -42,6 +46,11 @@ export interface QueryProps extends CommonProps {
    * @examples 1\n2
    */
   count: number;
+
+  /**
+   * @title Fuzzy
+   */
+  fuzzy?: LabelledFuzzy;
 }
 
 export interface ProductIDProps extends CommonProps {
@@ -92,6 +101,7 @@ const fromProps = ({ props }: Props) => {
       query: props.query || "",
       count: props.count || 12,
       sort: props.sort || "",
+      fuzzy: mapLabelledFuzzyToFuzzy(props.fuzzy),
       selectedFacets: [],
       hideUnavailableItems: props.hideUnavailableItems,
     } as const;

--- a/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -66,7 +66,7 @@ const LEGACY_TO_IS: Record<string, Sort> = {
   OrderByBestDiscountDESC: "discount:desc",
 };
 
-const mapLabelledFuzzyToFuzzy = (
+export const mapLabelledFuzzyToFuzzy = (
   labelledFuzzy?: LabelledFuzzy,
 ): Fuzzy | undefined => {
   switch (labelledFuzzy) {


### PR DESCRIPTION
The changes in this PR brings fuzzy as a property of `productList` loader.

Currenty, `productList` loader [adds `fuzzy=auto` in search params](https://github.com/deco-cx/apps/blob/ae6207d086c29b2dad27b776a6ae78213dcb0b8e/vtex/loaders/intelligentSearch/productList.ts#L130), which in some cases, brings an wrong result.

`fuzzy=auto`
![image](https://github.com/deco-cx/apps/assets/23545318/59524dc4-6982-4f99-a36c-a5bface3d7ce)

`fuzzy=0`
![image](https://github.com/deco-cx/apps/assets/23545318/399f5c30-302c-43d6-bcb6-89af8eb8ee6e)