### PR TITLE
[Shopify] - Fix stock filter

### DIFF
--- a/shopify/loaders/ProductListingPage.ts
+++ b/shopify/loaders/ProductListingPage.ts
@@ -113,7 +113,6 @@ const loader = async (
 
       shopifyProducts = data.collection?.products;
       shopifyFilters = data.collection?.products?.filters;
-      console.log(data.collection);
       hasNextPage = Boolean(
         data?.collection?.products.pageInfo.hasNextPage ?? false,
       );

--- a/shopify/utils/utils.ts
+++ b/shopify/utils/utils.ts
@@ -131,7 +131,7 @@ export const getFiltersByUrl = (url: URL) => {
     } else if (key.startsWith("filter.p.vendor")) {
       filters.push({ productVendor: value });
     } else if (key.startsWith("filter.v.availability")) {
-      filters.push({ available: value === "In Stock" });
+      filters.push({ available: value.toLowerCase() === "in stock" });
     } else if (key.startsWith("filter.v.price.gte")) {
       filters.push({ price: { min: Number(value) } });
     } else if (key.startsWith("filter.v.price.lte")) {


### PR DESCRIPTION
The current stock filter checks the "In stock" parameter value in the URL, but I can receive "In stock" for example, this PR fixes this by making the parameter value lowercase to avoid edge cases.

![image](https://github.com/deco-cx/apps/assets/32278696/b558b98e-1c2b-48de-a8ea-5756d18ff67b)
 