### PR TITLE
[VNDA] - Add search by type_tags in ProductList loader

### DIFF
--- a/vnda/loaders/productList.ts
+++ b/vnda/loaders/productList.ts
@@ -19,6 +19,9 @@ export interface Props {
   /** @description search for products that have certain tag */
   tags?: string[];
 
+  /** @description search for products that have certain type_tag */
+  type_tags?: { key?: string; value?: string }[] | undefined;
+
   /** @description search for products by id */
   ids: number[];
 }
@@ -42,6 +45,7 @@ const productListLoader = async (
       sort: props?.sort,
       per_page: props?.count,
       "tags[]": props?.tags,
+      "type_tags[]": props?.type_tags?.map(tag => ({ key: tag.key, value: tag.value })),
       "ids[]": props?.ids,
     }, STALE).then((res) => res.json());
 

--- a/vnda/loaders/productList.ts
+++ b/vnda/loaders/productList.ts
@@ -45,7 +45,10 @@ const productListLoader = async (
       sort: props?.sort,
       per_page: props?.count,
       "tags[]": props?.tags,
-      "type_tags[]": props?.type_tags?.map(tag => ({ key: tag.key, value: tag.value })),
+      "type_tags[]": props?.type_tags?.map((tag) => ({
+        key: tag.key,
+        value: tag.value,
+      })),
       "ids[]": props?.ids,
     }, STALE).then((res) => res.json());
 

--- a/vnda/utils/openapi/vnda.openapi.gen.ts
+++ b/vnda/utils/openapi/vnda.openapi.gen.ts
@@ -1388,9 +1388,7 @@ wildcard?: boolean
 /**
  * Filtra pelo nome da tag dentro de um tipo de tag. Exemplo, type_tags[cor]=verde
  */
-type_tags?: {
-
-}
+"type_tags[]"?: { key?: string; value?: string }[]
 /**
  * Operador lógico para o filtro de tag
  */


### PR DESCRIPTION
**Description:**

This pull request adds the ability to search for products using `type_tags` in the ProductList loader on pair with VNDA API. Users can now filter products based on specific tags, enhancing the experience.

**Changes Made:**
- Added support for the `type_tags` parameter in the ProductList loader.
- Implemented mapping and formatting of `type_tags` in the request.

**Additional Information:**
- This feature aligns with the goal of improving search capabilities, providing users with more flexibility in product searches, and it was a feature required to move on with a internal project to add color variation in the ProductCard.

**Code Highlight:**

```TypeScript
type_tags?: { key?: string; value?: string }[] | undefined
```

```TypeScript
"type_tags[]": props?.type_tags?.map((tag) => ({
        key: tag.key,
        value: tag.value,
      })),
```