### PR TITLE
fix remove senseless props from app site

### DIFF
--- a/decohub/manifest.gen.ts
+++ b/decohub/manifest.gen.ts
@@ -11,39 +11,39 @@ import * as $$$$$$$$$$$5 from "./apps/workflows.ts";
 import * as $$$$$$$$$$$6 from "./apps/implementation.ts";
 import * as $$$$$$$$$$$7 from "./apps/vnda.ts";
 import * as $$$$$$$$$$$8 from "./apps/algolia.ts";
-import * as $$$$$$$$$$$10 from "./apps/nuvemshop.ts";
-import * as $$$$$$$$$$$11 from "./apps/linx.ts";
-import * as $$$$$$$$$$$12 from "./apps/vtex.ts";
-import * as $$$$$$$$$$$13 from "./apps/weather.ts";
-import * as $$$$$$$$$$$14 from "./apps/brand-assistant.ts";
-import * as $$$$$$$$$$$15 from "./apps/sourei.ts";
-import * as $$$$$$$$$$$16 from "./apps/shopify.ts";
-import * as $$$$$$$$$$$17 from "./apps/handlebars.ts";
-import * as $$$$$$$$$$$18 from "./apps/verified-reviews.ts";
-import * as $$$$$$$$$$$19 from "./apps/files.ts";
-import * as $$$$$$$$$$$20 from "./apps/power-reviews.ts";
+import * as $$$$$$$$$$$9 from "./apps/nuvemshop.ts";
+import * as $$$$$$$$$$$10 from "./apps/linx.ts";
+import * as $$$$$$$$$$$11 from "./apps/vtex.ts";
+import * as $$$$$$$$$$$12 from "./apps/weather.ts";
+import * as $$$$$$$$$$$13 from "./apps/brand-assistant.ts";
+import * as $$$$$$$$$$$14 from "./apps/sourei.ts";
+import * as $$$$$$$$$$$15 from "./apps/shopify.ts";
+import * as $$$$$$$$$$$16 from "./apps/handlebars.ts";
+import * as $$$$$$$$$$$17 from "./apps/verified-reviews.ts";
+import * as $$$$$$$$$$$18 from "./apps/files.ts";
+import * as $$$$$$$$$$$19 from "./apps/power-reviews.ts";
 
 const manifest = {
   "apps": {
     "decohub/apps/ai-assistants.ts": $$$$$$$$$$$3,
     "decohub/apps/algolia.ts": $$$$$$$$$$$8,
     "decohub/apps/analytics.ts": $$$$$$$$$$$4,
-    "decohub/apps/brand-assistant.ts": $$$$$$$$$$$14,
+    "decohub/apps/brand-assistant.ts": $$$$$$$$$$$13,
     "decohub/apps/crux.ts": $$$$$$$$$$$2,
-    "decohub/apps/files.ts": $$$$$$$$$$$19,
-    "decohub/apps/handlebars.ts": $$$$$$$$$$$17,
+    "decohub/apps/files.ts": $$$$$$$$$$$18,
+    "decohub/apps/handlebars.ts": $$$$$$$$$$$16,
     "decohub/apps/implementation.ts": $$$$$$$$$$$6,
-    "decohub/apps/linx.ts": $$$$$$$$$$$11,
-    "decohub/apps/nuvemshop.ts": $$$$$$$$$$$10,
-    "decohub/apps/power-reviews.ts": $$$$$$$$$$$20,
-    "decohub/apps/shopify.ts": $$$$$$$$$$$16,
-    "decohub/apps/sourei.ts": $$$$$$$$$$$15,
+    "decohub/apps/linx.ts": $$$$$$$$$$$10,
+    "decohub/apps/nuvemshop.ts": $$$$$$$$$$$9,
+    "decohub/apps/power-reviews.ts": $$$$$$$$$$$19,
+    "decohub/apps/shopify.ts": $$$$$$$$$$$15,
+    "decohub/apps/sourei.ts": $$$$$$$$$$$14,
     "decohub/apps/typesense.ts": $$$$$$$$$$$0,
-    "decohub/apps/verified-reviews.ts": $$$$$$$$$$$18,
+    "decohub/apps/verified-reviews.ts": $$$$$$$$$$$17,
     "decohub/apps/vnda.ts": $$$$$$$$$$$7,
-    "decohub/apps/vtex.ts": $$$$$$$$$$$12,
+    "decohub/apps/vtex.ts": $$$$$$$$$$$11,
     "decohub/apps/wake.ts": $$$$$$$$$$$1,
-    "decohub/apps/weather.ts": $$$$$$$$$$$13,
+    "decohub/apps/weather.ts": $$$$$$$$$$$12,
     "decohub/apps/workflows.ts": $$$$$$$$$$$5,
   },
   "name": "decohub",

--- a/website/mod.ts
+++ b/website/mod.ts
@@ -41,7 +41,7 @@ export interface Props {
   routes?: Routes[];
 
   /** @title Seo */
-  seo?: Omit<Seo, "jsonLDs">;
+  seo?: Omit<Seo, "jsonLDs" | "titleTemplate" | "descriptionTemplate" | "canonical">;
 
   /**
    * @title Global Sections


### PR DESCRIPTION
A lot of stores were having problem with canonical, when you fill canonical at app "site", it overlaps other ones, affecting PDPs and PLPs.

In general, I do not think that canonical make senses in app "site".

Enjoying the movement, i am removing titleTemplate and descriptionTemplate from app "site", because both not receive any data to replace.
