### PR TITLE
Legacy autocomplete gives error if there is a space in the search

### DIFF
--- a/vtex/loaders/legacy/suggestions.ts
+++ b/vtex/loaders/legacy/suggestions.ts
@@ -31,7 +31,7 @@ const loaders = async (
 
   const suggestions = await vcsDeprecated["GET /buscaautocomplete"]({
     maxRows: count,
-    productNameContains: query,
+    productNameContains: encodeURIComponent(query ?? ""),
     suggestionsStack: "",
   }, {
     // Not adding suggestions to cache since queries are very spread out

--- a/vtex/utils/fetchVTEX.ts
+++ b/vtex/utils/fetchVTEX.ts
@@ -60,6 +60,15 @@ const getSanitizedInput = (
     }
   });
 
+  const productNameContains = url.searchParams.get("productNameContains");
+
+  if (productNameContains) {
+    return url.toString().replace(
+      /productNameContains=([^&#]*)/,
+      `productNameContains=${encodeURIComponent(productNameContains)}`,
+    );
+  }
+
   return url.toString();
 };
 

--- a/vtex/utils/fetchVTEX.ts
+++ b/vtex/utils/fetchVTEX.ts
@@ -60,15 +60,6 @@ const getSanitizedInput = (
     }
   });
 
-  const productNameContains = url.searchParams.get("productNameContains");
-
-  if (productNameContains) {
-    return url.toString().replace(
-      /productNameContains=([^&#]*)/,
-      `productNameContains=${encodeURIComponent(productNameContains)}`,
-    );
-  }
-
   return url.toString();
 };
 


### PR DESCRIPTION
Entre aqui https://www.miess.com.br/ e veja a aba de network, agora na busca procure por cueca, funciona, agora se adicionar um espaço, dá 400

Isso acontece porque o espaço da url vira "+", e a api do legado não entende isso
https://www.miess.com.br/buscaautocomplete/?maxRows=12&productNameContains=cueca+&suggestionsStack=

Mas quando você troca o "+" por "%20", a busca funciona normalmente
https://www.miess.com.br/buscaautocomplete/?maxRows=12&productNameContains=cueca%20&suggestionsStack=

Por algum motivo quando "cueca " é adicionado aqui https://github.com/deco-cx/apps/blob/main/utils/http.ts#L136, o espaço vira "+" em vez de "%20"

Então eu substituo manualmente esse parâmetro encodando ele, em vez de usar o searchParams 