### PR TITLE
Add prop to always show all filters

### DIFF
--- a/vtex/loaders/legacy/productListingPage.ts
+++ b/vtex/loaders/legacy/productListingPage.ts
@@ -310,16 +310,13 @@ const loader = async (
     .filter((x): x is Filter => Boolean(x))
     // Sort category name by position of api facets
     // because order is not preserved by object
-    .sort((a, b) => {
-      const aIndex = (vtexFacets.CategoriesTrees as LegacyFacet[]).findIndex(
-        ({ Name }) => a.label.localeCompare(Name),
+    .toSorted((a, b) => {
+      const aIndex = vtexFacets.Departments.findIndex((x) =>
+        x.Name === a.label
       );
-      const bIndex = (vtexFacets.CategoriesTrees as LegacyFacet[]).findIndex(
-        ({ Name }) => b.label.localeCompare(Name),
+      const bIndex = vtexFacets.Departments.findIndex((x) =>
+        x.Name === b.label
       );
-
-      if (aIndex === -1) return 0;
-      if (bIndex === -1) return 0;
 
       return aIndex - bIndex;
     });


### PR DESCRIPTION
Quando estou numa página de busca, por exemplo https://www.miess.com.br/cueca, existem outros filtros além de categoria, departamento etc…

Porém a deco não retornava todos os filtros, por isso adicionei uma prop para sempre mostrar todos os filtros

Antes
![image](https://github.com/deco-cx/apps/assets/66072698/59251e8e-0da1-4a9f-8708-b104da00525d)
Depois
![image](https://github.com/deco-cx/apps/assets/66072698/0403d2cc-9e90-4e8f-a032-1db6e2c52bdc)
