### PR TITLE
change plausible pageview to manual at proxy

### DIFF
--- a/analytics/components/DecoAnalytics.tsx
+++ b/analytics/components/DecoAnalytics.tsx
@@ -43,6 +43,7 @@ const snippet = () => {
   // setup plausible script and unsubscribe
   globalThis.window.DECO.events.subscribe((event) => {
     if (!event || event.name !== "deco") return;
+
     if (event.params) {
       const { flags, page } = event.params;
       if (Array.isArray(flags)) {
@@ -62,6 +63,7 @@ const snippet = () => {
     const { name, params } = event;
 
     if (!name || !params || name === "deco") return;
+
     const values = { ...props };
     for (const key in params) {
       // @ts-expect-error somehow typescript bugs

--- a/analytics/components/DecoAnalytics.tsx
+++ b/analytics/components/DecoAnalytics.tsx
@@ -43,7 +43,7 @@ const snippet = () => {
   // setup plausible script and unsubscribe
   globalThis.window.DECO.events.subscribe((event) => {
     if (!event || event.name !== "deco") return;
-
+  
     if (event.params) {
       const { flags, page } = event.params;
       if (Array.isArray(flags)) {
@@ -63,7 +63,7 @@ const snippet = () => {
     const { name, params } = event;
 
     if (!name || !params || name === "deco") return;
-
+    console.log("deco event", event)
     const values = { ...props };
     for (const key in params) {
       // @ts-expect-error somehow typescript bugs

--- a/analytics/components/DecoAnalytics.tsx
+++ b/analytics/components/DecoAnalytics.tsx
@@ -43,7 +43,6 @@ const snippet = () => {
   // setup plausible script and unsubscribe
   globalThis.window.DECO.events.subscribe((event) => {
     if (!event || event.name !== "deco") return;
-  
     if (event.params) {
       const { flags, page } = event.params;
       if (Array.isArray(flags)) {
@@ -63,7 +62,6 @@ const snippet = () => {
     const { name, params } = event;
 
     if (!name || !params || name === "deco") return;
-    console.log("deco event", event)
     const values = { ...props };
     for (const key in params) {
       // @ts-expect-error somehow typescript bugs

--- a/analytics/loaders/DecoAnalyticsScript.ts
+++ b/analytics/loaders/DecoAnalyticsScript.ts
@@ -55,7 +55,7 @@ const loader = (
       props.defer ? "defer" : ""
     } data-exclude="/proxy" ${
       props.domain ? "data-domain=" + props.domain : ""
-    } data-api="https://plausible.io/api/event" src="https://plausible.io/js/script.manual.local.js"></script>`;
+    } data-api="https://plausible.io/api/event" src="https://plausible.io/js/script.manual.js"></script>`;
 
     const flagsScript = `<script defer src="${
       scriptAsDataURI(snippet, flags)

--- a/analytics/loaders/DecoAnalyticsScript.ts
+++ b/analytics/loaders/DecoAnalyticsScript.ts
@@ -18,8 +18,8 @@ declare global {
 }
 
 const snippet = (flags: Record<string, string | boolean>) => {
-
-  const trackPageview = () => globalThis.window.plausible("pageview", { props : flags });
+  const trackPageview = () =>
+    globalThis.window.plausible("pageview", { props: flags });
 
   // First load
   trackPageview();
@@ -34,7 +34,7 @@ const snippet = (flags: Record<string, string | boolean>) => {
     };
     addEventListener("popstate", trackPageview);
   }
-}
+};
 
 const loader = (
   props: Props,
@@ -48,8 +48,8 @@ const loader = (
       '<link rel="preconnect" href="https://plausible.io/api/event" crossorigin="anonymous" />';
 
     const _flags = getFlagsFromCookies(req);
-    const flags: Record<string, string | boolean> = {}
-    _flags.forEach((flag) => flags[flag.flagName] = flag.flagActive)
+    const flags: Record<string, string | boolean> = {};
+    _flags.forEach((flag) => flags[flag.flagName] = flag.flagActive);
 
     const plausibleScript = `<script ${
       props.defer ? "defer" : ""
@@ -57,7 +57,9 @@ const loader = (
       props.domain ? "data-domain=" + props.domain : ""
     } data-api="https://plausible.io/api/event" src="https://plausible.io/js/script.manual.local.js"></script>`;
 
-    const flagsScript = `<script defer src="${scriptAsDataURI(snippet, flags)}"></script>`;
+    const flagsScript = `<script defer src="${
+      scriptAsDataURI(snippet, flags)
+    }"></script>`;
 
     return dnsPrefetchLink + preconnectLink + plausibleScript + flagsScript;
   };

--- a/website/components/Events.tsx
+++ b/website/components/Events.tsx
@@ -37,7 +37,7 @@ const snippet = ({ flags, page }: Deco) => {
       const ck = cookies[i].trim();
 
       if (ck.startsWith("deco_matcher_")) {
-        const name = atob(ck.slice(ck.indexOf("=") + 1, ck.indexOf("@")));
+        const name = atob(ck.slice(ck.lastIndexOf("=") + 1, ck.indexOf("@")));
         const value = ck.at(-1) === "1" ? true : false;
 
         if (knownFlags.has(name)) continue;


### PR DESCRIPTION
Today, we send events using html attributes, <script event-select-promotion="true"/>

We got a problem, because our matcher events could be "Product Page@..." and them, the problem:

``<script event-product page@something="true"``

I started to change to manual event, but it is necessary to do the logic to get historystate updates like push or replace, and popstate listener too.