### PR TITLE
flat categories to some type of pagetypes

### DIFF
--- a/vtex/loaders/legacy/productListingPage.ts
+++ b/vtex/loaders/legacy/productListingPage.ts
@@ -190,7 +190,7 @@ const loader = async (
 
   const pageTypes = await pageTypesFromPathname(maybeTerm, ctx);
   const pageType = pageTypes.at(-1) || pageTypes[0];
-
+  console.log(pageType)
   const missingParams = typeof maybeMap !== "string" || !maybeTerm;
   const [map, term] = missingParams && fq.length > 0
     ? ["", ""]

--- a/vtex/loaders/legacy/productListingPage.ts
+++ b/vtex/loaders/legacy/productListingPage.ts
@@ -190,7 +190,7 @@ const loader = async (
 
   const pageTypes = await pageTypesFromPathname(maybeTerm, ctx);
   const pageType = pageTypes.at(-1) || pageTypes[0];
-  console.log(pageType)
+  console.log(pageType);
   const missingParams = typeof maybeMap !== "string" || !maybeTerm;
   const [map, term] = missingParams && fq.length > 0
     ? ["", ""]

--- a/vtex/loaders/legacy/productListingPage.ts
+++ b/vtex/loaders/legacy/productListingPage.ts
@@ -190,7 +190,7 @@ const loader = async (
 
   const pageTypes = await pageTypesFromPathname(maybeTerm, ctx);
   const pageType = pageTypes.at(-1) || pageTypes[0];
-  console.log(pageType);
+
   const missingParams = typeof maybeMap !== "string" || !maybeTerm;
   const [map, term] = missingParams && fq.length > 0
     ? ["", ""]

--- a/vtex/loaders/legacy/productListingPage.ts
+++ b/vtex/loaders/legacy/productListingPage.ts
@@ -264,10 +264,17 @@ const loader = async (
       ),
   );
 
+  const getFlatCategories = (CategoriesTrees: LegacyFacet[]): Record<string, LegacyFacet[]> => {
+    const flatCategories : Record<string, LegacyFacet[]> = {}
+    
+    CategoriesTrees.forEach((category) => (flatCategories[category.Name] = category.Children || []));
+
+    return flatCategories
+  }
+
   // Get categories of the current department/category
-  const getCategoryFacets = (CategoriesTrees: LegacyFacet[]): LegacyFacet[] => {
-    const isDepartmentOrCategoryPage = !pageType;
-    if (isDepartmentOrCategoryPage) {
+  const getCategoryFacets = (CategoriesTrees: LegacyFacet[], isDepartmentOrCategoryPage: boolean): LegacyFacet[] => {
+    if (!isDepartmentOrCategoryPage) {
       return [];
     }
 
@@ -276,7 +283,7 @@ const loader = async (
       if (isCurrentCategory) {
         return category.Children || [];
       } else if (category.Children.length) {
-        const childFacets = getCategoryFacets(category.Children);
+        const childFacets = getCategoryFacets(category.Children, isDepartmentOrCategoryPage);
         const hasChildFacets = childFacets.length;
         if (hasChildFacets) {
           return childFacets;
@@ -286,13 +293,20 @@ const loader = async (
 
     return [];
   };
+  
+  const isDepartmentOrCategoryPage = pageType.pageType === "Department" || pageType.pageType === "Category";
+
+  // at search, collection and brand pages, the products are not of a specific category
+  // so we need to get the categories from the facets
+  const flatCategories = !isDepartmentOrCategoryPage ? getFlatCategories(vtexFacets.CategoriesTrees) : {};
 
   const filters = Object.entries({
     Departments: vtexFacets.Departments,
-    Categories: getCategoryFacets(vtexFacets.CategoriesTrees),
+    Categories: getCategoryFacets(vtexFacets.CategoriesTrees, isDepartmentOrCategoryPage),
     Brands: vtexFacets.Brands,
     ...vtexFacets.SpecificationFilters,
     PriceRanges: vtexFacets.PriceRanges,
+    ...flatCategories
   })
     .map(([name, facets]) =>
       legacyFacetToFilter(name, facets, url, map, term, filtersBehavior)

--- a/vtex/loaders/legacy/productListingPage.ts
+++ b/vtex/loaders/legacy/productListingPage.ts
@@ -305,7 +305,7 @@ const loader = async (
   };
 
   const isDepartmentOrCategoryPage = pageType.pageType === "Department" ||
-    pageType.pageType === "Category";
+    pageType.pageType === "Category" || pageType.pageType === "SubCategory";
 
   // at search, collection and brand pages, the products are not of a specific category
   // so we need to get the categories from the facets

--- a/vtex/loaders/legacy/productListingPage.ts
+++ b/vtex/loaders/legacy/productListingPage.ts
@@ -264,16 +264,23 @@ const loader = async (
       ),
   );
 
-  const getFlatCategories = (CategoriesTrees: LegacyFacet[]): Record<string, LegacyFacet[]> => {
-    const flatCategories : Record<string, LegacyFacet[]> = {}
-    
-    CategoriesTrees.forEach((category) => (flatCategories[category.Name] = category.Children || []));
+  const getFlatCategories = (
+    CategoriesTrees: LegacyFacet[],
+  ): Record<string, LegacyFacet[]> => {
+    const flatCategories: Record<string, LegacyFacet[]> = {};
 
-    return flatCategories
-  }
+    CategoriesTrees.forEach((
+      category,
+    ) => (flatCategories[category.Name] = category.Children || []));
+
+    return flatCategories;
+  };
 
   // Get categories of the current department/category
-  const getCategoryFacets = (CategoriesTrees: LegacyFacet[], isDepartmentOrCategoryPage: boolean): LegacyFacet[] => {
+  const getCategoryFacets = (
+    CategoriesTrees: LegacyFacet[],
+    isDepartmentOrCategoryPage: boolean,
+  ): LegacyFacet[] => {
     if (!isDepartmentOrCategoryPage) {
       return [];
     }
@@ -283,7 +290,10 @@ const loader = async (
       if (isCurrentCategory) {
         return category.Children || [];
       } else if (category.Children.length) {
-        const childFacets = getCategoryFacets(category.Children, isDepartmentOrCategoryPage);
+        const childFacets = getCategoryFacets(
+          category.Children,
+          isDepartmentOrCategoryPage,
+        );
         const hasChildFacets = childFacets.length;
         if (hasChildFacets) {
           return childFacets;
@@ -293,20 +303,26 @@ const loader = async (
 
     return [];
   };
-  
-  const isDepartmentOrCategoryPage = pageType.pageType === "Department" || pageType.pageType === "Category";
+
+  const isDepartmentOrCategoryPage = pageType.pageType === "Department" ||
+    pageType.pageType === "Category";
 
   // at search, collection and brand pages, the products are not of a specific category
   // so we need to get the categories from the facets
-  const flatCategories = !isDepartmentOrCategoryPage ? getFlatCategories(vtexFacets.CategoriesTrees) : {};
+  const flatCategories = !isDepartmentOrCategoryPage
+    ? getFlatCategories(vtexFacets.CategoriesTrees)
+    : {};
 
   const filters = Object.entries({
     Departments: vtexFacets.Departments,
-    Categories: getCategoryFacets(vtexFacets.CategoriesTrees, isDepartmentOrCategoryPage),
+    Categories: getCategoryFacets(
+      vtexFacets.CategoriesTrees,
+      isDepartmentOrCategoryPage,
+    ),
     Brands: vtexFacets.Brands,
     ...vtexFacets.SpecificationFilters,
     PriceRanges: vtexFacets.PriceRanges,
-    ...flatCategories
+    ...flatCategories,
   })
     .map(([name, facets]) =>
       legacyFacetToFilter(name, facets, url, map, term, filtersBehavior)

--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -598,7 +598,6 @@ export const legacyFacetToFilter = (
 
   const getLink = (facet: LegacyFacet, selected: boolean) => {
     const index = pathSegments.findIndex((s) => s === facet.Value);
-
     const newMap = selected
       ? [...mapSegments.filter((_, i) => i !== index)]
       : [...mapSegments, facet.Map];
@@ -609,21 +608,21 @@ export const legacyFacetToFilter = (
     // Insertion-sort like algorithm. Uses the c-continuum theorem
     const zipped: [string, string][] = [];
     for (let it = 0; it < newMap.length; it++) {
-        let i = 0;
-        if (newMap[it] === "productClusterIds") {
-            // If it's "productClusterIds", insert at the beginning, before all others
-            zipped.splice(i, 0, [newMap[it], newPath[it]]);
-        } else {
-            // Find the correct position for elements that are not "productClusterIds"
-            while (i < zipped.length && zipped[i][0] === "productClusterIds") {
-                i++; // Skip all "productClusterIds" to maintain their priority
-            }
-            // Now, find the position for inserting, considering 'c' or 'C'
-            while (i < zipped.length && (zipped[i][0].toLowerCase() === "c")) {
-                i++; // Skip elements starting with 'c' or 'C', which have lower priority than "productClusterIds"
-            }
-            zipped.splice(i, 0, [newMap[it], newPath[it]]);
+      let i = 0;
+      if (newMap[it] === "productClusterIds") {
+        // If it's "productClusterIds", insert at the beginning, before all others
+        zipped.splice(i, 0, [newMap[it], newPath[it]]);
+      } else {
+        // Find the correct position for elements that are not "productClusterIds"
+        while (i < zipped.length && zipped[i][0] === "productClusterIds") {
+          i++; // Skip all "productClusterIds" to maintain their priority
         }
+        // Now, find the position for inserting, considering 'c' or 'C'
+        while (i < zipped.length && (zipped[i][0].toLowerCase() === "c")) {
+          i++; // Skip elements starting with 'c' or 'C', which have lower priority than "productClusterIds"
+        }
+        zipped.splice(i, 0, [newMap[it], newPath[it]]);
+      }
     }
 
     const link = new URL(`/${zipped.map(([, s]) => s).join("/")}`, url);

--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -601,7 +601,7 @@ export const legacyFacetToFilter = (
   // category2/123?map=c,productClusterIds -> DO NOT WORK
   // category1/category2/123?map=c,c,productClusterIds -> WORK
   const hasProductClusterIds = mapSegments.includes("productClusterIds");
-  const hasToBeFullpath = hasProductClusterIds || mapSegments.includes("ft");
+  const hasToBeFullpath = hasProductClusterIds || mapSegments.includes("ft") || mapSegments.includes("b");
 
   const getLink = (facet: LegacyFacet, selected: boolean) => {
     const index = pathSegments.findIndex((s) => s === facet.Value);

--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -600,15 +600,20 @@ export const legacyFacetToFilter = (
   // example: 
   // category2/123?map=c,productClusterIds -> DO NOT WORK
   // category1/category2/123?map=c,c,productClusterIds -> WORK
-  const hasToBeFullpath = mapSegments.includes("productClusterIds")
+  const hasProductClusterIds = mapSegments.includes("productClusterIds")
+  const hasToBeFullpath = hasProductClusterIds || mapSegments.includes("ft")
 
   const getLink = (facet: LegacyFacet, selected: boolean) => {
     const index = pathSegments.findIndex((s) => s === facet.Value);
 
     const map = hasToBeFullpath ? facet.Link.split("map=")[1].split(",") : [facet.Map]
     const value = hasToBeFullpath ? facet.Link.split("?")[0].slice(1).split("/") : [facet.Value]
-    const _mapSegments = hasToBeFullpath ? ["productClusterIds"] : mapSegments
-    const _pathSegments = hasToBeFullpath ? [pathSegments[mapSegments.indexOf("productClusterIds")]] : pathSegments
+
+    const pathSegmentsFiltered = hasProductClusterIds ? [pathSegments[mapSegments.indexOf("productClusterIds")]] : []
+    const mapSegmentsFiltered = hasProductClusterIds ? ["productClusterIds"] : []
+
+    const _mapSegments = hasToBeFullpath ? mapSegmentsFiltered : mapSegments
+    const _pathSegments = hasToBeFullpath ? pathSegmentsFiltered : pathSegments
 
     const newMap = selected
       ? [...mapSegments.filter((_, i) => i !== index)]
@@ -640,6 +645,7 @@ export const legacyFacetToFilter = (
 
     return `${link.pathname}${link.search}`;
   };
+
   return {
     "@type": "FilterToggle",
     quantity: facets?.length,

--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -597,23 +597,31 @@ export const legacyFacetToFilter = (
   const pathSet = new Set(pathSegments);
 
   // for productClusterIds, we have to use the full path
-  // example: 
+  // example:
   // category2/123?map=c,productClusterIds -> DO NOT WORK
   // category1/category2/123?map=c,c,productClusterIds -> WORK
-  const hasProductClusterIds = mapSegments.includes("productClusterIds")
-  const hasToBeFullpath = hasProductClusterIds || mapSegments.includes("ft")
+  const hasProductClusterIds = mapSegments.includes("productClusterIds");
+  const hasToBeFullpath = hasProductClusterIds || mapSegments.includes("ft");
 
   const getLink = (facet: LegacyFacet, selected: boolean) => {
     const index = pathSegments.findIndex((s) => s === facet.Value);
 
-    const map = hasToBeFullpath ? facet.Link.split("map=")[1].split(",") : [facet.Map]
-    const value = hasToBeFullpath ? facet.Link.split("?")[0].slice(1).split("/") : [facet.Value]
+    const map = hasToBeFullpath
+      ? facet.Link.split("map=")[1].split(",")
+      : [facet.Map];
+    const value = hasToBeFullpath
+      ? facet.Link.split("?")[0].slice(1).split("/")
+      : [facet.Value];
 
-    const pathSegmentsFiltered = hasProductClusterIds ? [pathSegments[mapSegments.indexOf("productClusterIds")]] : []
-    const mapSegmentsFiltered = hasProductClusterIds ? ["productClusterIds"] : []
+    const pathSegmentsFiltered = hasProductClusterIds
+      ? [pathSegments[mapSegments.indexOf("productClusterIds")]]
+      : [];
+    const mapSegmentsFiltered = hasProductClusterIds
+      ? ["productClusterIds"]
+      : [];
 
-    const _mapSegments = hasToBeFullpath ? mapSegmentsFiltered : mapSegments
-    const _pathSegments = hasToBeFullpath ? pathSegmentsFiltered : pathSegments
+    const _mapSegments = hasToBeFullpath ? mapSegmentsFiltered : mapSegments;
+    const _pathSegments = hasToBeFullpath ? pathSegmentsFiltered : pathSegments;
 
     const newMap = selected
       ? [...mapSegments.filter((_, i) => i !== index)]

--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -596,19 +596,19 @@ export const legacyFacetToFilter = (
   const mapSet = new Set(mapSegments);
   const pathSet = new Set(pathSegments);
 
+  // for productClusterIds, we have to use the full path
+  // example: 
+  // category2/123?map=c,productClusterIds -> DO NOT WORK
+  // category1/category2/123?map=c,c,productClusterIds -> WORK
+  const hasToBeFullpath = mapSegments.includes("productClusterIds")
+
   const getLink = (facet: LegacyFacet, selected: boolean) => {
     const index = pathSegments.findIndex((s) => s === facet.Value);
 
-    // for productClusterIds, we have to use the full path
-    // example: 
-    // category2/123?map=c,productClusterIds -> DO NOT WORK
-    // category1/category2/123?map=c,c,productClusterIds -> WORK
-    const haveToBeFullpath = mapSegments.includes("productClusterIds")
-
-    const map = haveToBeFullpath ? facet.Link.split("map=")[1].split(",") : [facet.Map]
-    const value = haveToBeFullpath ? facet.Link.split("?")[0].slice(1).split("/") : [facet.Value]
-    const _mapSegments = haveToBeFullpath ? ["productClusterIds"] : mapSegments
-    const _pathSegments = haveToBeFullpath ? [pathSegments[mapSegments.indexOf("productClusterIds")]] : pathSegments
+    const map = hasToBeFullpath ? facet.Link.split("map=")[1].split(",") : [facet.Map]
+    const value = hasToBeFullpath ? facet.Link.split("?")[0].slice(1).split("/") : [facet.Value]
+    const _mapSegments = hasToBeFullpath ? ["productClusterIds"] : mapSegments
+    const _pathSegments = hasToBeFullpath ? [pathSegments[mapSegments.indexOf("productClusterIds")]] : pathSegments
 
     const newMap = selected
       ? [...mapSegments.filter((_, i) => i !== index)]

--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -599,39 +599,37 @@ export const legacyFacetToFilter = (
   const getLink = (facet: LegacyFacet, selected: boolean) => {
     const index = pathSegments.findIndex((s) => s === facet.Value);
 
-    // for productClusterIds, we have to use the full path
-    // example: 
-    // category2/123?map=c,productClusterIds -> DO NOT WORK
-    // category1/category2/123?map=c,c,productClusterIds -> WORK
-    const haveToBeFullpath = mapSegments.includes("productClusterIds")
-
-    const map = haveToBeFullpath ? facet.Link.split("map=")[1].split(",") : [facet.Map]
-    const value = haveToBeFullpath ? facet.Link.split("?")[0].slice(1).split("/") : [facet.Value]
-    const _mapSegments = haveToBeFullpath ? ["productClusterIds"] : mapSegments
-    const _pathSegments = haveToBeFullpath ? [pathSegments[mapSegments.indexOf("productClusterIds")]] : pathSegments
-    
     const newMap = selected
       ? [...mapSegments.filter((_, i) => i !== index)]
-      : [..._mapSegments, ...map];
+      : [...mapSegments, facet.Map];
     const newPath = selected
       ? [...pathSegments.filter((_, i) => i !== index)]
-      : [..._pathSegments, ...value];
+      : [...pathSegments, facet.Value];
 
     // Insertion-sort like algorithm. Uses the c-continuum theorem
     const zipped: [string, string][] = [];
     for (let it = 0; it < newMap.length; it++) {
-      let i = 0;
-      while (
-        i < zipped.length && (zipped[i][0] === "c" || zipped[i][0] === "C")
-      ) i++;
-
-      zipped.splice(i, 0, [newMap[it], newPath[it]]);
+        let i = 0;
+        if (newMap[it] === "productClusterIds") {
+            // If it's "productClusterIds", insert at the beginning, before all others
+            zipped.splice(i, 0, [newMap[it], newPath[it]]);
+        } else {
+            // Find the correct position for elements that are not "productClusterIds"
+            while (i < zipped.length && zipped[i][0] === "productClusterIds") {
+                i++; // Skip all "productClusterIds" to maintain their priority
+            }
+            // Now, find the position for inserting, considering 'c' or 'C'
+            while (i < zipped.length && (zipped[i][0].toLowerCase() === "c")) {
+                i++; // Skip elements starting with 'c' or 'C', which have lower priority than "productClusterIds"
+            }
+            zipped.splice(i, 0, [newMap[it], newPath[it]]);
+        }
     }
 
     const link = new URL(`/${zipped.map(([, s]) => s).join("/")}`, url);
     link.searchParams.set("map", zipped.map(([m]) => m).join(","));
     if (behavior === "static") {
-      link.searchParams.set("fmap", url.searchParams.get("fmap") || map[0]);
+      link.searchParams.set("fmap", url.searchParams.get("fmap") || map);
     }
     const currentQuery = url.searchParams.get("q");
     if (currentQuery) {
@@ -650,8 +648,8 @@ export const legacyFacetToFilter = (
         ? facet
         : normalizeFacet(facet);
 
-      const selected = mapSet.has(normalizedFacet.Map.toLowerCase()) &&
-        pathSet.has(normalizedFacet.Value.toLowerCase());
+      const selected = mapSet.has(normalizedFacet.Map) &&
+        pathSet.has(normalizedFacet.Value);
       return {
         value: normalizedFacet.Value,
         quantity: normalizedFacet.Quantity,


### PR DESCRIPTION
# Part 1
At category pages, we look for the current category to show all below in the three.
![image](https://github.com/deco-cx/apps/assets/76620866/0494153d-766c-4318-8083-bd9b6e1bb74f)

But, at search, collection, brand pages. The products are in different categories and object comes empty:
![image](https://github.com/deco-cx/apps/assets/76620866/c038655f-fa56-45a1-9a00-6e493a3c6079)

We could flat all categories here, but that would be weird, because we want to know the name of parent category. 

So, I liked @lui-dias purpose here: https://github.com/deco-cx/apps/pull/368. Bring categories separated:

Collection page before:
![image](https://github.com/deco-cx/apps/assets/76620866/4f01865b-040b-47ec-b8f3-4dcc29d309e7)

Collection page after:
![image](https://github.com/deco-cx/apps/assets/76620866/f539a722-3de0-486d-9126-5dbd6f299622)

# Part 2
At collection pages, the category link at filter should start with productClusterIds at map. Even at Vtex, it is necessary:
https://www.miess.com.br/velas/138?map=c,productClusterIds does not works.
https://www.miess.com.br/sex-shop/velas/138?map=c,c,productClusterIds works

This PR verify if request has a productClusterId at map and then deal in a different way.

