### PR TITLE
Feature: isvariantof on VTEX legacy suggestions

### DIFF
--- a/vtex/loaders/legacy/suggestions.ts
+++ b/vtex/loaders/legacy/suggestions.ts
@@ -23,7 +23,7 @@ export interface Props {
 const loaders = async (
   props: Props,
   _req: Request,
-  ctx: AppContext,
+  ctx: AppContext
 ): Promise<Suggestion | null> => {
   const { vcsDeprecated } = ctx;
   const { count = 4, query } = props;
@@ -39,7 +39,7 @@ const loaders = async (
       // Not adding suggestions to cache since queries are very spread out
       // deco: { cache: "stale-while-revalidate" },
       headers: withSegmentCookie(segment),
-    },
+    }
   ).then((res) => res.json());
 
   const searches: Suggestion["searches"] = suggestions.itemsReturned
@@ -49,7 +49,10 @@ const loaders = async (
   const products: Suggestion["products"] = suggestions.itemsReturned
     .filter(({ items }) => !!items.length)
     .map(
-      ({ items: [{ productId, itemId, imageUrl, name }], href }): Product => {
+      ({
+        items: [{ productId, itemId, imageUrl, name, nameComplete }],
+        href,
+      }): Product => {
         const url = new URL(href);
 
         return {
@@ -57,11 +60,19 @@ const loaders = async (
           productID: itemId,
           sku: itemId,
           inProductGroupWithID: productId,
+          isVariantOf: {
+            "@type": "ProductGroup",
+            name: nameComplete,
+            url: new URL(href).pathname,
+            hasVariant: [],
+            additionalProperty: [],
+            productGroupID: productId,
+          },
           image: [{ "@type": "ImageObject", url: imageUrl }],
           name,
           url: url.pathname + url.search + url.hash,
         };
-      },
+      }
     );
 
   return {

--- a/vtex/loaders/legacy/suggestions.ts
+++ b/vtex/loaders/legacy/suggestions.ts
@@ -23,7 +23,7 @@ export interface Props {
 const loaders = async (
   props: Props,
   _req: Request,
-  ctx: AppContext
+  ctx: AppContext,
 ): Promise<Suggestion | null> => {
   const { vcsDeprecated } = ctx;
   const { count = 4, query } = props;
@@ -39,7 +39,7 @@ const loaders = async (
       // Not adding suggestions to cache since queries are very spread out
       // deco: { cache: "stale-while-revalidate" },
       headers: withSegmentCookie(segment),
-    }
+    },
   ).then((res) => res.json());
 
   const searches: Suggestion["searches"] = suggestions.itemsReturned
@@ -72,7 +72,7 @@ const loaders = async (
           name,
           url: url.pathname + url.search + url.hash,
         };
-      }
+      },
     );
 
   return {


### PR DESCRIPTION
This PR brings back the `isVariantOf` object on the return of the VTEX legacy `suggestions` loader. 
It has the exact same shape as it once had in a [previous version of the repository](https://github.com/deco-cx/apps/blob/7ac0d59d52c51f6bdf2a966d6f4e3e12b09afb75/vtex/loaders/legacy/suggestions.ts#L60).

The `name` currently returned by the loader is the SKU name. 
This is fine in a lot of cases, but sometimes, the SKU name does not contain the product name, only a description of the variation. 

E.g.:

![image](https://github.com/deco-cx/apps/assets/47872968/41cb05f8-487f-4b7a-8442-9936b6d2f64e)

With `isVariantOf` containing the product name, stores can work around this issue, having access to the product name.

![image](https://github.com/deco-cx/apps/assets/47872968/b59cc28b-bb04-45c3-9973-6838c0c6dead)
