### PR TITLE
[WebSite] - RenderHooks

### DIFF
--- a/website/mod.ts
+++ b/website/mod.ts
@@ -7,6 +7,7 @@ import type { Props as Seo } from "./components/Seo.tsx";
 import { Routes } from "./flags/audience.ts";
 import manifest, { Manifest } from "./manifest.gen.ts";
 import { Page } from "deco/blocks/page.tsx";
+import { Props as PageProps } from "./pages/Page.tsx";
 
 export type AppContext = FnContext<Props, Manifest>;
 
@@ -32,6 +33,14 @@ export type CacheDirective = StaleWhileRevalidate | MaxAge;
 export interface Caching {
   enabled?: boolean;
   directives?: CacheDirective[];
+}
+
+export interface RenderHooks {
+  onBeforeRenderStart: (
+    props: PageProps,
+    req: Request,
+    appContext: AppContext,
+  ) => void;
 }
 
 export interface Props {
@@ -70,6 +79,8 @@ export interface Props {
    * @default 0
    */
   firstByteThresholdMS?: 0 | 1 | 100 | 300 | 500 | 700;
+
+  renderHooks?: RenderHooks[];
 }
 
 /**

--- a/website/pages/Page.tsx
+++ b/website/pages/Page.tsx
@@ -125,12 +125,18 @@ function Page(
 }
 
 export const loader = async (
-  { sections }: Props,
+  props: Props,
   req: Request,
   ctx: AppContext,
 ) => {
+  const { sections } = props;
   const url = new URL(req.url);
   const devMode = url.searchParams.has("__d");
+  const renderHooks = ctx?.renderHooks ?? [];
+  renderHooks.forEach((hook) => {
+    hook?.onBeforeRenderStart?.(props, req, ctx);
+  });
+
   return {
     sections,
     errorPage: isDeferred<Page>(ctx.errorPage)


### PR DESCRIPTION
Here we can run loaders before middlewares and global sections.

This is what we need to do to use this feature. This is a new loader with renderHooks.

![image](https://github.com/deco-cx/apps/assets/108771428/d07f7106-5df7-4e1d-8912-29517f957e1a)
