### PR TITLE
perf: Optimize build routes

### DIFF
--- a/website/handlers/router.ts
+++ b/website/handlers/router.ts
@@ -110,48 +110,35 @@ export const router = (
   };
 };
 
-export const toRouteMap = (
-  routes?: Route[],
-): [
-  Record<string, MaybePriorityHandler>,
-  Record<string, Resolvable<Handler>>,
-] => {
-  const routeMap: Record<string, MaybePriorityHandler> = {};
-  const hrefRoutes: Record<string, Resolvable<Handler>> = {};
-  (routes ?? [])
-    .forEach(
-      ({ pathTemplate, isHref, highPriority, handler: { value: handler } }) => {
-        if (isHref) {
-          hrefRoutes[pathTemplate] = handler;
-        } else {
-          routeMap[pathTemplate] = { func: handler, highPriority };
-        }
-      },
-    );
-  return [routeMap, hrefRoutes];
-};
-
-export const buildRoutes = (audiences: Routes[]): [
-  Record<string, MaybePriorityHandler>,
-  Record<string, Resolvable<Handler>>,
-] => {
-  // We should tackle this problem elsewhere
-  return audiences.filter(Boolean)
-    .reduce(
-      ([routes, hrefRoutes], audience) => {
-        // check if the audience matches with the given context considering the `isMatch` provided by the cookies.
-        const [newRoutes, newHrefRoutes] = toRouteMap(audience ?? []);
-        return [
-          { ...routes, ...newRoutes },
-          { ...hrefRoutes, ...newHrefRoutes },
-        ];
-      },
-      [{}, {}] as [
-        Record<string, MaybePriorityHandler>,
-        Record<string, Resolvable<Handler>>,
-      ],
-    );
-};
+export const buildRoutes = (
+    audiences: Routes[],
+  ): [
+    Record<string, MaybePriorityHandler>,
+    Record<string, Resolvable<Handler>>,
+  ] => {
+    const routeMap: Record<string, MaybePriorityHandler> = {};
+    const hrefRoutes: Record<string, Resolvable<Handler>> = {};
+  
+    // We should tackle this problem elsewhere
+    // check if the audience matches with the given context considering the `isMatch` provided by the cookies.
+    for (const audience of audiences.filter(Boolean).flat()) {
+      const {
+        pathTemplate,
+        isHref,
+        highPriority,
+        handler: { value: handler },
+      } = audience;
+  
+      if (isHref) {
+        hrefRoutes[pathTemplate] = handler;
+      } else {
+        routeMap[pathTemplate] = { func: handler, highPriority };
+      }
+    }
+  
+  
+    return [routeMap, hrefRoutes];
+  };
 
 export interface SelectionConfig {
   audiences: Routes[];


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?
If the site has a lot of redirects, ~80k like miess, it would take a long time to build the routes
![image](https://github.com/deco-cx/apps/assets/66072698/f388c81d-9728-4573-959b-38a2856bbfb1)

This pr reduces this time
![image](https://github.com/deco-cx/apps/assets/66072698/f0532651-f8a2-4b20-81a1-360324005023)

## Explanation
https://cdn.discordapp.com/attachments/1101246747604426885/1212419299814412309/2024-02-28_12-04-51.mkv?ex=65f1c476&is=65df4f76&hm=fe391f6f2369a4334358bdc161de7de51aafaf449f62f2cb94ad37a338843f7f&

## Link
Normal
https://miess-01.deco.site/?__d

With PR
https://deco-sites-miess-01--optimize-build-routes.deno.dev/?__d

Branch with PR
https://github.com/deco-sites/miess-01/tree/optimize-build-routes

