### PR TITLE
Feat: parse all categories to VTEX product's additional properties

### DIFF
--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -182,12 +182,25 @@ const toAdditionalPropertyCategories = <
 >(
   product: P,
 ): Product["additionalProperty"] => {
-  const categories = splitCategory(product.categories[0]);
-  const categoryIds = splitCategory(product.categoriesIds[0]);
+  const categories = new Set<string>();
+  const categoryIds = new Set<string>();
 
-  return categories.map((category, index) =>
+  product.categories.forEach((productCategory, i) => {
+    const category = splitCategory(productCategory);
+    const categoryId = splitCategory(product.categoriesIds[i]);
+
+    category.forEach((splitCategoryItem, j) => {
+      categories.add(splitCategoryItem);
+      categoryIds.add(categoryId[j]);
+    });
+  });
+
+  const categoriesArray = Array.from(categories);
+  const categoryIdsArray = Array.from(categoryIds);
+
+  return categoriesArray.map((category, index) =>
     toAdditionalPropertyCategory({
-      propertyID: categoryIds[index],
+      propertyID: categoryIdsArray[index],
       value: category || "",
     })
   );


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?

This PR aims to map through all categories from a VTEX product into its `additionalProperty` field, since currently Deco considers only the first in the array that the API returns. This is needed in [Sex Shop Atacadão](https://github.com/deco-sites/sexshopatacadao), as they had a logic in their VTEX IO environment that the discount badge in the Product Card would only render if the product is from the "Saldão" category. For example, the sku `997131094` has these categories returned in Intelligent Search API:
```json
{
  "categories": [
    "/Marcas/",
    "/Cuidados e Higiene/Cuidado Diário/",
    "/Cuidados e Higiene/",
    "/Atacadão/Saldão/",
    "/Atacadão/"
  ]
}
```
But what I had in Deco, was a field `category` = `Marcas` and an `additionalProperty` named `category` with value also being `Marcas` (besides the `propertyID`), because the parse function only considers the first item.
With the changes from this PR, now I receive all the categories this product has inside the `additionalProperty` array:
```json
{
  "additionalProperty": [
    {
      "@type": "PropertyValue",
      "name": "category",
      "propertyID": "767204221",
      "value": "Marcas"
    },
    {
      "@type": "PropertyValue",
      "name": "category",
      "propertyID": "696375531",
      "value": "Cuidados e Higiene"
    },
    {
      "@type": "PropertyValue",
      "name": "category",
      "propertyID": "696377460",
      "value": "Cuidado Diário"
    },
    {
      "@type": "PropertyValue",
      "name": "category",
      "propertyID": "721591269",
      "value": "Atacadão"
    },
    {
      "@type": "PropertyValue",
      "name": "category",
      "propertyID": "773084930",
      "value": "Saldão"
    }
  ]
}
```

## Loom
I've just mapped through all categories of the product in the `toAdditionalPropertyCategories` parse function, located at `vtex/utils/transform.ts`. Also added a `Set` so that they won't repeat.

## Link

I've pushed into store's main branch, import mapping to my forked `apps` repo, with the logic described above already in action. In https://www.sexshopatacadao.com.br/cuidados-e-higiene?sort=discount%3Adesc you can see the SKU I've mentioned in the example at the 3rd position (Suplemento Alimentar Slintt Wellness Com 60 Cápsulas Intt) already showing the discount badge.

