### PR TITLE
feat: Use sellerName instead sellerId

### DIFF
--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -525,10 +525,10 @@ const toAdditionalPropertiesLegacy = (sku: LegacySkuVTEX): PropertyValue[] => {
   return [...specificationProperties, ...attachmentProperties];
 };
 
-const toOffer = ({ commertialOffer: offer, sellerId }: SellerVTEX): Offer => ({
+const toOffer = ({ commertialOffer: offer, sellerName }: SellerVTEX): Offer => ({
   "@type": "Offer",
   price: offer.spotPrice ?? offer.Price,
-  seller: sellerId,
+  seller: sellerName,
   priceValidUntil: offer.PriceValidUntil,
   inventoryLevel: { value: offer.AvailableQuantity },
   giftSkuIds: offer.GiftSkuIds ?? [],


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
I need the sellerName to set up the jsonLD correctly, but `Offer.seller` returns the sellerId instead of the sellerName

I don't know if replacing sellerId with sellerName is the best way, but I haven't found another way that follows schema.org