### PR TITLE
[ SEO | VTEX ] Add meta robots in SEO PLP and SEO PDP

### DIFF
--- a/commerce/sections/Seo/SeoPLP.tsx
+++ b/commerce/sections/Seo/SeoPLP.tsx
@@ -22,7 +22,7 @@ function Section({ jsonLD, ...props }: Props) {
     ? canonicalFromBreadcrumblist(jsonLD?.breadcrumb)
     : undefined;
 
-  const noIndexing = !jsonLD || !jsonLD.products.length;
+  const noIndexing = jsonLD?.seo?.noIndexing || !jsonLD  || !jsonLD.products.length;
 
   return (
     <Seo

--- a/commerce/sections/Seo/SeoPLPV2.tsx
+++ b/commerce/sections/Seo/SeoPLPV2.tsx
@@ -43,7 +43,7 @@ export function loader(props: Props, _req: Request, ctx: AppContext) {
     ? canonicalFromBreadcrumblist(jsonLD?.breadcrumb)
     : undefined;
 
-  const noIndexing = !jsonLD || !jsonLD.products.length;
+  const noIndexing = !jsonLD || !jsonLD.products.length || jsonLD.seo?.noIndexing;;
 
   return {
     ...seoSiteProps,

--- a/vtex/loaders/legacy/productDetailsPage.ts
+++ b/vtex/loaders/legacy/productDetailsPage.ts
@@ -91,6 +91,7 @@ async function loader(
       title: product.productTitle,
       description: product.metaTagDescription,
       canonical: new URL(`/${product.linkText}/p`, url.origin).href,
+      noIndexing: !!skuId
     },
   };
 }

--- a/vtex/utils/legacy.ts
+++ b/vtex/utils/legacy.ts
@@ -109,6 +109,7 @@ export const pageTypesToSeo = (
 
   const url = new URL(baseUrl);
   const fullTextSearch = url.searchParams.get("q");
+  const hasMapTermOrSkuId = !!(url.searchParams.get("map") || url.searchParams.get("skuId"))
 
   if (
     (!current || current.pageType === "Search" ||
@@ -118,6 +119,7 @@ export const pageTypesToSeo = (
       title: capitalize(fullTextSearch),
       description: capitalize(fullTextSearch),
       canonical: url.href,
+      noIndexing: hasMapTermOrSkuId
     };
   }
 
@@ -128,6 +130,7 @@ export const pageTypesToSeo = (
   return {
     title: current.title!,
     description: current.metaTagDescription!,
+    noIndexing: hasMapTermOrSkuId,
     canonical: toCanonical(
       new URL(
         (current.url && current.pageType !== "Collection")

--- a/website/components/Seo.tsx
+++ b/website/components/Seo.tsx
@@ -87,6 +87,7 @@ function Component({
 
       {/* No index, no follow */}
       {noIndexing && <meta name="robots" content="noindex, nofollow" />}
+      {!noIndexing && <meta name="robots" content="index, follow" />}
 
       {jsonLDs.map((json) => (
         <script


### PR DESCRIPTION
## What is this contribution about?

In this pr I add 
```js
<meta name="robots" content="index, follow">
```
in all pages who don't receive "noIndexing prop" and add use cases to don't follow in PLP and PDP


![image](https://github.com/deco-cx/apps/assets/108771428/a54a3d6b-8b90-4f0b-b446-3cdb65d9357a)


## Link to test 

https://www.embelleze.com/Neutralizante/TRATAMENTO/1568?map=c%2Cc%2CproductClusterIds

## Link to undestand better the use cases

https://app.liveseo.com.br/projeto/CB566/task/8439/128563/preview?key=iXYXeK8m2S9x5Bhe
