### PR TITLE
fix: Preview fetched when imported

### DIFF
--- a/decohub/apps/algolia.ts
+++ b/decohub/apps/algolia.ts
@@ -1,7 +1,15 @@
+import { AppRuntime } from "deco/mod.ts";
 import { Markdown } from "../components/Markdown.tsx";
 
 export { default } from "../../algolia/mod.ts";
 
-export const Preview = await Markdown(
-  new URL("../../algolia/README.md", import.meta.url).href,
-);
+export const preview = async (props: AppRuntime) => {
+  const markdownContent = await Markdown(
+    new URL("../../algolia/README.md", import.meta.url).href,
+  );
+
+  return {
+    Component: markdownContent,
+    props,
+  };
+};

--- a/decohub/apps/implementation.ts
+++ b/decohub/apps/implementation.ts
@@ -1,7 +1,15 @@
+import { AppRuntime } from "deco/mod.ts";
 import { Markdown } from "../components/Markdown.tsx";
 
 export { default } from "../../implementation/mod.ts";
 
-export const Preview = await Markdown(
-  new URL("../../implementation/README.md", import.meta.url).href,
-);
+export const preview = async (props: AppRuntime) => {
+  const markdownContent = await Markdown(
+    new URL("../../implementation/README.md", import.meta.url).href,
+  );
+
+  return {
+    Component: markdownContent,
+    props,
+  };
+};

--- a/decohub/apps/linx.ts
+++ b/decohub/apps/linx.ts
@@ -1,7 +1,15 @@
+import { AppRuntime } from "deco/mod.ts";
 import { Markdown } from "../components/Markdown.tsx";
 
 export { default } from "../../linx/mod.ts";
 
-export const Preview = await Markdown(
-  new URL("../../linx/README.md", import.meta.url).href,
-);
+export const preview = async (props: AppRuntime) => {
+  const markdownContent = await Markdown(
+    new URL("../../linx/README.md", import.meta.url).href,
+  );
+
+  return {
+    Component: markdownContent,
+    props,
+  };
+};

--- a/decohub/apps/shopify.ts
+++ b/decohub/apps/shopify.ts
@@ -1,7 +1,15 @@
+import { AppRuntime } from "deco/mod.ts";
 import { Markdown } from "../components/Markdown.tsx";
 
 export { default } from "../../shopify/mod.ts";
 
-export const Preview = await Markdown(
-  new URL("../../shopify/README.md", import.meta.url).href,
-);
+export const preview = async (props: AppRuntime) => {
+  const markdownContent = await Markdown(
+    new URL("../../shopify/README.md", import.meta.url).href,
+  );
+
+  return {
+    Component: markdownContent,
+    props,
+  };
+};

--- a/decohub/apps/sourei.ts
+++ b/decohub/apps/sourei.ts
@@ -1,7 +1,15 @@
+import { AppRuntime } from "deco/mod.ts";
 import { Markdown } from "../components/Markdown.tsx";
 
 export { default } from "../../sourei/mod.ts";
 
-export const Preview = await Markdown(
-  new URL("../../sourei/README.md", import.meta.url).href,
-);
+export const preview = async (props: AppRuntime) => {
+  const markdownContent = await Markdown(
+    new URL("../../sourei/README.md", import.meta.url).href,
+  );
+
+  return {
+    Component: markdownContent,
+    props,
+  };
+};

--- a/decohub/apps/typesense.ts
+++ b/decohub/apps/typesense.ts
@@ -1,7 +1,15 @@
+import { AppRuntime } from "deco/mod.ts";
 import { Markdown } from "../components/Markdown.tsx";
 
 export { default } from "../../typesense/mod.ts";
 
-export const Preview = await Markdown(
-  new URL("../../typesense/README.md", import.meta.url).href,
-);
+export const preview = async (props: AppRuntime) => {
+  const markdownContent = await Markdown(
+    new URL("../../typesense/README.md", import.meta.url).href,
+  );
+
+  return {
+    Component: markdownContent,
+    props,
+  };
+};

--- a/decohub/apps/vnda.ts
+++ b/decohub/apps/vnda.ts
@@ -1,7 +1,15 @@
+import { AppRuntime } from "deco/mod.ts";
 import { Markdown } from "../components/Markdown.tsx";
 
 export { default } from "../../vnda/mod.ts";
 
-export const Preview = await Markdown(
-  new URL("../../vnda/README.md", import.meta.url).href,
-);
+export const preview = async (props: AppRuntime) => {
+  const markdownContent = await Markdown(
+    new URL("../../vnda/README.md", import.meta.url).href,
+  );
+
+  return {
+    Component: markdownContent,
+    props,
+  };
+};

--- a/decohub/apps/wake.ts
+++ b/decohub/apps/wake.ts
@@ -1,7 +1,15 @@
+import { AppRuntime } from "deco/mod.ts";
 import { Markdown } from "../components/Markdown.tsx";
 
 export { default } from "../../wake/mod.ts";
 
-export const Preview = await Markdown(
-  new URL("../../wake/README.md", import.meta.url).href,
-);
+export const preview = async (props: AppRuntime) => {
+  const markdownContent = await Markdown(
+    new URL("../../wake/README.md", import.meta.url).href,
+  );
+
+  return {
+    Component: markdownContent,
+    props,
+  };
+};


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?
The preview of some apps called the markdown component with await, and the markdown makes a fetch to get the content. So when importing apps into the decohub manifest, it was necessary to wait for the markdown to fetch.

This PR makes the component call the markdown only when it is rendered, so it avoids fetching when the apps are imported.
