### PR TITLE
Remove abort handler

### DIFF
--- a/website/handlers/fresh.ts
+++ b/website/handlers/fresh.ts
@@ -52,7 +52,8 @@ export default function Fresh(
     const ctrl = new AbortController();
 
     /** Aborts when: Incomming request is aborted */
-    req.signal.addEventListener("abort", () => ctrl.abort());
+    const abortHandler = () => ctrl.abort();
+    req.signal.addEventListener("abort", abortHandler);
 
     /**
      * Aborts when:
@@ -126,6 +127,7 @@ export default function Fresh(
           } finally {
             span.end();
             timing?.end();
+            req.signal.removeEventListener("abort", abortHandler);
           }
         },
       );


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?

Remove abort handler after fresh handler has return the getPage.

Fixes a potential memory leak.
