### PR TITLE
Add search params to cachekey creation

### DIFF
--- a/vtex/loaders/legacy/productListingPage.ts
+++ b/vtex/loaders/legacy/productListingPage.ts
@@ -397,6 +397,10 @@ export const cacheKey = (props: Props, req: Request, ctx: AppContext) => {
     ["pageOffset", (props.pageOffset ?? 1).toString()],
   ]);
 
+  url.searchParams.forEach((value, key) => {
+    params.append(key, value);
+  });
+
   params.sort();
   params.set("segment", token);
 


### PR DESCRIPTION
This is needed so that we can perform caching correctly in sites with pagination using the productListingPage legacy loader. Similar to what is done in the IntelligentSearch/ProductListingPage.ts.