### PR TITLE
refactor(linx-impulse): Hotsite loader

### DIFF
--- a/linx-impulse/loaders/products/hotsite.ts
+++ b/linx-impulse/loaders/products/hotsite.ts
@@ -55,7 +55,7 @@ const getSortFromQuery = (query: string): SortBy | undefined => {
 };
 
 /**
- * @title Linx Impulse - Search
+ * @title Linx Impulse - Hotsite
  * @description Product Listing Page loader
  */
 const loader = async (

--- a/linx-impulse/loaders/products/hotsite.ts
+++ b/linx-impulse/loaders/products/hotsite.ts
@@ -1,0 +1,103 @@
+import type { Person, ProductListingPage } from "../../../commerce/types.ts";
+import type { AppContext } from "../../mod.ts";
+import { getDeviceIdFromBag } from "../../utils/deviceId.ts";
+import getSource from "../../utils/source.ts";
+import { toProductListingPage } from "../../utils/transform.ts";
+import type { SortBy } from "../../utils/types/linx.ts";
+
+export interface Props {
+  hotsiteName: string;
+  /**
+   * @title Items per page
+   * @description number of products per page to display
+   */
+  resultsPerPage: number;
+
+  /**
+   * @title Sorting
+   */
+  sort?: SortBy;
+
+  /**
+   * @title Hide Unavailable Items
+   * @description Do not return out of stock items
+   */
+  showOnlyAvailable?: boolean;
+
+  /**
+   * @title User
+   * @description Used to sync user data with linx impulse
+   */
+  user: Person | null;
+
+  /**
+   * @ignore
+   */
+  page?: number;
+}
+
+const getSortFromQuery = (query: string): SortBy | undefined => {
+  switch (query) {
+    case "relevance":
+    case "pid":
+    case "ascPrice":
+    case "descPrice":
+    case "descDate":
+    case "ascSold":
+    case "descSold":
+    case "ascReview":
+    case "descReview":
+    case "descDiscount":
+      return query;
+    default:
+      return undefined;
+  }
+};
+
+/**
+ * @title Linx Impulse - Search
+ * @description Product Listing Page loader
+ */
+const loader = async (
+  props: Props,
+  req: Request,
+  ctx: AppContext,
+): Promise<ProductListingPage | null> => {
+  if (req.url.includes("_frsh")) {
+    return null;
+  }
+
+  const { resultsPerPage, showOnlyAvailable, user, hotsiteName } = props;
+  const { apiKey, origin, salesChannel, api, cdn } = ctx;
+  const deviceId = getDeviceIdFromBag(ctx);
+  const source = getSource(ctx);
+  const url = new URL(req.url);
+
+  const page = props.page ||
+    Number.parseInt(url.searchParams.get("page") || "1");
+  const sortBy = getSortFromQuery(url.searchParams.get("sort") ?? "") ||
+    props.sort;
+  const filter = url.searchParams.getAll("filter");
+  const userId = user?.["@id"];
+  const productFormat = "complete";
+
+  const response = await api["GET /engage/search/v3/hotsites"]({
+    apiKey,
+    origin,
+    salesChannel,
+    deviceId,
+    showOnlyAvailable,
+    resultsPerPage,
+    page,
+    sortBy,
+    filter,
+    source,
+    userId,
+    productFormat,
+    name: hotsiteName,
+  }).then((res) => res.json());
+
+  return toProductListingPage(response, page, resultsPerPage, req.url, cdn);
+};
+
+export default loader;

--- a/linx-impulse/loaders/products/productListingPage.ts
+++ b/linx-impulse/loaders/products/productListingPage.ts
@@ -108,87 +108,65 @@ const loader = async (
   const userId = user?.["@id"];
   const productFormat = "complete";
 
-  try {
-    if (searchTerm) {
-      const response = await api["GET /engage/search/v3/search"]({
-        apiKey,
-        origin,
-        salesChannel,
-        deviceId,
-        allowRedirect,
-        showOnlyAvailable,
-        resultsPerPage,
-        page,
-        sortBy,
-        filter,
-        source,
-        terms: searchTerm,
-        userId,
-        productFormat,
-      }).then((res) => res.json());
+  if (searchTerm) {
+    const response = await api["GET /engage/search/v3/search"]({
+      apiKey,
+      origin,
+      salesChannel,
+      deviceId,
+      allowRedirect,
+      showOnlyAvailable,
+      resultsPerPage,
+      page,
+      sortBy,
+      filter,
+      source,
+      terms: searchTerm,
+      userId,
+      productFormat,
+    }).then((res) => res.json());
 
-      return toProductListingPage(response, page, resultsPerPage, req.url, cdn);
-    } else if (category.length >= 2 && category[0] === "hotsite") {
-      const response = await api["GET /engage/search/v3/hotsites"]({
-        apiKey,
-        origin,
-        salesChannel,
-        deviceId,
-        showOnlyAvailable,
-        resultsPerPage,
-        page,
-        sortBy,
-        filter,
-        source,
-        userId,
-        productFormat,
-        name: category[1],
-      }).then((res) => res.json());
+    return toProductListingPage(response, page, resultsPerPage, req.url, cdn);
+  } else if (category.length > 0 || multicategory.length > 0) {
+    const response = await api["GET /engage/search/v3/navigates"]({
+      apiKey,
+      origin,
+      salesChannel,
+      deviceId,
+      allowRedirect,
+      showOnlyAvailable,
+      resultsPerPage,
+      page,
+      sortBy,
+      fields,
+      filter,
+      source,
+      userId,
+      productFormat,
+      ...(multicategory.length > 0 ? { multicategory } : { category }),
+    }).then((res) => res.json());
 
-      return toProductListingPage(response, page, resultsPerPage, req.url, cdn);
-    } else if (category.length > 0 || multicategory.length > 0) {
-      const response = await api["GET /engage/search/v3/navigates"]({
-        apiKey,
-        origin,
-        salesChannel,
-        deviceId,
-        allowRedirect,
-        showOnlyAvailable,
-        resultsPerPage,
-        page,
-        sortBy,
-        fields,
-        filter,
-        source,
-        userId,
-        productFormat,
-        ...(multicategory.length > 0 ? { multicategory } : { category }),
-      }).then((res) => res.json());
-
-      return toProductListingPage(response, page, resultsPerPage, req.url, cdn);
-    }
-  } catch (err) {
-    console.error(err);
+    return toProductListingPage(response, page, resultsPerPage, req.url, cdn);
+  } else {
+    return {
+      "@type": "ProductListingPage",
+      breadcrumb: {
+        "@type": "BreadcrumbList",
+        itemListElement: [],
+        numberOfItems: 0,
+      },
+      filters: [],
+      products: [],
+      pageInfo: {
+        nextPage: undefined,
+        previousPage: undefined,
+        currentPage: page,
+        records: 0,
+        recordPerPage: 0,
+      },
+      sortOptions,
+    };
   }
-
-  return {
-    "@type": "ProductListingPage",
-    breadcrumb: {
-      "@type": "BreadcrumbList",
-      itemListElement: [],
-      numberOfItems: 0,
-    },
-    filters: [],
-    products: [],
-    pageInfo: {
-      nextPage: undefined,
-      previousPage: undefined,
-      currentPage: page,
-      records: 0,
-      recordPerPage: 0,
-    },
-    sortOptions,
-  };
 };
 
 export default loader;

--- a/linx-impulse/manifest.gen.ts
+++ b/linx-impulse/manifest.gen.ts
@@ -4,22 +4,24 @@
 
 import * as $$$$$$$$$0 from "./actions/analytics/sendEvent.ts";
 import * as $$$0 from "./loaders/config.ts";
-import * as $$$1 from "./loaders/products/productList.ts";
-import * as $$$2 from "./loaders/products/productListingPage.ts";
-import * as $$$3 from "./loaders/search/autocomplete.ts";
-import * as $$$4 from "./loaders/search/popular.ts";
-import * as $$$5 from "./loaders/search/products.ts";
+import * as $$$1 from "./loaders/products/hotsite.ts";
+import * as $$$2 from "./loaders/products/productList.ts";
+import * as $$$3 from "./loaders/products/productListingPage.ts";
+import * as $$$4 from "./loaders/search/autocomplete.ts";
+import * as $$$5 from "./loaders/search/popular.ts";
+import * as $$$6 from "./loaders/search/products.ts";
 import * as $$$$$$0 from "./sections/Analytics/LinxImpulsePageView.tsx";
 import * as $$$$$$1 from "./sections/Script/LinxImpulseScript.tsx";
 
 const manifest = {
   "loaders": {
     "linx-impulse/loaders/config.ts": $$$0,
-    "linx-impulse/loaders/products/productList.ts": $$$1,
-    "linx-impulse/loaders/products/productListingPage.ts": $$$2,
-    "linx-impulse/loaders/search/autocomplete.ts": $$$3,
-    "linx-impulse/loaders/search/popular.ts": $$$4,
-    "linx-impulse/loaders/search/products.ts": $$$5,
+    "linx-impulse/loaders/products/hotsite.ts": $$$1,
+    "linx-impulse/loaders/products/productList.ts": $$$2,
+    "linx-impulse/loaders/products/productListingPage.ts": $$$3,
+    "linx-impulse/loaders/search/autocomplete.ts": $$$4,
+    "linx-impulse/loaders/search/popular.ts": $$$5,
+    "linx-impulse/loaders/search/products.ts": $$$6,
   },
   "sections": {
     "linx-impulse/sections/Analytics/LinxImpulsePageView.tsx": $$$$$$0,

--- a/linx-impulse/utils/transform.ts
+++ b/linx-impulse/utils/transform.ts
@@ -107,6 +107,10 @@ const sanitizeValue = (value: unknown): string | undefined => {
     return `${value}`;
   }
 
+  if (Array.isArray(value)) {
+    return sanitizeValue(value[0]);
+  }
+
   return JSON.stringify(value);
 };
 


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?
This PR aims to separate the Hotsite loader from the linx impulse into a separate loader, previously it was next to the PLP loader, the PR also fixes an error that the value sanitize function did a stringify in the arrays, the correct thing would be to take the first value , e.g: 
```js
Brand: ["Penalty"] // '["Penalty"]' ❌
Brand: ["Penalty"] // "Penalty"     ✅
```
![image](https://github.com/deco-cx/apps/assets/32278696/373efc44-63ab-4c1d-86ff-e9b340aa9f31)


## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

https://deco-sites-clovis.deno.dev/
