### PR TITLE
feat: Adding FileWidget to widgets.ts

### DIFF
--- a/admin/widgets.ts
+++ b/admin/widgets.ts
@@ -12,3 +12,8 @@ export type HTMLWidget = string;
  * @format video-uri
  */
 export type VideoWidget = string;
+
+/**
+ * @format file
+ */
+export type FileWidget = string;


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?

This commit causes a new option to appear for widget imports, giving the possibility of uploading files through deco admin.

I came across a use case where a client needed to upload files with extensions (PDF, docx, etc.) and suggested that this be done through the Deco admin. I noticed that this possibility exists if we import the @format file, which is a type of import that sometimes some Deco devs don't know about.

View in Admin:
![image](https://github.com/deco-cx/apps/assets/104099580/d4281492-5d59-43b8-aa76-cf34ec68f606)

I had to create a component that took advantage of the file upload functionality. Therefore, I thought it was fair and interesting to add this new typing to Deco widgets.

Below is a photo of the component using this functionality:
![image](https://github.com/deco-cx/apps/assets/104099580/6d2202cf-7fcf-4778-803a-5cd7b1a2172e)


