### PR TITLE
[ Routes ] - Fresh and js routes.

### DIFF
--- a/website/handlers/router.ts
+++ b/website/handlers/router.ts
@@ -190,6 +190,12 @@ export default function RoutesSelection(
 
     timing?.end();
 
+    const regexFile = /(\.js)|(_frsh)/gm;
+    if (regexFile.test(req.url)) {
+      return new Response(null, {
+        status: 404,
+      });
+    }
     return await server(req, connInfo);
   };
 }


### PR DESCRIPTION
## What is this contribution about?

This fix is about too many routes being called in loaders.

I block routes like: 

```js
"/image/app-apple.png?__frsh_c=707043eaa8a5026a7545d9f02028a85ebf7bdead"
"/sw.js"
```

In this context you only can call js files if this file are in the web-site repository. So, if you want to have a js file like:

"/results.js"

You need to put this file in the assets and use the fresh routes.
