### PR TITLE
Fix: Wrong facet map in VTEX legacy loaders with `static` behavior

### DIFF
--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -713,7 +713,7 @@ export const legacyFacetToFilter = (
     const link = new URL(`/${zipped.map(([, s]) => s).join("/")}`, url);
     link.searchParams.set("map", zipped.map(([m]) => m).join(","));
     if (behavior === "static") {
-      link.searchParams.set("fmap", url.searchParams.get("fmap") || map[0]);
+      link.searchParams.set("fmap", url.searchParams.get("fmap") || mapSegments[0]);
     }
     const currentQuery = url.searchParams.get("q");
     if (currentQuery) {


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?
This PR aims to fix the `fmap` query param in VTEX legacy (catalog) loaders, when it's behavior is set to `static`. In this behavior, all the facets are kept when the user selects one. For example, in the `dynamic` behavior, when setting the "Cor" facet being "Azul", the resulting search facets will remove all the "Cor" options and only show "Azul". But with the `static` behavior, all of them are shown still, enabling the user to select both "Azul" and "Amarelo" options of "Cor", resulting in a union of them.
The problem is, after the PR #392, the `fmap` query param (`static` behavior uses it to keep track of the initial facet) became broken: when inside a category, the "Azul" facet option should have `fmap=c` in it's URL (that's how it worked before the mentioned PR), but the URL actually has `fmap=specificationFilter_XX`
This is caused because of the flattening of the facets in the `legacyFacetToFilter` transform function. This PR fixes it by using the initial state of the facet map (`mapSegments`), before it is flattened.

## Link
In the link https://deco-sites-clovis--stale.deno.dev/Feminino, the fix is not applied, so if you hover any facet the `fmap` will be of that facet, instead of the initial `c` one. The "Azul" option in the "Cor" facet, for example, `fmap` is `specificationFilter_27`. This leads to a page with broken facets.
In the link https://deco-sites-clovis.deno.dev/Feminino, the fix is applied, so if you hover any facet the `fmap` will be `c`, which corresponds to the initial `Feminino` facet that is a category. Selecting it leads to a page with the same facets of the initial page, caused by the `behavior` being `static`.

