### PR TITLE
fix custom headers if it is cookie

### DIFF
--- a/shopify/loaders/proxy.ts
+++ b/shopify/loaders/proxy.ts
@@ -4,6 +4,7 @@ import { withDigestCookie } from "../utils/password.ts";
 
 const PATHS_TO_PROXY = [
   "/checkouts/*",
+  "/cart",
   "/cart/*",
   "/account",
   "/account/*",
@@ -11,6 +12,7 @@ const PATHS_TO_PROXY = [
   "/password/*",
   "/challenge",
   "/challenge/*",
+  "/services/*"
 ];
 const decoSiteMapUrl = "/sitemap/deco.xml";
 

--- a/shopify/loaders/proxy.ts
+++ b/shopify/loaders/proxy.ts
@@ -12,7 +12,7 @@ const PATHS_TO_PROXY = [
   "/password/*",
   "/challenge",
   "/challenge/*",
-  "/services/*"
+  "/services/*",
 ];
 const decoSiteMapUrl = "/sitemap/deco.xml";
 

--- a/shopify/loaders/proxy.ts
+++ b/shopify/loaders/proxy.ts
@@ -14,15 +14,6 @@ const PATHS_TO_PROXY = [
 ];
 const decoSiteMapUrl = "/sitemap/deco.xml";
 
-const PATHS_WITH_DIGEST = new Set([
-  "/account",
-  "/account/*",
-  "/password",
-  "/password/*",
-  "/challenge",
-  "/challenge/*",
-]);
-
 const buildProxyRoutes = (
   {
     ctx,
@@ -59,9 +50,7 @@ const buildProxyRoutes = (
           __resolveType: "website/handlers/proxy.ts",
           url: urlToProxy,
           host: hostToUse,
-          customHeaders: PATHS_WITH_DIGEST.has(pathTemplate)
-            ? withDigestCookie(ctx)
-            : [],
+          customHeaders: withDigestCookie(ctx),
         },
       },
     });

--- a/shopify/loaders/proxy.ts
+++ b/shopify/loaders/proxy.ts
@@ -13,6 +13,7 @@ const PATHS_TO_PROXY = [
   "/challenge",
   "/challenge/*",
   "/services/*",
+  "/.well-known/*"
 ];
 const decoSiteMapUrl = "/sitemap/deco.xml";
 

--- a/shopify/loaders/proxy.ts
+++ b/shopify/loaders/proxy.ts
@@ -13,7 +13,7 @@ const PATHS_TO_PROXY = [
   "/challenge",
   "/challenge/*",
   "/services/*",
-  "/.well-known/*"
+  "/.well-known/*",
 ];
 const decoSiteMapUrl = "/sitemap/deco.xml";
 

--- a/shopify/utils/cart.ts
+++ b/shopify/utils/cart.ts
@@ -8,7 +8,7 @@ const ONE_WEEK_MS = 7 * 24 * 3600 * 1_000;
 export const getCartCookie = (headers: Headers): string | null => {
   const cookies = getCookies(headers);
 
-  if(!cookies[CART_COOKIE]){
+  if (!cookies[CART_COOKIE]) {
     return null;
   }
 
@@ -25,4 +25,4 @@ export const setCartCookie = (headers: Headers, cartId: string) => {
     secure: true,
     sameSite: "Lax",
   });
-}
+};

--- a/shopify/utils/cart.ts
+++ b/shopify/utils/cart.ts
@@ -1,22 +1,28 @@
 import { getCookies, setCookie } from "std/http/cookie.ts";
 
-const CART_COOKIE = "shopify_cart_id";
+const CART_COOKIE = "cart";
+const SHOPIFY_PREFIX = "gid://shopify/Cart/";
 
 const ONE_WEEK_MS = 7 * 24 * 3600 * 1_000;
 
-export const getCartCookie = (headers: Headers): string | undefined => {
+export const getCartCookie = (headers: Headers): string | null => {
   const cookies = getCookies(headers);
 
-  return cookies[CART_COOKIE];
+  if(!cookies[CART_COOKIE]){
+    return null;
+  }
+
+  return `${SHOPIFY_PREFIX}${cookies[CART_COOKIE]}`;
 };
 
-export const setCartCookie = (headers: Headers, cartId: string) =>
+export const setCartCookie = (headers: Headers, cartId: string) => {
   setCookie(headers, {
     name: CART_COOKIE,
-    value: cartId,
+    value: cartId.replace(SHOPIFY_PREFIX, ""),
     path: "/",
     expires: new Date(Date.now() + ONE_WEEK_MS),
     httpOnly: true,
     secure: true,
     sameSite: "Lax",
   });
+}

--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -135,7 +135,16 @@ export default function Proxy({
     headers.set("x-forwarded-host", url.host);
 
     for (const { key, value } of customHeaders) {
-      headers.set(key, value);
+      if(key === "cookie"){
+        const existingCookie = headers.get('cookie');
+        if (existingCookie) {
+          headers.set('cookie', `${existingCookie}; ${value}`);
+        } else {
+          headers.set('cookie', value);
+        }
+      }else{
+        headers.set(key, value);
+      }
     }
 
     const monitoring = isFreshCtx<DecoSiteState>(_ctx)

--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -135,14 +135,14 @@ export default function Proxy({
     headers.set("x-forwarded-host", url.host);
 
     for (const { key, value } of customHeaders) {
-      if(key === "cookie"){
-        const existingCookie = headers.get('cookie');
+      if (key === "cookie") {
+        const existingCookie = headers.get("cookie");
         if (existingCookie) {
-          headers.set('cookie', `${existingCookie}; ${value}`);
+          headers.set("cookie", `${existingCookie}; ${value}`);
         } else {
-          headers.set('cookie', value);
+          headers.set("cookie", value);
         }
-      }else{
+      } else {
         headers.set(key, value);
       }
     }


### PR DESCRIPTION
First
Shopify now asks for digest_cookie at checkout for stores that have password.

Second
We were replacing all cookies at proxy level and it brokes checkout.