### PR TITLE
feat: choose whether to concatenate URL parameters in the redirect.

### DIFF
--- a/compat/std/loaders/x/redirects.ts
+++ b/compat/std/loaders/x/redirects.ts
@@ -13,9 +13,9 @@ export interface Redirect {
   to: string;
   type?: "temporary" | "permanent";
   /**
-   * @title Keep Query Parameters
+   * @title Discard query parameters
    */
-  keepQueryParameters?: boolean;
+  discardQueryParameters?: boolean;
 }
 
 export interface Redirects {
@@ -24,7 +24,7 @@ export interface Redirects {
 
 export default function redirect({ redirects }: Redirects): Route[] {
   const routes: Route[] = (redirects || []).map((
-    { from, to, type, keepQueryParameters },
+    { from, to, type, discardQueryParameters },
   ) => ({
     pathTemplate: from,
     isHref: true,
@@ -33,7 +33,7 @@ export default function redirect({ redirects }: Redirects): Route[] {
         __resolveType: "website/handlers/redirect.ts",
         to,
         type,
-        keepQueryParameters,
+        discardQueryParameters,
       },
     },
   }));

--- a/compat/std/loaders/x/redirects.ts
+++ b/compat/std/loaders/x/redirects.ts
@@ -13,9 +13,9 @@ export interface Redirect {
   to: string;
   type?: "temporary" | "permanent";
   /**
-   * @title Concatenate parameters
+   * @title Keep Query Parameters
    */
-  concatenateParams?: boolean;
+  keepQueryParameters?: boolean;
 }
 
 export interface Redirects {
@@ -24,7 +24,7 @@ export interface Redirects {
 
 export default function redirect({ redirects }: Redirects): Route[] {
   const routes: Route[] = (redirects || []).map((
-    { from, to, type, concatenateParams },
+    { from, to, type, keepQueryParameters },
   ) => ({
     pathTemplate: from,
     isHref: true,
@@ -33,7 +33,7 @@ export default function redirect({ redirects }: Redirects): Route[] {
         __resolveType: "website/handlers/redirect.ts",
         to,
         type,
-        concatenateParams,
+        keepQueryParameters,
       },
     },
   }));

--- a/compat/std/loaders/x/redirects.ts
+++ b/compat/std/loaders/x/redirects.ts
@@ -12,17 +12,19 @@ export interface Redirect {
    */
   to: string;
   type?: "temporary" | "permanent";
+  /**
+   * @title Concatenate parameters
+   */
+  concatenateParams?: boolean;
 }
 
 export interface Redirects {
   redirects: Redirect[];
 }
 
-export default function redirect(
-  { redirects }: Redirects,
-): Route[] {
+export default function redirect({ redirects }: Redirects): Route[] {
   const routes: Route[] = (redirects || []).map((
-    { from, to, type },
+    { from, to, type, concatenateParams },
   ) => ({
     pathTemplate: from,
     isHref: true,
@@ -31,6 +33,7 @@ export default function redirect(
         __resolveType: "website/handlers/redirect.ts",
         to,
         type,
+        concatenateParams,
       },
     },
   }));

--- a/website/handlers/redirect.ts
+++ b/website/handlers/redirect.ts
@@ -12,7 +12,7 @@ export interface RedirectConfig {
  * @description Redirect request to another url
  */
 export default function Redirect(
-  { to, type = "temporary", keepQueryParameters }: RedirectConfig,
+  { to, type = "temporary", discardQueryParameters }: RedirectConfig,
 ) {
   /** https://archive.is/kWvxu */
   const statusByRedirectType: Record<

--- a/website/handlers/redirect.ts
+++ b/website/handlers/redirect.ts
@@ -4,7 +4,7 @@ import { isFreshCtx } from "./fresh.ts";
 export interface RedirectConfig {
   to: string;
   type?: "permanent" | "temporary";
-  concatenateParams?: boolean;
+  keepQueryParameters?: boolean;
 }
 
 /**
@@ -12,7 +12,7 @@ export interface RedirectConfig {
  * @description Redirect request to another url
  */
 export default function Redirect(
-  { to, type = "temporary", concatenateParams }: RedirectConfig,
+  { to, type = "temporary", keepQueryParameters }: RedirectConfig,
 ) {
   /** https://archive.is/kWvxu */
   const statusByRedirectType: Record<
@@ -42,7 +42,7 @@ export default function Redirect(
      *
      * (Useful for tracking parameters e.g Google's gclid, utm_source...)
      */
-    const finalLocation = !queryString || !concatenateParams
+    const finalLocation = !queryString || !keepQueryParameters
       ? location
       : location.includes("?")
       ? `${location}&${queryString}`

--- a/website/handlers/redirect.ts
+++ b/website/handlers/redirect.ts
@@ -4,13 +4,16 @@ import { isFreshCtx } from "./fresh.ts";
 export interface RedirectConfig {
   to: string;
   type?: "permanent" | "temporary";
+  concatenateParams?: boolean;
 }
 
 /**
  * @title Redirect
  * @description Redirect request to another url
  */
-export default function Redirect({ to, type = "temporary" }: RedirectConfig) {
+export default function Redirect(
+  { to, type = "temporary", concatenateParams }: RedirectConfig,
+) {
   /** https://archive.is/kWvxu */
   const statusByRedirectType: Record<
     NonNullable<RedirectConfig["type"]>,
@@ -39,7 +42,7 @@ export default function Redirect({ to, type = "temporary" }: RedirectConfig) {
      *
      * (Useful for tracking parameters e.g Google's gclid, utm_source...)
      */
-    const finalLocation = !queryString
+    const finalLocation = !queryString || !concatenateParams
       ? location
       : location.includes("?")
       ? `${location}&${queryString}`

--- a/website/handlers/redirect.ts
+++ b/website/handlers/redirect.ts
@@ -42,7 +42,7 @@ export default function Redirect(
      *
      * (Useful for tracking parameters e.g Google's gclid, utm_source...)
      */
-    const finalLocation = !queryString || !keepQueryParameters
+    const finalLocation = !queryString || discardQueryParameters
       ? location
       : location.includes("?")
       ? `${location}&${queryString}`

--- a/website/handlers/redirect.ts
+++ b/website/handlers/redirect.ts
@@ -4,7 +4,7 @@ import { isFreshCtx } from "./fresh.ts";
 export interface RedirectConfig {
   to: string;
   type?: "permanent" | "temporary";
-  keepQueryParameters?: boolean;
+  discardQueryParameters?: boolean;
 }
 
 /**

--- a/website/loaders/redirects.ts
+++ b/website/loaders/redirects.ts
@@ -7,9 +7,7 @@ const isHref = (from: string) =>
   from.startsWith("http") || (!from?.includes("*") && !from?.includes("/:"));
 
 async function getAllRedirects(ctx: AppContext): Promise<Route[]> {
-  const allRedirects = await ctx.get<
-    RedirectProps[]
-  >({
+  const allRedirects = await ctx.get<RedirectProps[]>({
     resolveType: "website/loaders/redirect.ts",
     __resolveType: defaults["resolveTypeSelector"].name,
   });
@@ -22,6 +20,7 @@ async function getAllRedirects(ctx: AppContext): Promise<Route[]> {
         __resolveType: "website/handlers/redirect.ts",
         to: redirect.to,
         type: redirect.type,
+        concatenateParams: redirect.concatenateParams,
       },
     },
   }));
@@ -36,9 +35,7 @@ export default async function Redirects(
   _req: Request,
   ctx: AppContext,
 ): Promise<Route[]> {
-  const allRedirects = await ctx.get<
-    Route[]
-  >({
+  const allRedirects = await ctx.get<Route[]>({
     key: "getAllRedirects",
     func: () => getAllRedirects(ctx),
     __resolveType: defaults["once"].name,

--- a/website/loaders/redirects.ts
+++ b/website/loaders/redirects.ts
@@ -20,7 +20,7 @@ async function getAllRedirects(ctx: AppContext): Promise<Route[]> {
         __resolveType: "website/handlers/redirect.ts",
         to: redirect.to,
         type: redirect.type,
-        concatenateParams: redirect.concatenateParams,
+        keepQueryParameters: redirect.keepQueryParameters,
       },
     },
   }));

--- a/website/loaders/redirects.ts
+++ b/website/loaders/redirects.ts
@@ -20,7 +20,7 @@ async function getAllRedirects(ctx: AppContext): Promise<Route[]> {
         __resolveType: "website/handlers/redirect.ts",
         to: redirect.to,
         type: redirect.type,
-        keepQueryParameters: redirect.keepQueryParameters,
+        discardQueryParameters: redirect.discardQueryParameters,
       },
     },
   }));

--- a/website/loaders/redirectsFromCsv.ts
+++ b/website/loaders/redirectsFromCsv.ts
@@ -2,12 +2,14 @@ import { join } from "std/path/mod.ts";
 import { Route } from "../flags/audience.ts";
 
 const REDIRECT_TYPE_ENUM = ["temporary", "permanent"];
+const CONCATENATE_PARAMS_VALUES = ["true", "false"];
 
 /** @titleBy from */
 export interface Redirect {
   from: string;
   to: string;
   type?: "temporary" | "permanent";
+  concatenateParams?: boolean;
 }
 
 export interface Redirects {
@@ -17,6 +19,15 @@ export interface Redirects {
   from?: string;
   forcePermanentRedirects?: boolean;
   redirects: Redirect[];
+}
+
+function findAndRemove<T>(array: T[], values: T[]): T | null {
+  const index = array.findIndex((item) => values.includes(item));
+  if (index !== -1) {
+    const removedItem = array.splice(index, 1)[0];
+    return removedItem;
+  }
+  return null;
 }
 
 const getRedirectFromFile = async (
@@ -45,38 +56,31 @@ const getRedirectFromFile = async (
     .slice(1)
     .map((row) => {
       // this regex is necessary to handle csv with comma as part of value
-      const parts = row.split(/,(?=(?:(?:[^"]*"){2})*[^"]*$)/);
+      const parts = row.split(/[,;](?=(?:(?:[^"]*"){2})*[^"]*$)/);
 
-      const typeRowIndex = parts.findIndex((part: string) =>
-        REDIRECT_TYPE_ENUM.includes(part)
-      );
-
-      const type =
-        (parts[typeRowIndex] as Redirect["type"]) ?? forcePermanentRedirects
-          ? "permanent"
-          : "temporary";
-
-      if (typeRowIndex !== -1) {
-        parts.splice(typeRowIndex, 1);
-      }
-
-      const last = parts[parts.length - 1];
-      parts.splice(parts.length - 1, 1);
+      const type = findAndRemove(parts, REDIRECT_TYPE_ENUM) ??
+        (forcePermanentRedirects ? "permanent" : "temporary");
+      const concatenateParams =
+        findAndRemove(parts, CONCATENATE_PARAMS_VALUES) === "true";
+      const from = parts[0];
+      const to = parts[1];
 
       return [
-        removeTrailingSlash(parts.join(",").replaceAll('"', "")),
-        removeTrailingSlash(last.replaceAll('"', "")),
+        from,
+        to,
         type,
+        concatenateParams,
       ];
     })
     .filter(([from, to]) => from && to && from !== to)
-    .map(([from, to, type]) => ({
-      from,
-      to,
+    .map(([from, to, type, concatenateParams]) => ({
+      from: from as string,
+      to: to as string,
       type: type as Redirect["type"],
+      concatenateParams: concatenateParams as boolean,
     }));
 
-  return redirectsFromFiles.map(({ from, to, type }) => ({
+  return redirectsFromFiles.map(({ from, to, type, concatenateParams }) => ({
     pathTemplate: from,
     isHref: true,
     handler: {
@@ -84,6 +88,7 @@ const getRedirectFromFile = async (
         __resolveType: "website/handlers/redirect.ts",
         to,
         type,
+        concatenateParams,
       },
     },
   }));
@@ -112,7 +117,9 @@ export default async function redirect({
 
   const redirectsFromFiles: Route[] = await routesMap.get(from)!;
 
-  const routes: Route[] = (redirects || []).map(({ from, to, type }) => ({
+  const routes: Route[] = (redirects || []).map((
+    { from, to, type, concatenateParams },
+  ) => ({
     pathTemplate: from,
     isHref: true,
     handler: {
@@ -120,6 +127,7 @@ export default async function redirect({
         __resolveType: "website/handlers/redirect.ts",
         to,
         type,
+        concatenateParams,
       },
     },
   }));

--- a/website/loaders/redirectsFromCsv.ts
+++ b/website/loaders/redirectsFromCsv.ts
@@ -56,7 +56,7 @@ const getRedirectFromFile = async (
     .slice(1)
     .map((row) => {
       // this regex is necessary to handle csv with comma as part of value
-      const parts = row.split(/[,;](?=(?:(?:[^"]*"){2})*[^"]*$)/);
+      const parts = row.split(/,(?=(?:(?:[^"]*"){2})*[^"]*$)/);
 
       const type = findAndRemove(parts, REDIRECT_TYPE_ENUM) ??
         (forcePermanentRedirects ? "permanent" : "temporary");

--- a/website/loaders/redirectsFromCsv.ts
+++ b/website/loaders/redirectsFromCsv.ts
@@ -9,7 +9,7 @@ export interface Redirect {
   from: string;
   to: string;
   type?: "temporary" | "permanent";
-  concatenateParams?: boolean;
+  keepQueryParameters?: boolean;
 }
 
 export interface Redirects {
@@ -60,7 +60,7 @@ const getRedirectFromFile = async (
 
       const type = findAndRemove(parts, REDIRECT_TYPE_ENUM) ??
         (forcePermanentRedirects ? "permanent" : "temporary");
-      const concatenateParams =
+      const keepQueryParameters =
         findAndRemove(parts, CONCATENATE_PARAMS_VALUES) === "true";
       const from = parts[0];
       const to = parts[1];
@@ -69,18 +69,18 @@ const getRedirectFromFile = async (
         from,
         to,
         type,
-        concatenateParams,
+        keepQueryParameters,
       ];
     })
     .filter(([from, to]) => from && to && from !== to)
-    .map(([from, to, type, concatenateParams]) => ({
+    .map(([from, to, type, keepQueryParameters]) => ({
       from: from as string,
       to: to as string,
       type: type as Redirect["type"],
-      concatenateParams: concatenateParams as boolean,
+      keepQueryParameters: keepQueryParameters as boolean,
     }));
 
-  return redirectsFromFiles.map(({ from, to, type, concatenateParams }) => ({
+  return redirectsFromFiles.map(({ from, to, type, keepQueryParameters }) => ({
     pathTemplate: from,
     isHref: true,
     handler: {
@@ -88,7 +88,7 @@ const getRedirectFromFile = async (
         __resolveType: "website/handlers/redirect.ts",
         to,
         type,
-        concatenateParams,
+        keepQueryParameters,
       },
     },
   }));
@@ -118,7 +118,7 @@ export default async function redirect({
   const redirectsFromFiles: Route[] = await routesMap.get(from)!;
 
   const routes: Route[] = (redirects || []).map((
-    { from, to, type, concatenateParams },
+    { from, to, type, keepQueryParameters },
   ) => ({
     pathTemplate: from,
     isHref: true,
@@ -127,7 +127,7 @@ export default async function redirect({
         __resolveType: "website/handlers/redirect.ts",
         to,
         type,
-        concatenateParams,
+        keepQueryParameters,
       },
     },
   }));

--- a/website/loaders/redirectsFromCsv.ts
+++ b/website/loaders/redirectsFromCsv.ts
@@ -9,7 +9,7 @@ export interface Redirect {
   from: string;
   to: string;
   type?: "temporary" | "permanent";
-  keepQueryParameters?: boolean;
+  discardQueryParameters?: boolean;
 }
 
 export interface Redirects {
@@ -60,7 +60,7 @@ const getRedirectFromFile = async (
 
       const type = findAndRemove(parts, REDIRECT_TYPE_ENUM) ??
         (forcePermanentRedirects ? "permanent" : "temporary");
-      const keepQueryParameters =
+      const discardQueryParameters =
         findAndRemove(parts, CONCATENATE_PARAMS_VALUES) === "true";
       const from = parts[0];
       const to = parts[1];
@@ -69,18 +69,20 @@ const getRedirectFromFile = async (
         from,
         to,
         type,
-        keepQueryParameters,
+        discardQueryParameters,
       ];
     })
     .filter(([from, to]) => from && to && from !== to)
-    .map(([from, to, type, keepQueryParameters]) => ({
+    .map(([from, to, type, discardQueryParameters]) => ({
       from: from as string,
       to: to as string,
       type: type as Redirect["type"],
-      keepQueryParameters: keepQueryParameters as boolean,
+      discardQueryParameters: discardQueryParameters as boolean,
     }));
 
-  return redirectsFromFiles.map(({ from, to, type, keepQueryParameters }) => ({
+  return redirectsFromFiles.map((
+    { from, to, type, discardQueryParameters },
+  ) => ({
     pathTemplate: from,
     isHref: true,
     handler: {
@@ -88,7 +90,7 @@ const getRedirectFromFile = async (
         __resolveType: "website/handlers/redirect.ts",
         to,
         type,
-        keepQueryParameters,
+        discardQueryParameters,
       },
     },
   }));
@@ -118,7 +120,7 @@ export default async function redirect({
   const redirectsFromFiles: Route[] = await routesMap.get(from)!;
 
   const routes: Route[] = (redirects || []).map((
-    { from, to, type, keepQueryParameters },
+    { from, to, type, discardQueryParameters },
   ) => ({
     pathTemplate: from,
     isHref: true,
@@ -127,7 +129,7 @@ export default async function redirect({
         __resolveType: "website/handlers/redirect.ts",
         to,
         type,
-        keepQueryParameters,
+        discardQueryParameters,
       },
     },
   }));


### PR DESCRIPTION
Greetings,

This PR adds the option for the user to choose whether they want to keep the parameters in the redirect or not.
The functionality was changed to add the feature for files loaded via CSV and through the dashboard.

One issue that is occurring is that in the admin panel, the option, although functional, is not being saved. I would need some assistance or correction for this.

![image](https://github.com/deco-cx/apps/assets/65980571/31735419-2b0a-4a78-bf28-58ca3c688fcd)
* In this image, I demonstrate that despite being active, if I make it public, it will work. However, after refreshing the page, it remains functional but the active status is not retained.

** The parameter combination was initially starting as true by default. In this PR, I've changed it to false because "from" leads to "to," and if the user wishes "from" to lead to "to" with parameters added, they can enable it.

See how it works (PT-BR):
https://www.loom.com/share/24b287d5634c42178c9a522fc20e5c37