### PR TITLE
Make googlefonts loader cacheable.

### DIFF
--- a/utils/shortHash.ts
+++ b/utils/shortHash.ts
@@ -1,0 +1,21 @@
+export async function hashString(input: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(input);
+
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+
+  const hashHex = hashArray.map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  return hashHex.slice(0, 8);
+}
+
+export function hashStringSync(input: string): string {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    const char = input.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash |= 0; // Convert to 32-bit integer
+  }
+  return hash.toString(16).slice(0, 8);
+}

--- a/website/loaders/fonts/googleFonts.ts
+++ b/website/loaders/fonts/googleFonts.ts
@@ -1,10 +1,24 @@
 import { fetchSafe } from "../../../utils/fetch.ts";
 import { Font } from "../../components/Theme.tsx";
 import type { Manifest } from "../../manifest.gen.ts";
+import { hashStringSync } from "../../../utils/shortHash.ts";
 
 interface Props {
   fonts: GoogleFont[];
 }
+
+export const cache = "stale-while-revalidate";
+
+export const cacheKey = (props: Props, req: Request, _ctx: unknown) => {
+  const url = new URL(req.url);
+
+  const params = new URLSearchParams([
+    ["fonts", encodeURIComponent(hashStringSync(JSON.stringify(props.fonts)))],
+  ]);
+  url.pathname = "";
+  url.search = params.toString();
+  return url.href;
+};
 
 /**
  * @title {{weight}} {{#italic}}Italic{{/italic}}{{^italic}}{{/italic}}

--- a/website/loaders/fonts/googleFonts.ts
+++ b/website/loaders/fonts/googleFonts.ts
@@ -13,7 +13,7 @@ export const cacheKey = (props: Props, req: Request, _ctx: unknown) => {
   const url = new URL(req.url);
 
   const params = new URLSearchParams([
-    ["fonts", encodeURIComponent(hashStringSync(JSON.stringify(props.fonts)))],
+    ["googlefontsloader", encodeURIComponent(hashStringSync(JSON.stringify(props.fonts)))],
   ]);
   url.pathname = "";
   url.search = params.toString();


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?

Create a cachekey for googlefonts loader based upon fonts (GoogleFonts[]) property.

## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

