### PR TITLE
Avoid frsh routes

### DIFF
--- a/website/handlers/router.ts
+++ b/website/handlers/router.ts
@@ -49,9 +49,10 @@ export const router = (
   hrefRoutes: Record<string, Resolvable<Handler>> = {},
   resolver: ResolveFunc,
   configs?: ResolveOptions,
+  parsedUrl?: URL,
 ): Handler => {
   return async (req: Request, connInfo: ConnInfo): Promise<Response> => {
-    const url = new URL(req.url);
+    const url = parsedUrl ?? new URL(req.url);
     const route = async (
       handler: Resolvable<Handler>,
       routePath: string,
@@ -153,7 +154,8 @@ export default function RoutesSelection(
 ): Handler {
   return async (req: Request, connInfo: ConnInfo): Promise<Response> => {
     // TODO: (@tlgimenes) Remove routing from request cycle
-    if ((new URL(req.url)).pathname.startsWith("/_frsh/")) {
+    const url = new URL(req.url);
+    if (url.pathname.startsWith("/_frsh/")) {
       return new Response(null, {
         status: 404,
       });
@@ -190,6 +192,7 @@ export default function RoutesSelection(
       hrefRoutes,
       ctx.get,
       { monitoring },
+      url,
     );
 
     timing?.end();

--- a/website/handlers/router.ts
+++ b/website/handlers/router.ts
@@ -153,7 +153,11 @@ export default function RoutesSelection(
 ): Handler {
   return async (req: Request, connInfo: ConnInfo): Promise<Response> => {
     // TODO: (@tlgimenes) Remove routing from request cycle
-
+    if ((new URL(req.url)).pathname.startsWith("/_frsh/")) {
+      return new Response(null, {
+        status: 404,
+      });
+    }
     const monitoring = isFreshCtx<DecoSiteState>(connInfo)
       ? connInfo.state.monitoring
       : undefined;


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?

Avoid router to match /frsh routes (and accept 200 responses)

## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

