### PR TITLE
Fix: Consider the "noIndexing" property when disabling page indexing

### DIFF
--- a/commerce/sections/Seo/SeoPDP.tsx
+++ b/commerce/sections/Seo/SeoPDP.tsx
@@ -1,11 +1,11 @@
-import Seo, { Props as SeoProps } from "../../../website/components/Seo.tsx";
-import { ProductDetailsPage } from "../../types.ts";
-import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts";
+import Seo, { Props as SeoProps } from "../../../website/components/Seo.tsx"
+import { ProductDetailsPage } from "../../types.ts"
+import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts"
 
 export type Props = {
-  jsonLD: ProductDetailsPage | null;
-  omitVariants?: boolean;
-} & Partial<Omit<SeoProps, "jsonLDs">>;
+  jsonLD: ProductDetailsPage | null
+  omitVariants?: boolean
+} & Partial<Omit<SeoProps, "jsonLDs">>
 
 /**
  * @deprecated true
@@ -13,18 +13,18 @@ export type Props = {
  * @title SeoPDP deprecated
  */
 function Section({ jsonLD, omitVariants, ...props }: Props) {
-  const title = jsonLD?.seo?.title;
-  const description = jsonLD?.seo?.description;
-  const image = jsonLD?.product.image?.[0]?.url;
+  const title = jsonLD?.seo?.title
+  const description = jsonLD?.seo?.description
+  const image = jsonLD?.product.image?.[0]?.url
   const canonical = jsonLD?.seo?.canonical
     ? jsonLD.seo.canonical
     : jsonLD?.breadcrumbList
     ? canonicalFromBreadcrumblist(jsonLD?.breadcrumbList)
-    : undefined;
-  const noIndexing = !jsonLD || jsonLD.seo?.noIndexing;
+    : undefined
+  const noIndexing = props.noIndexing || !jsonLD || jsonLD.seo?.noIndexing
 
   if (omitVariants && jsonLD?.product.isVariantOf?.hasVariant) {
-    jsonLD.product.isVariantOf.hasVariant = [];
+    jsonLD.product.isVariantOf.hasVariant = []
   }
 
   return (
@@ -37,7 +37,7 @@ function Section({ jsonLD, omitVariants, ...props }: Props) {
       jsonLDs={[jsonLD]}
       noIndexing={noIndexing}
     />
-  );
+  )
 }
 
-export default Section;
+export default Section

--- a/commerce/sections/Seo/SeoPDP.tsx
+++ b/commerce/sections/Seo/SeoPDP.tsx
@@ -1,11 +1,11 @@
-import Seo, { Props as SeoProps } from "../../../website/components/Seo.tsx"
-import { ProductDetailsPage } from "../../types.ts"
-import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts"
+import Seo, { Props as SeoProps } from "../../../website/components/Seo.tsx";
+import { ProductDetailsPage } from "../../types.ts";
+import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts";
 
 export type Props = {
-  jsonLD: ProductDetailsPage | null
-  omitVariants?: boolean
-} & Partial<Omit<SeoProps, "jsonLDs">>
+  jsonLD: ProductDetailsPage | null;
+  omitVariants?: boolean;
+} & Partial<Omit<SeoProps, "jsonLDs">>;
 
 /**
  * @deprecated true
@@ -13,18 +13,18 @@ export type Props = {
  * @title SeoPDP deprecated
  */
 function Section({ jsonLD, omitVariants, ...props }: Props) {
-  const title = jsonLD?.seo?.title
-  const description = jsonLD?.seo?.description
-  const image = jsonLD?.product.image?.[0]?.url
+  const title = jsonLD?.seo?.title;
+  const description = jsonLD?.seo?.description;
+  const image = jsonLD?.product.image?.[0]?.url;
   const canonical = jsonLD?.seo?.canonical
     ? jsonLD.seo.canonical
     : jsonLD?.breadcrumbList
     ? canonicalFromBreadcrumblist(jsonLD?.breadcrumbList)
-    : undefined
-  const noIndexing = props.noIndexing || !jsonLD || jsonLD.seo?.noIndexing
+    : undefined;
+  const noIndexing = props.noIndexing || !jsonLD || jsonLD.seo?.noIndexing;
 
   if (omitVariants && jsonLD?.product.isVariantOf?.hasVariant) {
-    jsonLD.product.isVariantOf.hasVariant = []
+    jsonLD.product.isVariantOf.hasVariant = [];
   }
 
   return (
@@ -37,7 +37,7 @@ function Section({ jsonLD, omitVariants, ...props }: Props) {
       jsonLDs={[jsonLD]}
       noIndexing={noIndexing}
     />
-  )
+  );
 }
 
-export default Section
+export default Section;

--- a/commerce/sections/Seo/SeoPDPV2.tsx
+++ b/commerce/sections/Seo/SeoPDPV2.tsx
@@ -1,25 +1,25 @@
-import Seo from "../../../website/components/Seo.tsx"
+import Seo from "../../../website/components/Seo.tsx";
 import {
   renderTemplateString,
   SEOSection,
-} from "../../../website/components/Seo.tsx"
-import { ProductDetailsPage } from "../../types.ts"
-import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts"
-import { AppContext } from "../../mod.ts"
+} from "../../../website/components/Seo.tsx";
+import { ProductDetailsPage } from "../../types.ts";
+import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts";
+import { AppContext } from "../../mod.ts";
 
 export interface Props {
   /** @title Data Source */
-  jsonLD: ProductDetailsPage | null
-  omitVariants?: boolean
+  jsonLD: ProductDetailsPage | null;
+  omitVariants?: boolean;
   /** @title Title Override */
-  title?: string
+  title?: string;
   /** @title Description Override */
-  description?: string
+  description?: string;
   /**
    * @title Disable indexing
    * @description In testing, you can use this to prevent search engines from indexing your site
    */
-  noIndexing?: boolean
+  noIndexing?: boolean;
 }
 
 /** @title Product details */
@@ -28,32 +28,32 @@ export function loader(props: Props, _req: Request, ctx: AppContext) {
     titleTemplate = "",
     descriptionTemplate = "",
     ...seoSiteProps
-  } = ctx.seo ?? {}
+  } = ctx.seo ?? {};
   const {
     title: titleProp,
     description: descriptionProp,
     jsonLD,
     omitVariants,
-  } = props
+  } = props;
 
   const title = renderTemplateString(
     titleTemplate,
-    titleProp || jsonLD?.seo?.title || ""
-  )
+    titleProp || jsonLD?.seo?.title || "",
+  );
   const description = renderTemplateString(
     descriptionTemplate,
-    descriptionProp || jsonLD?.seo?.description || ""
-  )
-  const image = jsonLD?.product.image?.[0]?.url
+    descriptionProp || jsonLD?.seo?.description || "",
+  );
+  const image = jsonLD?.product.image?.[0]?.url;
   const canonical = jsonLD?.seo?.canonical
     ? jsonLD?.seo?.canonical
     : jsonLD?.breadcrumbList
     ? canonicalFromBreadcrumblist(jsonLD?.breadcrumbList)
-    : undefined
-  const noIndexing = props.noIndexing || !jsonLD || jsonLD.seo?.noIndexing
+    : undefined;
+  const noIndexing = props.noIndexing || !jsonLD || jsonLD.seo?.noIndexing;
 
   if (omitVariants && jsonLD?.product.isVariantOf?.hasVariant) {
-    jsonLD.product.isVariantOf.hasVariant = []
+    jsonLD.product.isVariantOf.hasVariant = [];
   }
 
   return {
@@ -64,13 +64,13 @@ export function loader(props: Props, _req: Request, ctx: AppContext) {
     canonical,
     noIndexing,
     jsonLDs: [jsonLD],
-  }
+  };
 }
 
 function Section(props: Props): SEOSection {
-  return <Seo {...props} />
+  return <Seo {...props} />;
 }
 
-export { default as Preview } from "../../../website/components/_seo/Preview.tsx"
+export { default as Preview } from "../../../website/components/_seo/Preview.tsx";
 
-export default Section
+export default Section;

--- a/commerce/sections/Seo/SeoPDPV2.tsx
+++ b/commerce/sections/Seo/SeoPDPV2.tsx
@@ -1,20 +1,25 @@
-import Seo from "../../../website/components/Seo.tsx";
+import Seo from "../../../website/components/Seo.tsx"
 import {
   renderTemplateString,
   SEOSection,
-} from "../../../website/components/Seo.tsx";
-import { ProductDetailsPage } from "../../types.ts";
-import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts";
-import { AppContext } from "../../mod.ts";
+} from "../../../website/components/Seo.tsx"
+import { ProductDetailsPage } from "../../types.ts"
+import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts"
+import { AppContext } from "../../mod.ts"
 
 export interface Props {
   /** @title Data Source */
-  jsonLD: ProductDetailsPage | null;
-  omitVariants?: boolean;
+  jsonLD: ProductDetailsPage | null
+  omitVariants?: boolean
   /** @title Title Override */
-  title?: string;
+  title?: string
   /** @title Description Override */
-  description?: string;
+  description?: string
+  /**
+   * @title Disable indexing
+   * @description In testing, you can use this to prevent search engines from indexing your site
+   */
+  noIndexing?: boolean
 }
 
 /** @title Product details */
@@ -23,32 +28,32 @@ export function loader(props: Props, _req: Request, ctx: AppContext) {
     titleTemplate = "",
     descriptionTemplate = "",
     ...seoSiteProps
-  } = ctx.seo ?? {};
+  } = ctx.seo ?? {}
   const {
     title: titleProp,
     description: descriptionProp,
     jsonLD,
     omitVariants,
-  } = props;
+  } = props
 
   const title = renderTemplateString(
     titleTemplate,
-    titleProp || jsonLD?.seo?.title || "",
-  );
+    titleProp || jsonLD?.seo?.title || ""
+  )
   const description = renderTemplateString(
     descriptionTemplate,
-    descriptionProp || jsonLD?.seo?.description || "",
-  );
-  const image = jsonLD?.product.image?.[0]?.url;
+    descriptionProp || jsonLD?.seo?.description || ""
+  )
+  const image = jsonLD?.product.image?.[0]?.url
   const canonical = jsonLD?.seo?.canonical
     ? jsonLD?.seo?.canonical
     : jsonLD?.breadcrumbList
     ? canonicalFromBreadcrumblist(jsonLD?.breadcrumbList)
-    : undefined;
-  const noIndexing = !jsonLD || jsonLD.seo?.noIndexing;
+    : undefined
+  const noIndexing = props.noIndexing || !jsonLD || jsonLD.seo?.noIndexing
 
   if (omitVariants && jsonLD?.product.isVariantOf?.hasVariant) {
-    jsonLD.product.isVariantOf.hasVariant = [];
+    jsonLD.product.isVariantOf.hasVariant = []
   }
 
   return {
@@ -59,13 +64,13 @@ export function loader(props: Props, _req: Request, ctx: AppContext) {
     canonical,
     noIndexing,
     jsonLDs: [jsonLD],
-  };
+  }
 }
 
 function Section(props: Props): SEOSection {
-  return <Seo {...props} />;
+  return <Seo {...props} />
 }
 
-export { default as Preview } from "../../../website/components/_seo/Preview.tsx";
+export { default as Preview } from "../../../website/components/_seo/Preview.tsx"
 
-export default Section;
+export default Section

--- a/commerce/sections/Seo/SeoPLP.tsx
+++ b/commerce/sections/Seo/SeoPLP.tsx
@@ -1,10 +1,10 @@
-import Seo, { Props as SeoProps } from "../../../website/components/Seo.tsx"
-import { ProductListingPage } from "../../types.ts"
-import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts"
+import Seo, { Props as SeoProps } from "../../../website/components/Seo.tsx";
+import { ProductListingPage } from "../../types.ts";
+import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts";
 
 export type Props = {
-  jsonLD: ProductListingPage | null
-} & Partial<Omit<SeoProps, "jsonLDs">>
+  jsonLD: ProductListingPage | null;
+} & Partial<Omit<SeoProps, "jsonLDs">>;
 
 /**
  * @deprecated true
@@ -12,21 +12,20 @@ export type Props = {
  * @title SeoPLP deprecated
  */
 function Section({ jsonLD, ...props }: Props) {
-  const title = jsonLD?.seo?.title
-  const description = jsonLD?.seo?.description
+  const title = jsonLD?.seo?.title;
+  const description = jsonLD?.seo?.description;
   const canonical = props.canonical
     ? props.canonical
     : jsonLD?.seo?.canonical
     ? jsonLD.seo.canonical
     : jsonLD?.breadcrumb
     ? canonicalFromBreadcrumblist(jsonLD?.breadcrumb)
-    : undefined
+    : undefined;
 
-  const noIndexing =
-    props.noIndexing ||
+  const noIndexing = props.noIndexing ||
     jsonLD?.seo?.noIndexing ||
     !jsonLD ||
-    !jsonLD.products.length
+    !jsonLD.products.length;
 
   return (
     <Seo
@@ -37,7 +36,7 @@ function Section({ jsonLD, ...props }: Props) {
       jsonLDs={[jsonLD]}
       noIndexing={noIndexing}
     />
-  )
+  );
 }
 
-export default Section
+export default Section;

--- a/commerce/sections/Seo/SeoPLP.tsx
+++ b/commerce/sections/Seo/SeoPLP.tsx
@@ -1,10 +1,10 @@
-import Seo, { Props as SeoProps } from "../../../website/components/Seo.tsx";
-import { ProductListingPage } from "../../types.ts";
-import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts";
+import Seo, { Props as SeoProps } from "../../../website/components/Seo.tsx"
+import { ProductListingPage } from "../../types.ts"
+import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts"
 
 export type Props = {
-  jsonLD: ProductListingPage | null;
-} & Partial<Omit<SeoProps, "jsonLDs">>;
+  jsonLD: ProductListingPage | null
+} & Partial<Omit<SeoProps, "jsonLDs">>
 
 /**
  * @deprecated true
@@ -12,18 +12,21 @@ export type Props = {
  * @title SeoPLP deprecated
  */
 function Section({ jsonLD, ...props }: Props) {
-  const title = jsonLD?.seo?.title;
-  const description = jsonLD?.seo?.description;
+  const title = jsonLD?.seo?.title
+  const description = jsonLD?.seo?.description
   const canonical = props.canonical
     ? props.canonical
     : jsonLD?.seo?.canonical
     ? jsonLD.seo.canonical
     : jsonLD?.breadcrumb
     ? canonicalFromBreadcrumblist(jsonLD?.breadcrumb)
-    : undefined;
+    : undefined
 
-  const noIndexing = jsonLD?.seo?.noIndexing || !jsonLD ||
-    !jsonLD.products.length;
+  const noIndexing =
+    props.noIndexing ||
+    jsonLD?.seo?.noIndexing ||
+    !jsonLD ||
+    !jsonLD.products.length
 
   return (
     <Seo
@@ -34,7 +37,7 @@ function Section({ jsonLD, ...props }: Props) {
       jsonLDs={[jsonLD]}
       noIndexing={noIndexing}
     />
-  );
+  )
 }
 
-export default Section;
+export default Section

--- a/commerce/sections/Seo/SeoPLPV2.tsx
+++ b/commerce/sections/Seo/SeoPLPV2.tsx
@@ -1,26 +1,26 @@
-import Seo from "../../../website/components/Seo.tsx"
+import Seo from "../../../website/components/Seo.tsx";
 import {
   renderTemplateString,
   SEOSection,
-} from "../../../website/components/Seo.tsx"
-import { ProductListingPage } from "../../types.ts"
-import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts"
-import { AppContext } from "../../mod.ts"
+} from "../../../website/components/Seo.tsx";
+import { ProductListingPage } from "../../types.ts";
+import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts";
+import { AppContext } from "../../mod.ts";
 
 export interface Props {
   /** @title Data Source */
-  jsonLD: ProductListingPage | null
+  jsonLD: ProductListingPage | null;
   /** @title Title Override */
-  title?: string
+  title?: string;
   /** @title Description Override */
-  description?: string
+  description?: string;
   /** @hide true */
-  canonical?: string
+  canonical?: string;
   /**
    * @title Disable indexing
    * @description In testing, you can use this to prevent search engines from indexing your site
    */
-  noIndexing?: boolean
+  noIndexing?: boolean;
 }
 
 /** @title Product listing */
@@ -29,30 +29,29 @@ export function loader(props: Props, _req: Request, ctx: AppContext) {
     titleTemplate = "",
     descriptionTemplate = "",
     ...seoSiteProps
-  } = ctx.seo ?? {}
-  const { title: titleProp, description: descriptionProp, jsonLD } = props
+  } = ctx.seo ?? {};
+  const { title: titleProp, description: descriptionProp, jsonLD } = props;
 
   const title = renderTemplateString(
     titleTemplate,
-    titleProp || jsonLD?.seo?.title || ""
-  )
+    titleProp || jsonLD?.seo?.title || "",
+  );
   const description = renderTemplateString(
     descriptionTemplate,
-    descriptionProp || jsonLD?.seo?.description || ""
-  )
+    descriptionProp || jsonLD?.seo?.description || "",
+  );
   const canonical = props.canonical
     ? props.canonical
     : jsonLD?.seo?.canonical
     ? jsonLD.seo.canonical
     : jsonLD?.breadcrumb
     ? canonicalFromBreadcrumblist(jsonLD?.breadcrumb)
-    : undefined
+    : undefined;
 
-  const noIndexing =
-    props.noIndexing ||
+  const noIndexing = props.noIndexing ||
     !jsonLD ||
     !jsonLD.products.length ||
-    jsonLD.seo?.noIndexing
+    jsonLD.seo?.noIndexing;
 
   return {
     ...seoSiteProps,
@@ -61,13 +60,13 @@ export function loader(props: Props, _req: Request, ctx: AppContext) {
     canonical,
     jsonLDs: [jsonLD],
     noIndexing,
-  }
+  };
 }
 
 function Section(props: Props): SEOSection {
-  return <Seo {...props} />
+  return <Seo {...props} />;
 }
 
-export { default as Preview } from "../../../website/components/_seo/Preview.tsx"
+export { default as Preview } from "../../../website/components/_seo/Preview.tsx";
 
-export default Section
+export default Section;

--- a/commerce/sections/Seo/SeoPLPV2.tsx
+++ b/commerce/sections/Seo/SeoPLPV2.tsx
@@ -1,21 +1,26 @@
-import Seo from "../../../website/components/Seo.tsx";
+import Seo from "../../../website/components/Seo.tsx"
 import {
   renderTemplateString,
   SEOSection,
-} from "../../../website/components/Seo.tsx";
-import { ProductListingPage } from "../../types.ts";
-import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts";
-import { AppContext } from "../../mod.ts";
+} from "../../../website/components/Seo.tsx"
+import { ProductListingPage } from "../../types.ts"
+import { canonicalFromBreadcrumblist } from "../../utils/canonical.ts"
+import { AppContext } from "../../mod.ts"
 
 export interface Props {
   /** @title Data Source */
-  jsonLD: ProductListingPage | null;
+  jsonLD: ProductListingPage | null
   /** @title Title Override */
-  title?: string;
+  title?: string
   /** @title Description Override */
-  description?: string;
+  description?: string
   /** @hide true */
-  canonical?: string;
+  canonical?: string
+  /**
+   * @title Disable indexing
+   * @description In testing, you can use this to prevent search engines from indexing your site
+   */
+  noIndexing?: boolean
 }
 
 /** @title Product listing */
@@ -24,27 +29,30 @@ export function loader(props: Props, _req: Request, ctx: AppContext) {
     titleTemplate = "",
     descriptionTemplate = "",
     ...seoSiteProps
-  } = ctx.seo ?? {};
-  const { title: titleProp, description: descriptionProp, jsonLD } = props;
+  } = ctx.seo ?? {}
+  const { title: titleProp, description: descriptionProp, jsonLD } = props
 
   const title = renderTemplateString(
     titleTemplate,
-    titleProp || jsonLD?.seo?.title || "",
-  );
+    titleProp || jsonLD?.seo?.title || ""
+  )
   const description = renderTemplateString(
     descriptionTemplate,
-    descriptionProp || jsonLD?.seo?.description || "",
-  );
+    descriptionProp || jsonLD?.seo?.description || ""
+  )
   const canonical = props.canonical
     ? props.canonical
     : jsonLD?.seo?.canonical
     ? jsonLD.seo.canonical
     : jsonLD?.breadcrumb
     ? canonicalFromBreadcrumblist(jsonLD?.breadcrumb)
-    : undefined;
+    : undefined
 
-  const noIndexing = !jsonLD || !jsonLD.products.length ||
-    jsonLD.seo?.noIndexing;
+  const noIndexing =
+    props.noIndexing ||
+    !jsonLD ||
+    !jsonLD.products.length ||
+    jsonLD.seo?.noIndexing
 
   return {
     ...seoSiteProps,
@@ -53,13 +61,13 @@ export function loader(props: Props, _req: Request, ctx: AppContext) {
     canonical,
     jsonLDs: [jsonLD],
     noIndexing,
-  };
+  }
 }
 
 function Section(props: Props): SEOSection {
-  return <Seo {...props} />;
+  return <Seo {...props} />
 }
 
-export { default as Preview } from "../../../website/components/_seo/Preview.tsx";
+export { default as Preview } from "../../../website/components/_seo/Preview.tsx"
 
-export default Section;
+export default Section

--- a/website/sections/Seo/SeoV2.tsx
+++ b/website/sections/Seo/SeoV2.tsx
@@ -1,38 +1,40 @@
-import Seo, { Props as SeoProps } from "../../components/Seo.tsx";
-import { renderTemplateString, SEOSection } from "../../components/Seo.tsx";
-import { AppContext } from "../../mod.ts";
+import Seo, { Props as SeoProps } from "../../components/Seo.tsx"
+import { renderTemplateString, SEOSection } from "../../components/Seo.tsx"
+import { AppContext } from "../../mod.ts"
 
 type Props = Pick<
   SeoProps,
-  "title" | "description" | "type" | "favicon" | "image" | "themeColor"
->;
+  | "title"
+  | "description"
+  | "type"
+  | "favicon"
+  | "image"
+  | "themeColor"
+  | "noIndexing"
+>
 
-export function loader(
-  props: Props,
-  _req: Request,
-  ctx: AppContext,
-) {
+export function loader(props: Props, _req: Request, ctx: AppContext) {
   const {
     titleTemplate = "",
     descriptionTemplate = "",
     title: appTitle = "",
     description: appDescription = "",
     ...seoSiteProps
-  } = ctx.seo ?? {};
-  const { title: _title, description: _description, ...seoProps } = props;
-  const title = renderTemplateString(titleTemplate, _title ?? appTitle);
+  } = ctx.seo ?? {}
+  const { title: _title, description: _description, ...seoProps } = props
+  const title = renderTemplateString(titleTemplate, _title ?? appTitle)
   const description = renderTemplateString(
     descriptionTemplate,
-    _description ?? appDescription,
-  );
+    _description ?? appDescription
+  )
 
-  return { ...seoSiteProps, ...seoProps, title, description };
+  return { ...seoSiteProps, ...seoProps, title, description }
 }
 
 function Section(props: Props): SEOSection {
-  return <Seo {...props} />;
+  return <Seo {...props} />
 }
 
-export { default as Preview } from "../../components/_seo/Preview.tsx";
+export { default as Preview } from "../../components/_seo/Preview.tsx"
 
-export default Section;
+export default Section

--- a/website/sections/Seo/SeoV2.tsx
+++ b/website/sections/Seo/SeoV2.tsx
@@ -1,6 +1,6 @@
-import Seo, { Props as SeoProps } from "../../components/Seo.tsx"
-import { renderTemplateString, SEOSection } from "../../components/Seo.tsx"
-import { AppContext } from "../../mod.ts"
+import Seo, { Props as SeoProps } from "../../components/Seo.tsx";
+import { renderTemplateString, SEOSection } from "../../components/Seo.tsx";
+import { AppContext } from "../../mod.ts";
 
 type Props = Pick<
   SeoProps,
@@ -11,7 +11,7 @@ type Props = Pick<
   | "image"
   | "themeColor"
   | "noIndexing"
->
+>;
 
 export function loader(props: Props, _req: Request, ctx: AppContext) {
   const {
@@ -20,21 +20,21 @@ export function loader(props: Props, _req: Request, ctx: AppContext) {
     title: appTitle = "",
     description: appDescription = "",
     ...seoSiteProps
-  } = ctx.seo ?? {}
-  const { title: _title, description: _description, ...seoProps } = props
-  const title = renderTemplateString(titleTemplate, _title ?? appTitle)
+  } = ctx.seo ?? {};
+  const { title: _title, description: _description, ...seoProps } = props;
+  const title = renderTemplateString(titleTemplate, _title ?? appTitle);
   const description = renderTemplateString(
     descriptionTemplate,
-    _description ?? appDescription
-  )
+    _description ?? appDescription,
+  );
 
-  return { ...seoSiteProps, ...seoProps, title, description }
+  return { ...seoSiteProps, ...seoProps, title, description };
 }
 
 function Section(props: Props): SEOSection {
-  return <Seo {...props} />
+  return <Seo {...props} />;
 }
 
-export { default as Preview } from "../../components/_seo/Preview.tsx"
+export { default as Preview } from "../../components/_seo/Preview.tsx";
 
-export default Section
+export default Section;


### PR DESCRIPTION
This PR adjusts the SEO components to include the "noIndexing" property when disabling page indexing via the Deco CMS. Currently, the behavior is to maintain indexing if the page has data in the JSON LD, even if the user has selected in the CMS that they do not want to index the page. With the fix, the user's choice in the admin becomes the priority, so the page will not be indexed, even if it has data in the JSON LD.



Old behavior with indexing disabled in the Deco admin:

<img width="1440" alt="image" src="https://github.com/deco-cx/apps/assets/100779640/96028772-f1f4-4c3a-9417-46f3575fdc18">

Behavior after the fix:

<img width="1440" alt="image" src="https://github.com/deco-cx/apps/assets/100779640/8f90618c-b0d9-46b1-8694-8042fc37f6db">