### PR TITLE
fix: prevent TypeError in variantsExt function

### DIFF
--- a/vtex/loaders/product/extend.ts
+++ b/vtex/loaders/product/extend.ts
@@ -78,7 +78,9 @@ const variantsExt = async (
   const productsById = new Map<string, Product>();
   for (const batch of batched) {
     for (const product of batch || []) {
-      productsById.set(product.productID, product);
+      if (product) {
+        productsById.set(product.productID, product);
+      }
     }
   }
 


### PR DESCRIPTION
This PR solves de TypeError on the VariantsExt function

When updating apps to version 0.36.14, the wish list stops working and returns this error:

![image](https://github.com/deco-cx/apps/assets/6700671/adddfff1-99a0-4de1-ac88-ba61d2e34a7d)

### Suggestion

If you add a check or optional chaining in line 81 of this extend.ts (“apps/vtex/loaders/product/extend.ts”), the wish list works again

