### PR TITLE
Vtex Ads inteligent-search advertisement Prop.

### DIFF
--- a/commerce/types.ts
+++ b/commerce/types.ts
@@ -446,6 +446,15 @@ export interface Question extends Omit<Thing, "@type" | "name"> {
   author?: Author[];
 }
 
+export interface AdverTisement extends Omit<Thing, "@type"> {
+  "@type": "AdverTisement";
+  adId?: string;
+  campaignId?: string;
+  actionCost?: number;
+  adRequestId?: string;
+  adResponseId?: string;
+}
+
 export interface Product extends Omit<Thing, "@type"> {
   "@type": "Product";
   /**
@@ -487,6 +496,8 @@ export interface Product extends Omit<Thing, "@type"> {
   sku: string;
   /** A pointer to another product (or multiple products) for which this product is an accessory or spare part. */
   isAccessoryOrSparePartFor?: ProductLeaf[];
+  // The type is an optional property named "advertisement" to the code. This property is a string and is used to provide information about VTEX Ads, in search results and categories. This allows developers to customize their marketing strategies according to the specific needs and goals of the marketing team.
+  advertisement?: AdverTisement[];
 
   questions?: Question[];
 }


### PR DESCRIPTION
The type is an optional property named advertisement to the code. This property is a string and is used to provide information about VTEX Ads, in search results and categories. This allows developers to customize their marketing strategies according to the specific needs and goals of the marketing team.

![image](https://github.com/hxavierxp2/deco-apps/assets/60657828/97348845-dead-432b-aa37-3bd414712349)
