### PR TITLE
Remove quotes from utm

### DIFF
--- a/utils/normalize.ts
+++ b/utils/normalize.ts
@@ -9,6 +9,6 @@ export const removeScriptChars = (str: string): string => {
 
 export const removeNonLatin1Chars = (str: string): string => {
   // deno-lint-ignore no-control-regex
-  const latin1Regex = /[^\x00-\xFF]/g;
+  const latin1Regex = /[^\x00-\xFF]|[\"\']/g;
   return str.replace(latin1Regex, "");
 };


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
Quotes on UTM query parameters breaks VTEX API.

## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

