### PR TITLE
Add propagate options

### DIFF
--- a/website/handlers/fresh.ts
+++ b/website/handlers/fresh.ts
@@ -71,6 +71,7 @@ export default function Fresh(
       async () =>
         isDeferred<Page, BaseContext & { context: ConnInfo }>(freshConfig.page)
           ? await freshConfig.page({ context: ctx }, {
+            propagateOptions: true,
             hooks: {
               onPropsResolveStart: (
                 resolve,


### PR DESCRIPTION
This allow any subsequent calls to resolve to have the same hooks as the first one called at page level. This allows matchers to be evaluated without time restrictions.