### PR TITLE
Don't remove abort ctrl so deno can do its cleanup

### DIFF
--- a/website/handlers/fresh.ts
+++ b/website/handlers/fresh.ts
@@ -165,7 +165,6 @@ export default function Fresh(
         status: 500,
       });
     } finally {
-      req.signal.removeEventListener("abort", abortHandler);
       if (firstByteThreshold) {
         clearTimeout(firstByteThreshold);
       }


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?

## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

