### PR TITLE
feat: inline scripts support

### DIFF
--- a/algolia/sections/Analytics/Algolia.tsx
+++ b/algolia/sections/Analytics/Algolia.tsx
@@ -6,7 +6,7 @@ import {
   ViewItemEvent,
   ViewItemListEvent,
 } from "../../../commerce/types.ts";
-import { scriptAsDataURI } from "../../../utils/dataURI.ts";
+import { useScriptAsDataURI } from "../../../utils/useScript.ts";
 import { AppContext } from "../../mod.ts";
 
 declare global {
@@ -188,7 +188,7 @@ function Analytics({
   return (
     <script
       defer
-      src={scriptAsDataURI(
+      src={useScriptAsDataURI(
         setupAndListen,
         applicationId,
         searchApiKey,

--- a/analytics/components/DecoAnalytics.tsx
+++ b/analytics/components/DecoAnalytics.tsx
@@ -1,5 +1,5 @@
 import { Head } from "$fresh/runtime.ts";
-import { scriptAsDataURI } from "../../utils/dataURI.ts";
+import { useScriptAsDataURI } from "../../utils/useScript.ts";
 
 export interface Props {
   /**
@@ -96,7 +96,7 @@ function Component({ exclude, domain }: Props) {
         data-api="https://plausible.io/api/event"
         src="https://plausible.io/js/script.manual.js"
       />
-      <script defer src={scriptAsDataURI(snippet)} />
+      <script defer src={useScriptAsDataURI(snippet)} />
     </Head>
   );
 }

--- a/analytics/loaders/DecoAnalyticsScript.ts
+++ b/analytics/loaders/DecoAnalyticsScript.ts
@@ -1,6 +1,6 @@
 import { Script } from "../../website/types.ts";
 import { AppContext } from "../mod.ts";
-import { scriptAsDataURI } from "../../utils/dataURI.ts";
+import { useScriptAsDataURI } from "../../utils/useScript.ts";
 import { Flag } from "deco/types.ts";
 
 export type Props = {
@@ -96,7 +96,7 @@ const loader = (
     } data-api="https://plausible.io/api/event" src="https://plausible.io/js/script.manual.hash.js"></script>`;
 
     const flagsScript = `<script defer src="${
-      scriptAsDataURI(snippet)
+      useScriptAsDataURI(snippet)
     }"></script>`;
 
     return dnsPrefetchLink + preconnectLink + plausibleScript + flagsScript;

--- a/htmx/hooks/useScript.ts
+++ b/htmx/hooks/useScript.ts
@@ -1,0 +1,51 @@
+/**
+ * By importing this file, you will get a `wasm` module added to your server
+ * while it's booting. If it fails to load, your server will hang indefinitely.
+ *
+ * Use at your own risk.
+ */
+
+import initSwc, {
+  transformSync,
+} from "https://cdn.jsdelivr.net/npm/@swc/wasm-web/wasm-web.js";
+import { LRU } from "../../utils/lru.ts";
+
+await initSwc(
+  "https://cdn.jsdelivr.net/npm/@swc/wasm-web@1.5.25/wasm-web_bg.wasm",
+);
+
+const cache = LRU(100);
+
+const minify = (js: string) => {
+  const start = performance.now();
+
+  const code = transformSync(js, {
+    minify: true,
+    jsc: {
+      target: "esnext",
+      minify: { mangle: true, format: { comments: false } },
+    },
+  }, undefined).code.replace(/;$/, "");
+  const duration = performance.now() - start;
+
+  cache.set(js, code);
+
+  console.log(
+    `[htmx]: ${duration}ms minifiying script ${
+      js.slice(0, 38).replace(/(\n|\s)+/g, " ")
+    }...`,
+  );
+
+  return code;
+};
+
+// deno-lint-ignore no-explicit-any
+export function useScript<T extends (...args: any[]) => any>(
+  fn: T,
+  ...params: Parameters<T>
+) {
+  const javascript = fn.toString();
+  const minified = cache.get(javascript) || minify(javascript);
+
+  return `(${minified})(${params.map((p) => JSON.stringify(p)).join(", ")})`;
+}

--- a/htmx/sections/htmx.tsx
+++ b/htmx/sections/htmx.tsx
@@ -1,6 +1,6 @@
 import { Head } from "$fresh/runtime.ts";
 import { SectionProps } from "deco/mod.ts";
-import { useScript } from "../hooks/useScript.ts";
+import { useScript } from "../../utils/useScript.ts";
 import { AppContext, Extension } from "../mod.ts";
 
 const script = (extensions: Extension[]) => {

--- a/htmx/sections/htmx.tsx
+++ b/htmx/sections/htmx.tsx
@@ -1,7 +1,7 @@
 import { Head } from "$fresh/runtime.ts";
-import { AppContext, Extension } from "../mod.ts";
-import { scriptAsDataURI } from "../../utils/dataURI.ts";
 import { SectionProps } from "deco/mod.ts";
+import { useScript } from "../hooks/useScript.ts";
+import { AppContext, Extension } from "../mod.ts";
 
 const script = (extensions: Extension[]) => {
   if (extensions.length > 0) {
@@ -13,8 +13,7 @@ function Section({ version, cdn, extensions }: SectionProps<typeof loader>) {
   return (
     <Head>
       <script
-        defer
-        src={scriptAsDataURI(script, extensions)}
+        dangerouslySetInnerHTML={{ __html: useScript(script, extensions) }}
       />
       <script
         defer

--- a/sourei/sections/Analytics/Sourei.tsx
+++ b/sourei/sections/Analytics/Sourei.tsx
@@ -1,6 +1,6 @@
 // deno-lint-ignore-file no-explicit-any
 import { Head } from "$fresh/runtime.ts";
-import { scriptAsDataURI } from "../../../utils/dataURI.ts";
+import { useScriptAsDataURI } from "../../../utils/useScript.ts";
 
 interface Props {
   /**
@@ -86,7 +86,11 @@ function Section({
           async={loading === "async"}
           type={loading === "module" ? "module" : "text/javascript"}
         />
-        <script src={scriptAsDataURI(snippet)} defer type="text/javascript" />
+        <script
+          src={useScriptAsDataURI(snippet)}
+          defer
+          type="text/javascript"
+        />
       </Head>
 
       {/* Body */}

--- a/utils/dataURI.ts
+++ b/utils/dataURI.ts
@@ -13,7 +13,7 @@ export const scriptAsDataURI = <T extends (...args: any[]) => any>(
   if (once) {
     once = false;
     console.warn(
-      `scriptAsDataURI is deprecated and will soon be removed. Use import { useScriptAsDataURI } from 'apps/hooks/useScrip.ts' instead.`,
+      `scriptAsDataURI is deprecated and will soon be removed. Use import { useScriptAsDataURI } from 'apps/hooks/useScript.ts' instead.`,
     );
   }
 

--- a/utils/dataURI.ts
+++ b/utils/dataURI.ts
@@ -1,3 +1,5 @@
+let once = true;
+
 // Avoid throwing DOM Exception:
 // The string to be encoded contains characters outside of the Latin1 range.
 const btoaSafe = (x: string) =>
@@ -7,12 +9,20 @@ const btoaSafe = (x: string) =>
 export const scriptAsDataURI = <T extends (...args: any[]) => any>(
   fn: T,
   ...params: Parameters<T>
-) =>
-  dataURI(
+) => {
+  if (once) {
+    once = false;
+    console.warn(
+      `scriptAsDataURI is deprecated and will soon be removed. Use import { useScriptAsDataURI } from 'apps/hooks/useScrip.ts' instead.`,
+    );
+  }
+
+  return dataURI(
     "text/javascript",
     true,
     `(${fn})(${params.map((p) => JSON.stringify(p)).join(", ")})`,
   );
+};
 
 export const dataURI = (
   contentType: "text/javascript",

--- a/utils/lru.ts
+++ b/utils/lru.ts
@@ -1,0 +1,24 @@
+export const LRU = <K, T>(max: number) => {
+  const cache = new Map<K, T>();
+
+  return {
+    get: (key: K) => {
+      const value = cache.get(key);
+
+      // update LRU index
+      if (value) {
+        cache.delete(key);
+        cache.set(key, value);
+      }
+
+      return value;
+    },
+    set: (key: K, value: T) => {
+      if (cache.size > max) {
+        const lru = cache.keys().next().value;
+        cache.delete(lru);
+      }
+      cache.set(key, value);
+    },
+  };
+};

--- a/utils/lru.ts
+++ b/utils/lru.ts
@@ -20,5 +20,8 @@ export const LRU = <K, T>(max: number) => {
       }
       cache.set(key, value);
     },
+    delete: (key: K) => {
+      cache.delete(key);
+    },
   };
 };

--- a/vtex/components/VTEXPortalDataLayerCompatibility.tsx
+++ b/vtex/components/VTEXPortalDataLayerCompatibility.tsx
@@ -1,6 +1,6 @@
 import { type JSX } from "preact";
 import { Product } from "../../commerce/types.ts";
-import { scriptAsDataURI } from "../../utils/dataURI.ts";
+import { useScriptAsDataURI } from "../../utils/useScript.ts";
 
 declare global {
   interface Window {
@@ -122,7 +122,7 @@ export function AddVTEXPortalData({
       {...props}
       id="datalayer-portal-compat"
       defer
-      src={scriptAsDataURI(addVTEXPortalDataSnippet, accountName)}
+      src={useScriptAsDataURI(addVTEXPortalDataSnippet, accountName)}
     />
   );
 }
@@ -176,7 +176,7 @@ export function ProductDetailsTemplate({
     <script
       {...props}
       defer
-      src={scriptAsDataURI((t) => {
+      src={useScriptAsDataURI((t) => {
         globalThis.window.datalayer_product = t;
       }, template)}
     />
@@ -194,7 +194,7 @@ export function ProductInfo({ product, ...props }: ProductInfoProps) {
       {...props}
       defer
       data-product-info
-      src={scriptAsDataURI((t) => {
+      src={useScriptAsDataURI((t) => {
         globalThis.window.shelfProductIds = globalThis.window.shelfProductIds ||
           [];
         globalThis.window.shelfProductIds.push(t);
@@ -211,7 +211,7 @@ export function ProductSKUJson({ product, ...props }: ProductSKUJsonProps) {
     <script
       {...props}
       defer
-      src={scriptAsDataURI((p) => {
+      src={useScriptAsDataURI((p) => {
         globalThis.window.skuJson = p;
       }, product)}
     />

--- a/vtex/sections/Analytics/Vtex.tsx
+++ b/vtex/sections/Analytics/Vtex.tsx
@@ -3,7 +3,7 @@ import {
   AnalyticsItem,
   SelectItemEvent,
 } from "../../../commerce/types.ts";
-import { scriptAsDataURI } from "../../../utils/dataURI.ts";
+import { useScriptAsDataURI } from "../../../utils/useScript.ts";
 import { AppContext } from "../../mod.ts";
 import { SectionProps } from "deco/blocks/section.ts";
 import { getISCookiesFromBag } from "../../utils/intelligentSearch.ts";
@@ -105,7 +105,7 @@ export default function VtexAnalytics(
     <script
       type="text/javascript"
       defer
-      src={scriptAsDataURI(snippet, account, agent, cookies)}
+      src={useScriptAsDataURI(snippet, account, agent, cookies)}
     />
   );
 }

--- a/website/components/Analytics.tsx
+++ b/website/components/Analytics.tsx
@@ -1,6 +1,6 @@
 import { Head } from "$fresh/runtime.ts";
 import { context } from "deco/live.ts";
-import { scriptAsDataURI } from "../../utils/dataURI.ts";
+import { useScriptAsDataURI } from "../../utils/useScript.ts";
 
 interface Hosted {
   trackingId: string;
@@ -149,7 +149,7 @@ export default function Analytics({
       )}
 
       {disableAutomaticEventPush !== true && (
-        <script defer id="analytics-script" src={scriptAsDataURI(snippet)} />
+        <script defer id="analytics-script" src={useScriptAsDataURI(snippet)} />
       )}
     </>
   );

--- a/website/components/Events.tsx
+++ b/website/components/Events.tsx
@@ -1,7 +1,7 @@
 import { Head } from "$fresh/runtime.ts";
 import { DECO_SEGMENT } from "deco/runtime/fresh/middlewares/3_main.ts";
 import { type AnalyticsEvent, type Deco } from "../../commerce/types.ts";
-import { scriptAsDataURI } from "../../utils/dataURI.ts";
+import { useScriptAsDataURI } from "../../utils/useScript.ts";
 import { Flag } from "deco/types.ts";
 
 type EventHandler = (event?: AnalyticsEvent) => void | Promise<void>;
@@ -91,7 +91,7 @@ function Events({ deco }: { deco: Deco }) {
       <script
         defer
         id="deco-events"
-        src={scriptAsDataURI(snippet, { deco, segmentCookie: DECO_SEGMENT })}
+        src={useScriptAsDataURI(snippet, { deco, segmentCookie: DECO_SEGMENT })}
       />
     </Head>
   );

--- a/website/components/_Controls.tsx
+++ b/website/components/_Controls.tsx
@@ -4,7 +4,7 @@ import type { Flag, Site } from "deco/types.ts";
 import { DomInspectorActivators } from "https://deno.land/x/inspect_vscode@0.2.1/inspector.ts";
 import { DomInspector } from "https://deno.land/x/inspect_vscode@0.2.1/mod.ts";
 import { Page } from "../../commerce/types.ts";
-import { scriptAsDataURI } from "../../utils/dataURI.ts";
+import { useScriptAsDataURI } from "../../utils/useScript.ts";
 
 const IS_LOCALHOST = context.deploymentId === undefined;
 
@@ -130,7 +130,7 @@ function LiveControls(
     <Head>
       <script
         defer
-        src={scriptAsDataURI(snippet, {
+        src={useScriptAsDataURI(snippet, {
           page,
           site,
           flags,

--- a/website/sections/Rendering/Deferred.tsx
+++ b/website/sections/Rendering/Deferred.tsx
@@ -1,7 +1,7 @@
 import type { Section } from "deco/blocks/section.ts";
 import { usePartialSection } from "deco/hooks/usePartialSection.ts";
 import { useId } from "preact/hooks";
-import { scriptAsDataURI } from "../../../utils/dataURI.ts";
+import { useScriptAsDataURI } from "../../../utils/useScript.ts";
 
 /** @titleBy type */
 interface Scroll {
@@ -86,7 +86,7 @@ const Deferred = (props: Props) => {
       />
       <script
         defer
-        src={scriptAsDataURI(
+        src={useScriptAsDataURI(
           script,
           buttonId,
           behavior?.type || "intersection",


### PR DESCRIPTION
This PR adds a new hook called useScript. 

This hook allows you to write inline scrips, much like `scriptAsDataURI` function, but without having to deal with minification. Also, this PR drops support for `scriptAsDataURI` function since I've discovered base64 increases up to 30% final uris and encodeURIComponent should do the job.