### PR TITLE
feat: Retrives user document information by GraphQL Query

### DIFF
--- a/vtex/loaders/user.ts
+++ b/vtex/loaders/user.ts
@@ -10,13 +10,14 @@ interface User {
   lastName?: string;
   profilePicture?: string;
   gender?: string;
+  document?: string;
 }
 
 async function loader(
   _props: unknown,
   req: Request,
   ctx: AppContext,
-): Promise<Person | null> {
+): Promise<Person & { document?: string } | null> {
   const { io } = ctx;
   const { cookie, payload } = parseCookie(req.headers, ctx.account);
 
@@ -25,7 +26,7 @@ async function loader(
   }
 
   const query =
-    "query getUserProfile { profile { id userId email firstName lastName profilePicture gender }}";
+    "query getUserProfile { profile { id userId email firstName lastName profilePicture gender document }}";
 
   try {
     const { profile: user } = await io.query<{ profile: User }, null>(
@@ -38,6 +39,7 @@ async function loader(
       email: user.email,
       givenName: user.firstName,
       familyName: user.lastName,
+      document: user.document,
       gender: user.gender === "f"
         ? "https://schema.org/Female"
         : "https://schema.org/Male",


### PR DESCRIPTION
This Pull Request introduces a modification to the loader to fetch the document (CPF) field of a user via a GraphQL query. The purpose of this change is to enable communication with a Cashback API, allowing the retrieval of cashback values for a user based on their CPF.

# Objective

- CPF Capture: The updated loader allows obtaining the user's CPF, which is necessary for communication with the Cashback API.
- Cashback API Integration: With the user's CPF, it will be possible to query the available cashback values for the user.
- GraphQL Query: The loader uses a GraphQL query to fetch the user profile, including the CPF.

Usage Example:
```
{
  "@id": "user-id",
  "email": "user@example.com",
  "givenName": "First",
  "familyName": "Last",
  "document": "123.456.789-00",
  "gender": "https://schema.org/Female"
}
```
Request:

The loader function will be triggered as part of the normal application flow, capturing the user profile details, including the CPF.