### PR TITLE
fix: set attributes after DOM loads

### DIFF
--- a/htmx/sections/htmx.tsx
+++ b/htmx/sections/htmx.tsx
@@ -5,7 +5,14 @@ import { AppContext, Extension } from "../mod.ts";
 
 const script = (extensions: Extension[]) => {
   if (extensions.length > 0) {
-    document.body.setAttribute("hx-ext", extensions.join(","));
+    if (document.readyState === "complete") {
+      document.body.setAttribute("hx-ext", extensions.join(","));
+      return;
+    }
+
+    globalThis.onload = () => {
+      document.body.setAttribute("hx-ext", extensions.join(","));
+    };
   }
 };
 


### PR DESCRIPTION
The HTMX script was trying to define the "hx-ext" attribute in the "body" so that the extensions would be available throughout the site, but as the script is in the <head> the body does not exist yet, returning null and giving an error when adding the attribute, now the script checks if the DOM is already loaded to add the extensions, and if not, it adds an onload listener to the window to be added as soon as possible