### PR TITLE
fix: remove ai assistant error insuportavel

### DIFF
--- a/ai-assistants/mod.ts
+++ b/ai-assistants/mod.ts
@@ -146,6 +146,10 @@ export default function App(
 ): App<Manifest, State, [ReturnType<typeof openai>]> {
   const openAIApp = openai(state);
   const assistantsAPI = openAIApp.state.openAI.beta.assistants;
+  // Sets assistantId only if state.assistants exists
+  const assistantId = (state.assistants?.[0] ?? null) !== null
+    ? state.assistantId
+    : "";
   return {
     manifest,
     state: {
@@ -170,9 +174,7 @@ export default function App(
         {},
       ),
       instructions: `${state.instructions ?? ""}`,
-      assistant: assistantsAPI.retrieve(
-        state.assistantId,
-      ),
+      assistant: assistantsAPI.retrieve(assistantId),
       s3: new AWS.S3({
         region: state.assistantAwsProps?.assistantBucketRegion.get?.() ??
           Deno.env.get("ASSISTANT_BUCKET_REGION"),


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?
Removendo esse erro do admin.
O id que ele se refere no erro existe sim na nossa openAI, mas nao tem nenhum assistente no admin configurado, logo teoricamente esse assistant_id existe, mas na verdade nao existe. E quem solta esse erro é a funcao de retrieve. Entao parece que checando antes se existe algum assistente configurado resolve o problema. Acho que isso resolve o erro sem quebrar o funcionamento anterior...

![Screenshot 2024-06-28 at 13 08 00](https://github.com/deco-cx/apps/assets/43659990/ab1cf77e-00a9-48e5-b4be-ab55c56128b2)


## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

