### PR TITLE
fix: Prevent the cart from resorting when the quantity is updated

### DIFF
--- a/wake/actions/cart/updateItemQuantity.ts
+++ b/wake/actions/cart/updateItemQuantity.ts
@@ -2,12 +2,9 @@ import { HttpError } from "../../../utils/http.ts";
 import { AppContext } from "../../mod.ts";
 import { getCartCookie, setCartCookie } from "../../utils/cart.ts";
 import {
-  AddItemToCart,
   RemoveItemFromCart,
 } from "../../utils/graphql/queries.ts";
 import {
-  AddItemToCartMutation,
-  AddItemToCartMutationVariables,
   CheckoutFragment,
   RemoveItemFromCartMutation,
   RemoveItemFromCartMutationVariables,
@@ -20,22 +17,6 @@ export interface Props {
   customization?: { customizationId: number; value: string }[];
   subscription?: { subscriptionGroupId: number; recurringTypeId: number };
 }
-
-const addToCart = (
-  props: Props,
-  cartId: string,
-  ctx: AppContext,
-  headers: Headers,
-) =>
-  ctx.storefront.query<
-    AddItemToCartMutation,
-    AddItemToCartMutationVariables
-  >({
-    variables: {
-      input: { id: cartId, products: [props] },
-    },
-    ...AddItemToCart,
-  }, { headers });
 
 const removeFromCart = (
   props: Props,
@@ -64,6 +45,13 @@ const action = async (
   if (!cartId) {
     throw new HttpError(400, "Missing cart cookie");
   }
+
+  /* 
+  * get cart
+  * find the current product on cart
+  * the current amount
+  * calculate the difference between the current item amount and requested new amount 
+  */
 
   const cart = await ctx.invoke.wake.loaders.cart(props, req)
   const item = cart.products?.find(item => item?.productVariantId === props.productVariantId)

--- a/wake/actions/cart/updateItemQuantity.ts
+++ b/wake/actions/cart/updateItemQuantity.ts
@@ -48,7 +48,7 @@ const removeFromCart = (
     RemoveItemFromCartMutationVariables
   >({
     variables: {
-      input: { id: cartId, products: [{ ...props }] },
+      input: { id: cartId, products: [props] },
     },
     ...RemoveItemFromCart,
   }, { headers });

--- a/wake/actions/cart/updateItemQuantity.ts
+++ b/wake/actions/cart/updateItemQuantity.ts
@@ -75,7 +75,7 @@ const action = async (
   if (props.quantity > 0 && quantity > 0) {
     checkout = await ctx.invoke.wake.actions.cart.addItem({...props, quantity})
   } else {
-    const data = await removeFromCart({...props, quantity:quantity*-1}, cartId, ctx, headers);
+    const data = await removeFromCart({...props, quantity:-quantity}, cartId, ctx, headers);
     checkout = data.checkout
   }
 


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?

Ao aumentar a quantidade no minicart o produto era removido e adicionado novamente, alterando a ordem dos produtos 

Esse PR corrige esse comportamento

## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

