### PR TITLE
linx(fix + debug): Exclude headers that cause the API to fail on different infra + CURL logs for proxy and outbound requests.

### DIFF
--- a/linx/loaders/proxy.ts
+++ b/linx/loaders/proxy.ts
@@ -19,7 +19,7 @@ const linxProxyFailingHeaders = [
   "x-envoy-attempt-count",
 ];
 
-const removeFailingHeaders = (headers: Headers) => {
+export const removeFailingHeaders = (headers: Headers) => {
   for (const header of linxProxyFailingHeaders) {
     headers.delete(header);
   }

--- a/linx/loaders/proxy.ts
+++ b/linx/loaders/proxy.ts
@@ -12,6 +12,20 @@ const PATHS_TO_PROXY = [
 ];
 const decoSiteMapUrl = "/sitemap/deco.xml";
 
+const linxProxyFailingHeaders = [
+  "x-b3-sampled",
+  "x-b3-spanid",
+  "x-b3-traceid",
+  "x-envoy-attempt-count",
+];
+
+const removeFailingHeaders = (headers: Headers) => {
+  for (const header of linxProxyFailingHeaders) {
+    headers.delete(header);
+  }
+  return headers;
+}
+
 const buildProxyRoutes = (
   {
     ctx: { account },
@@ -50,6 +64,7 @@ const buildProxyRoutes = (
           host: hostToUse,
           redirect: "follow",
           includeScriptsToHead,
+          transformHeaders: removeFailingHeaders,
         },
       },
     });

--- a/linx/loaders/proxy.ts
+++ b/linx/loaders/proxy.ts
@@ -19,13 +19,6 @@ const linxProxyFailingHeaders = [
   "x-envoy-attempt-count",
 ];
 
-export const removeFailingHeaders = (headers: Headers) => {
-  for (const header of linxProxyFailingHeaders) {
-    headers.delete(header);
-  }
-  return headers;
-}
-
 const buildProxyRoutes = (
   {
     ctx: { account },
@@ -64,7 +57,7 @@ const buildProxyRoutes = (
           host: hostToUse,
           redirect: "follow",
           includeScriptsToHead,
-          transformHeaders: removeFailingHeaders,
+          excludeHeaders: linxProxyFailingHeaders,
         },
       },
     });

--- a/linx/loaders/proxy.ts
+++ b/linx/loaders/proxy.ts
@@ -1,6 +1,7 @@
 import { Route } from "../../website/flags/audience.ts";
 import { AppContext } from "../mod.ts";
 import { Script } from "../../website/types.ts";
+import { linxProxyFailingHeaders } from "../utils/headers.ts";
 
 const PATHS_TO_PROXY = [
   "/login",
@@ -11,13 +12,6 @@ const PATHS_TO_PROXY = [
   "/painel-do-cliente/*",
 ];
 const decoSiteMapUrl = "/sitemap/deco.xml";
-
-const linxProxyFailingHeaders = [
-  "x-b3-sampled",
-  "x-b3-spanid",
-  "x-b3-traceid",
-  "x-envoy-attempt-count",
-];
 
 const buildProxyRoutes = (
   {

--- a/linx/loaders/proxy.ts
+++ b/linx/loaders/proxy.ts
@@ -1,7 +1,6 @@
 import { Route } from "../../website/flags/audience.ts";
 import { AppContext } from "../mod.ts";
 import { Script } from "../../website/types.ts";
-import { linxProxyFailingHeaders } from "../utils/headers.ts";
 
 const PATHS_TO_PROXY = [
   "/login",
@@ -51,7 +50,6 @@ const buildProxyRoutes = (
           host: hostToUse,
           redirect: "follow",
           includeScriptsToHead,
-          excludeHeaders: linxProxyFailingHeaders,
         },
       },
     });

--- a/linx/utils/headers.ts
+++ b/linx/utils/headers.ts
@@ -1,5 +1,12 @@
 import { removeCFHeaders } from "../../website/handlers/proxy.ts";
 
+export const linxProxyFailingHeaders = [
+  "x-b3-sampled",
+  "x-b3-spanid",
+  "x-b3-traceid",
+  "x-envoy-attempt-count",
+];
+
 /**
  * Some headers can cause the linx API to error, so we always filter
  * only the necessary ones when proxying request headers to the linx API
@@ -8,6 +15,10 @@ export function toLinxHeaders(inputHeaders: Headers): Headers {
   const headers = new Headers(inputHeaders);
 
   removeCFHeaders(headers);
+
+  for (const header of linxProxyFailingHeaders) {
+    headers.delete(header);
+  }
 
   return headers;
 }

--- a/linx/utils/headers.ts
+++ b/linx/utils/headers.ts
@@ -5,6 +5,7 @@ export const linxProxyFailingHeaders = [
   "x-b3-spanid",
   "x-b3-traceid",
   "x-envoy-attempt-count",
+  "k-proxy-request",
 ];
 
 const linxApiFailingHeaders = [
@@ -12,7 +13,6 @@ const linxApiFailingHeaders = [
   "host",
   "origin",
   "referer",
-  "k-proxy-request",
 ];
 
 /**

--- a/linx/utils/headers.ts
+++ b/linx/utils/headers.ts
@@ -7,6 +7,14 @@ export const linxProxyFailingHeaders = [
   "x-envoy-attempt-count",
 ];
 
+const linxApiFailingHeaders = [
+  "forwarded",
+  "host",
+  "origin",
+  "referer",
+  "k-proxy-request",
+];
+
 /**
  * Some headers can cause the linx API to error, so we always filter
  * only the necessary ones when proxying request headers to the linx API
@@ -17,6 +25,10 @@ export function toLinxHeaders(inputHeaders: Headers): Headers {
   removeCFHeaders(headers);
 
   for (const header of linxProxyFailingHeaders) {
+    headers.delete(header);
+  }
+
+  for (const header of linxApiFailingHeaders) {
     headers.delete(header);
   }
 

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -1,5 +1,6 @@
 import { RequestInit } from "deco/runtime/fetch/mod.ts";
 import { fetchSafe } from "./fetch.ts";
+import { fetchToCurl } from "jsr:@viktor/fetch-to-curl";
 
 const HTTP_VERBS = new Set(
   [
@@ -150,6 +151,13 @@ export const createHttpClient = <T>({
 
         const body = isJSON ? JSON.stringify(init.body) : init?.body;
 
+        const curl = fetchToCurl(url.href, {
+          ...init,
+          headers,
+          method,
+          body,
+        });
+        console.log(curl);
         return fetcher(url.href, {
           ...init,
           headers,

--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -166,6 +166,14 @@ export default function Proxy({
 
     const fetchFunction = async () => {
       try {
+        const curl = await fetch(to, {
+          headers: headersTransformed,
+          redirect,
+          method: req.method,
+          body: req.body,
+        });
+        console.log(curl);
+
         return await fetch(to, {
           headers: headersTransformed,
           redirect,

--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -3,7 +3,8 @@ import { DecoSiteState } from "deco/mod.ts";
 import { Handler } from "std/http/mod.ts";
 import { proxySetCookie } from "../../utils/cookie.ts";
 import { Script } from "../types.ts";
-import { Monitoring } from "deco/engine/core/resolver.ts";;
+import { Monitoring } from "deco/engine/core/resolver.ts";
+import { fetchToCurl } from "jsr:@viktor/fetch-to-curl";
 
 const HOP_BY_HOP = [
   "Keep-Alive",
@@ -169,6 +170,13 @@ export default function Proxy({
 
     const fetchFunction = async () => {
       try {
+        const curl = fetchToCurl(to, { 
+          headers,
+          redirect,
+          method: req.method,
+          body: req.body,
+        });
+        console.log(curl);
         return await fetch(to, {
           headers,
           redirect,

--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -5,6 +5,8 @@ import { proxySetCookie } from "../../utils/cookie.ts";
 import { Script } from "../types.ts";
 import { Monitoring } from "deco/engine/core/resolver.ts";
 import { fetchToCurl } from "jsr:@viktor/fetch-to-curl";
+import { removeFailingHeaders } from "../../linx/loaders/proxy.ts";
+import { transform } from "deco/deps.ts";
 
 const HOP_BY_HOP = [
   "Keep-Alive",
@@ -163,11 +165,12 @@ export default function Proxy({
       ? _ctx?.state?.monitoring
       : undefined;
 
-    const headersTransformed = transformHeaders(new Headers(headers));
+      console.log(transformHeaders)
+    const headersTransformed = removeFailingHeaders(new Headers(headers));
 
     const fetchFunction = async () => {
       try {
-        const curl = await fetchToCurl(to, {
+        const curl = fetchToCurl(to, {
           headers: headersTransformed,
           redirect,
           method: req.method,

--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -4,6 +4,7 @@ import { Handler } from "std/http/mod.ts";
 import { proxySetCookie } from "../../utils/cookie.ts";
 import { Script } from "../types.ts";
 import { Monitoring } from "deco/engine/core/resolver.ts";
+import { fetchToCurl } from "jsr:@viktor/fetch-to-curl";
 
 const HOP_BY_HOP = [
   "Keep-Alive",
@@ -166,7 +167,7 @@ export default function Proxy({
 
     const fetchFunction = async () => {
       try {
-        const curl = await fetch(to, {
+        const curl = await fetchToCurl(to, {
           headers: headersTransformed,
           redirect,
           method: req.method,

--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -4,6 +4,7 @@ import { Handler } from "std/http/mod.ts";
 import { proxySetCookie } from "../../utils/cookie.ts";
 import { Script } from "../types.ts";
 import { Monitoring } from "deco/engine/core/resolver.ts";
+import { fetchToCurl } from "jsr:@viktor/fetch-to-curl";
 
 const HOP_BY_HOP = [
   "Keep-Alive",
@@ -162,6 +163,13 @@ export default function Proxy({
     headers.forEach((value, key) => {
       console.log("proxy sending header", key, value);
     });
+
+    console.log("CURL", fetchToCurl(to, {
+      headers,
+      redirect,
+      method: req.method,
+      body: req.body,
+    }));
     const fetchFunction = async () => {
       try {
         return await fetch(to, {

--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -160,7 +160,13 @@ export default function Proxy({
       }
     }
 
+    console.log({
+      excludeHeaders,
+    });
     for (const key of excludeHeaders) {
+      console.log({
+        "excludeHeaders.key": key,
+      });
       headers.delete(key);
     }
 

--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -159,6 +159,9 @@ export default function Proxy({
       ? _ctx?.state?.monitoring
       : undefined;
 
+    headers.forEach((value, key) => {
+      console.log("proxy sending header", key, value);
+    });
     const fetchFunction = async () => {
       try {
         return await fetch(to, {

--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -5,6 +5,7 @@ import { proxySetCookie } from "../../utils/cookie.ts";
 import { Script } from "../types.ts";
 import { Monitoring } from "deco/engine/core/resolver.ts";
 import { fetchToCurl } from "jsr:@viktor/fetch-to-curl";
+import { linxProxyFailingHeaders } from "../../linx/utils/headers.ts";
 
 const HOP_BY_HOP = [
   "Keep-Alive",
@@ -85,8 +86,6 @@ export interface Props {
    */
   customHeaders?: Header[];
 
-  excludeHeaders?: string[];
-
   /**
    * @description Scripts to be included in the head of the html
    */
@@ -114,7 +113,6 @@ export default function Proxy({
   basePath,
   host: hostToUse,
   customHeaders = [],
-  excludeHeaders = [],
   includeScriptsToHead,
   redirect = "manual",
   avoidAppendPath,
@@ -160,13 +158,7 @@ export default function Proxy({
       }
     }
 
-    console.log({
-      excludeHeaders,
-    });
-    for (const key of excludeHeaders) {
-      console.log({
-        "excludeHeaders.key": key,
-      });
+    for (const key of linxProxyFailingHeaders) {
       headers.delete(key);
     }
 


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?

## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

