### PR TITLE
Blog: Expose blogpost unique identifier

### DIFF
--- a/blog/types.ts
+++ b/blog/types.ts
@@ -18,6 +18,7 @@ export interface Category {
 }
 
 export interface BlogPost {
+  name: string,
   title: string;
   excerpt: string;
   image?: ImageWidget;

--- a/blog/types.ts
+++ b/blog/types.ts
@@ -18,7 +18,7 @@ export interface Category {
 }
 
 export interface BlogPost {
-  name: string,
+  name: string;
   title: string;
   excerpt: string;
   image?: ImageWidget;

--- a/blog/utils/records.ts
+++ b/blog/utils/records.ts
@@ -14,5 +14,11 @@ export async function getRecordsByPath<T>(
     return key.startsWith(path) ? value : [];
   });
 
-  return (current as Record<string, T>[]).map((item) => item[accessor]);
+  return (current as Record<string, T>[]).map((item) => {
+    const name = (item.name as string).split(path)[1]?.replace("/", "");
+    return {
+      ...item[accessor],
+      name
+    }
+  });
 }

--- a/blog/utils/records.ts
+++ b/blog/utils/records.ts
@@ -18,7 +18,7 @@ export async function getRecordsByPath<T>(
     const name = (item.name as string).split(path)[1]?.replace("/", "");
     return {
       ...item[accessor],
-      name
-    }
+      name,
+    };
   });
 }


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?

A blogpost can be completely edited, so the only unique identifier is the created file hash id. This pr exposes this id so it can be used on the BlogPost section.
