### PR TITLE
feat(vtex): recordsFiltered in suggestions loader

### DIFF
--- a/commerce/types.ts
+++ b/commerce/types.ts
@@ -609,6 +609,7 @@ export interface Search {
 export interface Suggestion {
   searches?: Search[];
   products?: Product[];
+  hits?: number;
 }
 
 /** @titleBy url */

--- a/vtex/loaders/intelligentSearch/suggestions.ts
+++ b/vtex/loaders/intelligentSearch/suggestions.ts
@@ -68,7 +68,7 @@ const loaders = async (
       .then((res) => res.json());
   };
 
-  const [{ searches }, { products }] = await Promise.all([
+  const [{ searches }, { products, recordsFiltered }] = await Promise.all([
     query ? suggestions() : topSearches(),
     productSearch(),
   ]);
@@ -88,6 +88,7 @@ const loaders = async (
           withIsSimilarTo(req, ctx, p)
         ),
     ),
+    hits: recordsFiltered,
   };
 };
 


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
Add the "recordsFiltered" field in suggestions as a new attribute.

Necessary to replicate the "see all x products" behavior in the "useReserva" store:
![Captura de Tela 2024-07-17 às 19 08 12](https://github.com/user-attachments/assets/4a58189d-4e0e-41de-8021-fa24ccd97740)

