### PR TITLE
fix(website/htmx): prevent deferred render visible auxiliary elements

### DIFF
--- a/htmx/sections/Deferred.tsx
+++ b/htmx/sections/Deferred.tsx
@@ -67,7 +67,10 @@ const Deferred = (props: Props) => {
         hx-trigger={triggerList.join(" ")}
         hx-target="closest section"
         hx-swap="outerHTML"
-        style={{ height: "100vh" }}
+        style={{
+          height: "100vh",
+          display: props.fallbacks?.length ? "none" : undefined,
+        }}
       />
       {props.fallbacks?.map(renderSection)}
     </>

--- a/htmx/sections/Deferred.tsx
+++ b/htmx/sections/Deferred.tsx
@@ -66,7 +66,7 @@ const Deferred = (props: Props) => {
         hx-get={href}
         hx-trigger={triggerList.join(" ")}
         hx-target="closest section"
-        hx-swap="outerHTML"
+        hx-swap="outerHTML transition:true"
         style={{
           height: "100vh",
           display: props.fallbacks?.length ? "none" : undefined,

--- a/htmx/sections/Deferred.tsx
+++ b/htmx/sections/Deferred.tsx
@@ -10,8 +10,6 @@ import { renderSection, shouldForceRender } from "../../utils/deferred.tsx";
  */
 interface Load {
   type: "load";
-  /** @hide true */
-  delay?: number;
 }
 
 /**
@@ -34,8 +32,6 @@ interface Intersect {
 
 export interface Props {
   sections: Section[];
-  /** @hide true */
-  fallbacks?: Section[];
   trigger?: Load | Revealed | Intersect;
   loading?: "lazy" | "eager";
 }
@@ -56,9 +52,6 @@ const Deferred = (props: Props) => {
   });
 
   const triggerList: (string | number)[] = [trigger?.type ?? "load", "once"];
-  if (trigger?.type === "load" && trigger.delay !== undefined) {
-    triggerList.push(`${trigger.delay}ms`);
-  }
 
   return (
     <>
@@ -67,12 +60,8 @@ const Deferred = (props: Props) => {
         hx-trigger={triggerList.join(" ")}
         hx-target="closest section"
         hx-swap="outerHTML transition:true"
-        style={{
-          height: "100vh",
-          display: props.fallbacks?.length ? "none" : undefined,
-        }}
+        style={{ height: "100vh" }}
       />
-      {props.fallbacks?.map(renderSection)}
     </>
   );
 };

--- a/website/sections/Rendering/Deferred.tsx
+++ b/website/sections/Rendering/Deferred.tsx
@@ -115,6 +115,7 @@ const Deferred = (props: Props) => {
         id={buttonId}
         data-deferred
         aria-label={`Deferred Section - ${sectionID}`}
+        style={{ display: "none" }}
       />
       <script
         defer

--- a/website/sections/Rendering/Deferred.tsx
+++ b/website/sections/Rendering/Deferred.tsx
@@ -18,17 +18,6 @@ export interface Scroll {
   payload: number;
 }
 
-interface Load {
-  type: "load";
-
-  /**
-   * @hide true
-   * @title Delay MS
-   * @description Delay (in milliseconds) to wait after the DOMContentLoaded event is fired. If value is 0, it will trigger when page load
-   */
-  payload: number;
-}
-
 /** @titleBy type */
 export interface Intersection {
   type: "intersection";
@@ -42,14 +31,12 @@ export interface Intersection {
 export interface Props {
   sections: Section[];
   display?: boolean;
-  behavior?: Scroll | Intersection | Load;
-  /** @hide true */
-  fallbacks?: Section[];
+  behavior?: Scroll | Intersection;
 }
 
 const script = (
   id: string,
-  type: "scroll" | "intersection" | "load",
+  type: "scroll" | "intersection",
   payload: string,
 ) => {
   const element = document.getElementById(id);
@@ -61,16 +48,6 @@ const script = (
   const triggerRender = (timeout: number) => () => {
     setTimeout(() => element.click(), timeout);
   };
-
-  if (type === "load") {
-    const timeout = Number(payload || 200);
-    const instant = timeout === 0;
-
-    if (instant || document.readyState === "complete") triggerRender(timeout);
-    else {
-      addEventListener("DOMContentLoaded", triggerRender(timeout));
-    }
-  }
 
   if (type === "scroll") {
     addEventListener(
@@ -126,7 +103,6 @@ const Deferred = (props: Props) => {
           behavior?.payload.toString() || "",
         )}
       />
-      {props.fallbacks?.map(renderSection)}
     </>
   );
 };

--- a/website/sections/Rendering/SingleDeferred.tsx
+++ b/website/sections/Rendering/SingleDeferred.tsx
@@ -1,33 +1,13 @@
 import type { Section } from "deco/blocks/section.ts";
-import PartialDeferred from "./Deferred.tsx";
-import HTMXDeferred from "../../../htmx/sections/Deferred.tsx";
 import type { AppContext } from "../../mod.ts";
 import { asResolved, isDeferred } from "deco/mod.ts";
 import { __DECO_FBT } from "../../handlers/fresh.ts";
 import { shouldForceRender } from "../../../utils/deferred.tsx";
-import { useContext } from "preact/hooks";
-import { SectionContext } from "deco/components/section.tsx";
 import { RequestContext } from "deco/deco.ts";
-
-const useSectionContext = () => useContext(SectionContext);
-
-const isHtmx = (
-  props: SectionProps,
-): props is SectionProps & { framework: "htmx" } => props.framework === "htmx";
 
 interface Props {
   /** @label hidden */
   section: Section;
-  /**
-   * @description fresh/Deferred.tsx props
-   * @hide true
-   */
-  display?: boolean;
-  /**
-   * @description htmx/Deferred.tsx prop
-   * @hide true
-   */
-  loading?: "eager";
 }
 
 export const loader = async (
@@ -35,25 +15,20 @@ export const loader = async (
   _req: Request,
   ctx: AppContext,
 ) => {
-  const isFreshSyncRender = "display" in props && props.display === true;
-  const isHtmxSyncRender = "loading" in props && props.loading === "eager";
   const url = new URL(_req.url);
   const _shouldForceRender = shouldForceRender({
     ctx,
     searchParams: url.searchParams,
   });
-  const shouldRender = isFreshSyncRender || isHtmxSyncRender ||
-    _shouldForceRender;
-  const framework = ctx.flavor?.framework || "fresh";
+  const shouldRender = _shouldForceRender;
 
   if (shouldRender) {
     const section = isDeferred<Section>(props.section)
       ? await props.section()
       : props.section;
-    return { ...props, framework, section, fallback: null };
+    return { ...props, section };
   }
 
-  // How to improve it
   const abortControler = new AbortController();
   abortControler.abort();
   const section = isDeferred<Section>(props.section)
@@ -63,43 +38,14 @@ export const loader = async (
     )()
     : props.section;
 
-  return { ...props, framework, section: null, fallback: section };
+  return { ...props, section };
 };
 
 type SectionProps = Awaited<ReturnType<typeof loader>>;
 
 function SingleDeferred(props: SectionProps) {
-  const ctx = useSectionContext();
-  const idxOrNaN = Number(ctx?.resolveChain.at(-2)?.value);
-  const delay = 25 * (Math.min(Number.isNaN(idxOrNaN) ? 1 : idxOrNaN, 10) || 1);
-  const sections = props.section ? [props.section] : [];
-  const fallbacks = props.fallback ? [props.fallback] : undefined;
-
-  if (isHtmx(props)) {
-    return (
-      <HTMXDeferred
-        sections={sections}
-        fallbacks={fallbacks}
-        loading={props.section ? "eager" : "lazy"}
-        trigger={{
-          type: "load",
-          delay,
-        }}
-      />
-    );
-  }
-
-  return (
-    <PartialDeferred
-      sections={props.section ? [props.section] : []}
-      fallbacks={props.fallback ? [props.fallback] : undefined}
-      display={props.section ? true : false}
-      behavior={{
-        type: "load",
-        payload: delay,
-      }}
-    />
-  );
+  const { section: { Component, props: componentProps } } = props;
+  return <Component {...componentProps} />;
 }
 
 const DEFERRED = true;


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?
before website/Deferred:
<img width="375" alt="image" src="https://github.com/user-attachments/assets/eefc4325-a428-4f92-9a6c-7e77748000b6">

after website/Deferred:
<img width="389" alt="image" src="https://github.com/user-attachments/assets/dff44f16-b362-4187-8f98-c3e1da559c88">

## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

