### PR TITLE
feat(vtex): add some new loaders

### DIFF
--- a/vtex/loaders/legacy/pageType.ts
+++ b/vtex/loaders/legacy/pageType.ts
@@ -1,0 +1,25 @@
+import { STALE } from "../../../utils/fetch.ts";
+import { AppContext } from "../../mod.ts";
+
+interface Props {
+  term?: string;
+}
+
+export default async function loader(
+  props: Props,
+  req: Request,
+  ctx: AppContext,
+) {
+  const { vcsDeprecated } = ctx;
+  const term = props.term ?? new URL(req.url).pathname.slice(1); // remove first slash
+
+  return await vcsDeprecated
+    ["GET /api/catalog_system/pub/portal/pagetype/:term"]({
+      term,
+    }, STALE).then((res) => res.json());
+}
+
+export const cache = "stale-while-revalidate";
+
+export const cacheKey = (props: Props, req: Request, _ctx: AppContext) =>
+  props.term ? props.term : new URL(req.url).pathname;

--- a/vtex/loaders/logistics/listPickupPoints.ts
+++ b/vtex/loaders/logistics/listPickupPoints.ts
@@ -1,0 +1,15 @@
+import { AppContext } from "../../mod.ts";
+
+export default async function loader(
+  _props: unknown,
+  _req: Request,
+  ctx: AppContext,
+) {
+  const { vcs } = ctx;
+
+  const pickupPoints = await vcs
+    ["GET /api/logistics/pvt/configuration/pickuppoints"]({})
+    .then((r) => r.json());
+
+  return pickupPoints;
+}

--- a/vtex/loaders/logistics/listPickupPointsByLocation.ts
+++ b/vtex/loaders/logistics/listPickupPointsByLocation.ts
@@ -1,0 +1,35 @@
+import { AppContext } from "../../mod.ts";
+
+interface Props {
+  /**
+   * @description Geocoordinates (first longitude, then latitude) around which to search for pickup points. If you use this type of search, do not pass postal and country codes.
+   */
+  geoCoordinates?: number[];
+  /**
+   * @description Postal code around which to search for pickup points. If you use this type of search, make sure to pass a countryCode and do not pass geoCoordinates.
+   */
+  postalCode?: string;
+  /**
+   * @description Three letter country code referring to the postalCode field. Pass the country code only if you are searching pickup points by postal code.
+   */
+  countryCode?: string;
+}
+
+export default async function loader(
+  props: Props,
+  _req: Request,
+  ctx: AppContext,
+) {
+  const { geoCoordinates, postalCode, countryCode } = props;
+  const { vcs } = ctx;
+
+  const _props = geoCoordinates
+    ? { geoCoordinates }
+    : { postalCode, countryCode };
+
+  const pickupPoints = await vcs
+    ["GET /api/checkout/pub/pickup-points"](_props)
+    .then((r) => r.json());
+
+  return pickupPoints;
+}

--- a/vtex/manifest.gen.ts
+++ b/vtex/manifest.gen.ts
@@ -35,25 +35,27 @@ import * as $$$7 from "./loaders/intelligentSearch/productSearchValidator.ts";
 import * as $$$8 from "./loaders/intelligentSearch/suggestions.ts";
 import * as $$$9 from "./loaders/intelligentSearch/topsearches.ts";
 import * as $$$10 from "./loaders/legacy/brands.ts";
-import * as $$$11 from "./loaders/legacy/productDetailsPage.ts";
-import * as $$$12 from "./loaders/legacy/productList.ts";
-import * as $$$13 from "./loaders/legacy/productListingPage.ts";
-import * as $$$14 from "./loaders/legacy/relatedProductsLoader.ts";
-import * as $$$15 from "./loaders/legacy/suggestions.ts";
-import * as $$$16 from "./loaders/navbar.ts";
-import * as $$$17 from "./loaders/paths/PDPDefaultPath.ts";
-import * as $$$18 from "./loaders/paths/PLPDefaultPath.ts";
-import * as $$$19 from "./loaders/product/extend.ts";
-import * as $$$20 from "./loaders/product/extensions/detailsPage.ts";
-import * as $$$21 from "./loaders/product/extensions/list.ts";
-import * as $$$22 from "./loaders/product/extensions/listingPage.ts";
-import * as $$$23 from "./loaders/product/extensions/suggestions.ts";
-import * as $$$24 from "./loaders/product/wishlist.ts";
-import * as $$$25 from "./loaders/proxy.ts";
-import * as $$$26 from "./loaders/user.ts";
-import * as $$$27 from "./loaders/wishlist.ts";
-import * as $$$28 from "./loaders/workflow/product.ts";
-import * as $$$29 from "./loaders/workflow/products.ts";
+import * as $$$11 from "./loaders/legacy/pageType.ts";
+import * as $$$12 from "./loaders/legacy/productDetailsPage.ts";
+import * as $$$13 from "./loaders/legacy/productList.ts";
+import * as $$$14 from "./loaders/legacy/productListingPage.ts";
+import * as $$$15 from "./loaders/legacy/relatedProductsLoader.ts";
+import * as $$$16 from "./loaders/legacy/suggestions.ts";
+import * as $$$17 from "./loaders/logistics/listPickupPoints.ts";
+import * as $$$18 from "./loaders/navbar.ts";
+import * as $$$19 from "./loaders/paths/PDPDefaultPath.ts";
+import * as $$$20 from "./loaders/paths/PLPDefaultPath.ts";
+import * as $$$21 from "./loaders/product/extend.ts";
+import * as $$$22 from "./loaders/product/extensions/detailsPage.ts";
+import * as $$$23 from "./loaders/product/extensions/list.ts";
+import * as $$$24 from "./loaders/product/extensions/listingPage.ts";
+import * as $$$25 from "./loaders/product/extensions/suggestions.ts";
+import * as $$$26 from "./loaders/product/wishlist.ts";
+import * as $$$27 from "./loaders/proxy.ts";
+import * as $$$28 from "./loaders/user.ts";
+import * as $$$29 from "./loaders/wishlist.ts";
+import * as $$$30 from "./loaders/workflow/product.ts";
+import * as $$$31 from "./loaders/workflow/products.ts";
 import * as $$$$$$0 from "./sections/Analytics/Vtex.tsx";
 import * as $$$$$$$$$$0 from "./workflows/events.ts";
 import * as $$$$$$$$$$1 from "./workflows/product/index.ts";
@@ -71,25 +73,27 @@ const manifest = {
     "vtex/loaders/intelligentSearch/suggestions.ts": $$$8,
     "vtex/loaders/intelligentSearch/topsearches.ts": $$$9,
     "vtex/loaders/legacy/brands.ts": $$$10,
-    "vtex/loaders/legacy/productDetailsPage.ts": $$$11,
-    "vtex/loaders/legacy/productList.ts": $$$12,
-    "vtex/loaders/legacy/productListingPage.ts": $$$13,
-    "vtex/loaders/legacy/relatedProductsLoader.ts": $$$14,
-    "vtex/loaders/legacy/suggestions.ts": $$$15,
-    "vtex/loaders/navbar.ts": $$$16,
-    "vtex/loaders/paths/PDPDefaultPath.ts": $$$17,
-    "vtex/loaders/paths/PLPDefaultPath.ts": $$$18,
-    "vtex/loaders/product/extend.ts": $$$19,
-    "vtex/loaders/product/extensions/detailsPage.ts": $$$20,
-    "vtex/loaders/product/extensions/list.ts": $$$21,
-    "vtex/loaders/product/extensions/listingPage.ts": $$$22,
-    "vtex/loaders/product/extensions/suggestions.ts": $$$23,
-    "vtex/loaders/product/wishlist.ts": $$$24,
-    "vtex/loaders/proxy.ts": $$$25,
-    "vtex/loaders/user.ts": $$$26,
-    "vtex/loaders/wishlist.ts": $$$27,
-    "vtex/loaders/workflow/product.ts": $$$28,
-    "vtex/loaders/workflow/products.ts": $$$29,
+    "vtex/loaders/legacy/pageType.ts": $$$11,
+    "vtex/loaders/legacy/productDetailsPage.ts": $$$12,
+    "vtex/loaders/legacy/productList.ts": $$$13,
+    "vtex/loaders/legacy/productListingPage.ts": $$$14,
+    "vtex/loaders/legacy/relatedProductsLoader.ts": $$$15,
+    "vtex/loaders/legacy/suggestions.ts": $$$16,
+    "vtex/loaders/logistics/listPickupPoints.ts": $$$17,
+    "vtex/loaders/navbar.ts": $$$18,
+    "vtex/loaders/paths/PDPDefaultPath.ts": $$$19,
+    "vtex/loaders/paths/PLPDefaultPath.ts": $$$20,
+    "vtex/loaders/product/extend.ts": $$$21,
+    "vtex/loaders/product/extensions/detailsPage.ts": $$$22,
+    "vtex/loaders/product/extensions/list.ts": $$$23,
+    "vtex/loaders/product/extensions/listingPage.ts": $$$24,
+    "vtex/loaders/product/extensions/suggestions.ts": $$$25,
+    "vtex/loaders/product/wishlist.ts": $$$26,
+    "vtex/loaders/proxy.ts": $$$27,
+    "vtex/loaders/user.ts": $$$28,
+    "vtex/loaders/wishlist.ts": $$$29,
+    "vtex/loaders/workflow/product.ts": $$$30,
+    "vtex/loaders/workflow/products.ts": $$$31,
   },
   "handlers": {
     "vtex/handlers/sitemap.ts": $$$$0,

--- a/vtex/manifest.gen.ts
+++ b/vtex/manifest.gen.ts
@@ -42,20 +42,21 @@ import * as $$$14 from "./loaders/legacy/productListingPage.ts";
 import * as $$$15 from "./loaders/legacy/relatedProductsLoader.ts";
 import * as $$$16 from "./loaders/legacy/suggestions.ts";
 import * as $$$17 from "./loaders/logistics/listPickupPoints.ts";
-import * as $$$18 from "./loaders/navbar.ts";
-import * as $$$19 from "./loaders/paths/PDPDefaultPath.ts";
-import * as $$$20 from "./loaders/paths/PLPDefaultPath.ts";
-import * as $$$21 from "./loaders/product/extend.ts";
-import * as $$$22 from "./loaders/product/extensions/detailsPage.ts";
-import * as $$$23 from "./loaders/product/extensions/list.ts";
-import * as $$$24 from "./loaders/product/extensions/listingPage.ts";
-import * as $$$25 from "./loaders/product/extensions/suggestions.ts";
-import * as $$$26 from "./loaders/product/wishlist.ts";
-import * as $$$27 from "./loaders/proxy.ts";
-import * as $$$28 from "./loaders/user.ts";
-import * as $$$29 from "./loaders/wishlist.ts";
-import * as $$$30 from "./loaders/workflow/product.ts";
-import * as $$$31 from "./loaders/workflow/products.ts";
+import * as $$$18 from "./loaders/logistics/listPickupPointsByLocation.ts";
+import * as $$$19 from "./loaders/navbar.ts";
+import * as $$$20 from "./loaders/paths/PDPDefaultPath.ts";
+import * as $$$21 from "./loaders/paths/PLPDefaultPath.ts";
+import * as $$$22 from "./loaders/product/extend.ts";
+import * as $$$23 from "./loaders/product/extensions/detailsPage.ts";
+import * as $$$24 from "./loaders/product/extensions/list.ts";
+import * as $$$25 from "./loaders/product/extensions/listingPage.ts";
+import * as $$$26 from "./loaders/product/extensions/suggestions.ts";
+import * as $$$27 from "./loaders/product/wishlist.ts";
+import * as $$$28 from "./loaders/proxy.ts";
+import * as $$$29 from "./loaders/user.ts";
+import * as $$$30 from "./loaders/wishlist.ts";
+import * as $$$31 from "./loaders/workflow/product.ts";
+import * as $$$32 from "./loaders/workflow/products.ts";
 import * as $$$$$$0 from "./sections/Analytics/Vtex.tsx";
 import * as $$$$$$$$$$0 from "./workflows/events.ts";
 import * as $$$$$$$$$$1 from "./workflows/product/index.ts";
@@ -80,20 +81,21 @@ const manifest = {
     "vtex/loaders/legacy/relatedProductsLoader.ts": $$$15,
     "vtex/loaders/legacy/suggestions.ts": $$$16,
     "vtex/loaders/logistics/listPickupPoints.ts": $$$17,
-    "vtex/loaders/navbar.ts": $$$18,
-    "vtex/loaders/paths/PDPDefaultPath.ts": $$$19,
-    "vtex/loaders/paths/PLPDefaultPath.ts": $$$20,
-    "vtex/loaders/product/extend.ts": $$$21,
-    "vtex/loaders/product/extensions/detailsPage.ts": $$$22,
-    "vtex/loaders/product/extensions/list.ts": $$$23,
-    "vtex/loaders/product/extensions/listingPage.ts": $$$24,
-    "vtex/loaders/product/extensions/suggestions.ts": $$$25,
-    "vtex/loaders/product/wishlist.ts": $$$26,
-    "vtex/loaders/proxy.ts": $$$27,
-    "vtex/loaders/user.ts": $$$28,
-    "vtex/loaders/wishlist.ts": $$$29,
-    "vtex/loaders/workflow/product.ts": $$$30,
-    "vtex/loaders/workflow/products.ts": $$$31,
+    "vtex/loaders/logistics/listPickupPointsByLocation.ts": $$$18,
+    "vtex/loaders/navbar.ts": $$$19,
+    "vtex/loaders/paths/PDPDefaultPath.ts": $$$20,
+    "vtex/loaders/paths/PLPDefaultPath.ts": $$$21,
+    "vtex/loaders/product/extend.ts": $$$22,
+    "vtex/loaders/product/extensions/detailsPage.ts": $$$23,
+    "vtex/loaders/product/extensions/list.ts": $$$24,
+    "vtex/loaders/product/extensions/listingPage.ts": $$$25,
+    "vtex/loaders/product/extensions/suggestions.ts": $$$26,
+    "vtex/loaders/product/wishlist.ts": $$$27,
+    "vtex/loaders/proxy.ts": $$$28,
+    "vtex/loaders/user.ts": $$$29,
+    "vtex/loaders/wishlist.ts": $$$30,
+    "vtex/loaders/workflow/product.ts": $$$31,
+    "vtex/loaders/workflow/products.ts": $$$32,
   },
   "handlers": {
     "vtex/handlers/sitemap.ts": $$$$0,

--- a/vtex/utils/openapi/vcs.openapi.gen.ts
+++ b/vtex/utils/openapi/vcs.openapi.gen.ts
@@ -16845,6 +16845,133 @@ postalCode?: string
  */
 countryCode?: string
 }
+response: {
+/**
+ * Paging.
+ */
+paging?: {
+/**
+ * Page number.
+ */
+page?: number
+/**
+ * Page size.
+ */
+pageSize?: number
+/**
+ * Total pages.
+ */
+total?: number
+/**
+ * Pages.
+ */
+pages?: number
+}
+/**
+ * Items.
+ */
+items?: {
+/**
+ * Distance.
+ */
+distance?: number
+/**
+ * Pickup point.
+ */
+pickupPoint?: {
+/**
+ * Friendly name.
+ */
+friendlyName?: string
+/**
+ * Address.
+ */
+address?: {
+/**
+ * Address type.
+ */
+addressType?: string
+/**
+ * Receiver name.
+ */
+receiverName?: string
+/**
+ * Address ID.
+ */
+addressId?: (null | string)
+/**
+ * Is disposable.
+ */
+isDisposable?: boolean
+/**
+ * Postal code.
+ */
+postalCode?: string
+/**
+ * City.
+ */
+city?: string
+/**
+ * State.
+ */
+state?: string
+/**
+ * Country.
+ */
+country?: string
+/**
+ * Street.
+ */
+street?: string
+/**
+ * Number.
+ */
+number?: string
+/**
+ * Neighborhood.
+ */
+neighborhood?: string
+/**
+ * Complement to the shipping address, in case it applies.
+ */
+complement?: (null | string)
+/**
+ * Racao.
+ */
+reference?: string
+/**
+ * Geo coordinates.
+ */
+geoCoordinates?: number[]
+}
+/**
+ * Additional info.
+ */
+additionalInfo?: string
+/**
+ * ID.
+ */
+id?: string
+/**
+ * Array with business hours.
+ */
+businessHours?: {
+/**
+ * Day of week.
+ */
+DayOfWeek?: number
+/**
+ * Opening time.
+ */
+OpeningTime?: string
+/**
+ * Closing time.
+ */
+ClosingTime?: string
+}[]
+}
+}[]
+}
 }
 /**
  * Retrieves address information for a given postal code and country.

--- a/vtex/utils/openapi/vcs.openapi.gen.ts
+++ b/vtex/utils/openapi/vcs.openapi.gen.ts
@@ -66,6 +66,17 @@ export type OptinNewsLetter = boolean
 
 export interface OpenAPI {
 /**
+ * Retrieves information about [pickup points](https://help.vtex.com/en/tutorial/pickup-points--2fljn6wLjn8M4lJHA6HP3R) of your store.
+ * 
+ * >⚠️ The response is limited to 1.000 pickup points. If you need more than 1000 results, you can use the [List paged pickup points](https://developers.vtex.com/docs/api-reference/logistics-api#get-/api/logistics/pvt/configuration/pickuppoints/_search) endpoint.
+ */
+"GET /api/logistics/pvt/configuration/pickuppoints": {
+/**
+ * List of pickup points, limited to 1.000 pickup points. If you need more than 1000 results, you can use the [List paged pickup points](https://developers.vtex.com/docs/api-reference/logistics-api#get-/api/logistics/pvt/configuration/pickuppoints/_search) endpoint.
+ */
+response: PickupPoint[]
+}
+/**
  * Retrieves the IDs of products and SKUs. 
  * > 📘 Onboarding guide 
  * >
@@ -18460,6 +18471,168 @@ logo?: (null | string)
 }[]
 }
 }
+}
+/**
+ * Pickup point information.
+ */
+export interface PickupPoint {
+/**
+ * [Pickup point](https://help.vtex.com/en/tutorial/pickup-points--2fljn6wLjn8M4lJHA6HP3R) ID.
+ */
+id?: string
+/**
+ * Pickup point name displayed to customers at checkout.
+ */
+name?: string
+/**
+ * Pickup point description displayed to customers at checkout.
+ */
+description?: string
+/**
+ * Instructions for customers when collecting their package.
+ */
+instructions?: string
+/**
+ * Formatted address.
+ */
+formatted_address?: string
+/**
+ * Pickup point address information.
+ */
+address?: {
+/**
+ * Pickup point address postal code.
+ */
+postalCode?: string
+/**
+ * Information about the pickup point address country.
+ */
+country?: {
+/**
+ * Three-digit country code of the pickup point address, in [ISO 3166 ALPHA-3](https://www.iban.com/country-codes) format.
+ */
+acronym?: string
+/**
+ * Country name of the pickup point address.
+ */
+name?: string
+}
+/**
+ * Pickup point address city.
+ */
+city?: string
+/**
+ * Pickup point address state.
+ */
+state?: string
+/**
+ * Pickup point address neighborhood.
+ */
+neighborhood?: string
+/**
+ * Pickup point address street.
+ */
+street?: string
+/**
+ * Pickup point address number.
+ */
+number?: string
+/**
+ * Pickup point address complement.
+ */
+complement?: string
+/**
+ * Reference point to help the customer find the pickup point.
+ */
+reference?: string
+/**
+ * Pickup point address geolocation coordinates.
+ */
+location?: {
+/**
+ * Latitude coordinate.
+ */
+latitude?: number
+/**
+ * Longitude coordinate.
+ */
+longitude?: number
+}
+}
+/**
+ * Defines if the pickup point is active (`true`) or inactive (`false`).
+ */
+isActive?: boolean
+/**
+ * Pickup point configured distance.
+ */
+distance?: number
+/**
+ * Seller that corresponds to the pickup point.
+ */
+seller?: string
+/**
+ * Sort array.
+ */
+_sort?: number[]
+/**
+ * Pickup point business hours configurations.
+ */
+businessHours?: {
+/**
+ * Day of the week identification, as in `1` = Monday, `2` = Tuesday, `3` = Wednesday, `4` = Thursday, and `5` = Friday.
+ */
+dayOfWeek?: number
+/**
+ * Opening time in `HH:MM:SS` format.
+ */
+openingTime?: string
+/**
+ * Closing time in `HH:MM:SS` format.
+ */
+closingTime?: string
+}[]
+/**
+ * Tags that identify a group of pickup points.
+ */
+tagsLabel?: string[]
+/**
+ * [Holidays](https://help.vtex.com/en/tutorial/registering-holidays--2ItOthSEAoyAmcwsuiO6Yk) configured for the pickup point.
+ */
+pickupHolidays?: {
+/**
+ * Holiday date and time, in [ISO 8601 time zone offset format](https://learn.microsoft.com/en-us/rest/api/storageservices/formatting-datetime-values), as in `YYYY-MM-DDThh:mm:ss.ssZ`.
+ */
+date?: string
+/**
+ * Holiday beginning time in `HH:MM` format.
+ */
+hourBegin?: string
+/**
+ * Holiday ending time in `HH:MM` format.
+ */
+hourEnd?: string
+}[]
+/**
+ * Defines if the pickup point is third-party (`true`) or not (`false`).
+ */
+isThirdPartyPickup?: boolean
+/**
+ * Account owner name.
+ */
+accountOwnerName?: string
+/**
+ * Account owner ID.
+ */
+accountOwnerId?: string
+/**
+ * Parent account name.
+ */
+parentAccountName?: string
+/**
+ * Original ID.
+ */
+originalId?: string
 }
 export interface GetorUpdateProductSpecification {
 /**

--- a/vtex/utils/openapi/vcs.openapi.json
+++ b/vtex/utils/openapi/vcs.openapi.json
@@ -33756,6 +33756,155 @@
                       }
                     }
                   ]
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "paging": {
+                      "description": "Paging.",
+                      "type": "object",
+                      "properties": {
+                        "page": {
+                          "description": "Page number.",
+                          "type": "integer"
+                        },
+                        "pageSize": {
+                          "description": "Page size.",
+                          "type": "integer"
+                        },
+                        "total": {
+                          "description": "Total pages.",
+                          "type": "integer"
+                        },
+                        "pages": {
+                          "description": "Pages.",
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    "items": {
+                      "description": "Items.",
+                      "type": "array",
+                      "items": {
+                        "description": "Item information.",
+                        "type": "object",
+                        "properties": {
+                          "distance": {
+                            "description": "Distance.",
+                            "type": "integer"
+                          },
+                          "pickupPoint": {
+                            "description": "Pickup point.",
+                            "type": "object",
+                            "properties": {
+                              "friendlyName": {
+                                "description": "Friendly name.",
+                                "type": "string"
+                              },
+                              "address": {
+                                "description": "Address.",
+                                "type": "object",
+                                "properties": {
+                                  "addressType": {
+                                    "description": "Address type.",
+                                    "type": "string"
+                                  },
+                                  "receiverName": {
+                                    "description": "Receiver name.",
+                                    "type": "string"
+                                  },
+                                  "addressId": {
+                                    "description": "Address ID.",
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "isDisposable": {
+                                    "description": "Is disposable.",
+                                    "type": "boolean"
+                                  },
+                                  "postalCode": {
+                                    "description": "Postal code.",
+                                    "type": "string"
+                                  },
+                                  "city": {
+                                    "description": "City.",
+                                    "type": "string"
+                                  },
+                                  "state": {
+                                    "description": "State.",
+                                    "type": "string"
+                                  },
+                                  "country": {
+                                    "description": "Country.",
+                                    "type": "string"
+                                  },
+                                  "street": {
+                                    "description": "Street.",
+                                    "type": "string"
+                                  },
+                                  "number": {
+                                    "description": "Number.",
+                                    "type": "string"
+                                  },
+                                  "neighborhood": {
+                                    "description": "Neighborhood.",
+                                    "type": "string"
+                                  },
+                                  "complement": {
+                                    "description": "Complement to the shipping address, in case it applies.",
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "reference": {
+                                    "description": "Racao.",
+                                    "type": "string"
+                                  },
+                                  "geoCoordinates": {
+                                    "description": "Geo coordinates.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Geo coordinate.",
+                                      "type": "integer"
+                                    }
+                                  }
+                                }
+                              },
+                              "additionalInfo": {
+                                "description": "Additional info.",
+                                "type": "string"
+                              },
+                              "id": {
+                                "description": "ID.",
+                                "type": "string"
+                              },
+                              "businessHours": {
+                                "description": "Array with business hours.",
+                                "type": "array",
+                                "items": {
+                                  "description": "Business hours.",
+                                  "type": "object",
+                                  "properties": {
+                                    "DayOfWeek": {
+                                      "description": "Day of week.",
+                                      "type": "integer"
+                                    },
+                                    "OpeningTime": {
+                                      "description": "Opening time.",
+                                      "type": "string"
+                                    },
+                                    "ClosingTime": {
+                                      "description": "Closing time.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/vtex/utils/openapi/vcs.openapi.json
+++ b/vtex/utils/openapi/vcs.openapi.json
@@ -7,6 +7,211 @@
     "version": "1.0"
   },
   "paths": {
+    "/api/logistics/pvt/configuration/pickuppoints": {
+      "get": {
+        "tags": [
+          "Pickup points"
+        ],
+        "summary": "List pickup points",
+        "description": "Retrieves information about [pickup points](https://help.vtex.com/en/tutorial/pickup-points--2fljn6wLjn8M4lJHA6HP3R) of your store.\r\n\r\n>⚠️ The response is limited to 1.000 pickup points. If you need more than 1000 results, you can use the [List paged pickup points](https://developers.vtex.com/docs/api-reference/logistics-api#get-/api/logistics/pvt/configuration/pickuppoints/_search) endpoint.",
+        "operationId": "ListAllPickupPpoints",
+        "parameters": [
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "description": "Type of the content being sent.",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            }
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "description": "List of pickup points, limited to 1.000 pickup points. If you need more than 1000 results, you can use the [List paged pickup points](https://developers.vtex.com/docs/api-reference/logistics-api#get-/api/logistics/pvt/configuration/pickuppoints/_search) endpoint.",
+                  "items": {
+                    "$ref": "#/components/schemas/PickupPoint"
+                  }
+                },
+                "example": [
+                  {
+                    "id": "b8e7ca56",
+                    "name": "Pickup Shopping Center",
+                    "description": "Shopping Center from Barra",
+                    "instructions": "You have to present a document to collect your package",
+                    "formatted_address": "undefined",
+                    "address": {
+                      "postalCode": "22250040",
+                      "country": {
+                        "acronym": "BRA",
+                        "name": "Brazil"
+                      },
+                      "city": "Rio de Janeiro",
+                      "state": "RJ",
+                      "neighborhood": "Botafogo",
+                      "street": "Botafogo beach",
+                      "number": "300",
+                      "complement": "Shopping Center",
+                      "reference": "Third floor",
+                      "location": {
+                        "latitude": -22.906847,
+                        "longitude": -43.172897
+                      }
+                    },
+                    "isActive": true,
+                    "distance": 0,
+                    "seller": "Fashion Skirts",
+                    "_sort": [
+                      1574240390000
+                    ],
+                    "businessHours": [
+                      {
+                        "dayOfWeek": 1,
+                        "openingTime": "09:00:00",
+                        "closingTime": "18:00:00"
+                      },
+                      {
+                        "dayOfWeek": 2,
+                        "openingTime": "09:00:00",
+                        "closingTime": "18:00:00"
+                      },
+                      {
+                        "dayOfWeek": 3,
+                        "openingTime": "09:00:00",
+                        "closingTime": "18:00:00"
+                      },
+                      {
+                        "dayOfWeek": 4,
+                        "openingTime": "09:00:00",
+                        "closingTime": "18:00:00"
+                      },
+                      {
+                        "dayOfWeek": 5,
+                        "openingTime": "09:00:00",
+                        "closingTime": "18:00:00"
+                      }
+                    ],
+                    "tagsLabel": [
+                      "w67",
+                      "p34"
+                    ],
+                    "pickupHolidays": [
+                      {
+                        "date": "2024-12-28T03:00:00Z",
+                        "hourBegin": "09:00",
+                        "hourEnd": "13:00"
+                      },
+                      {
+                        "date": "2024-11-17T03:00:00Z",
+                        "hourBegin": "00:00",
+                        "hourEnd": "00:00"
+                      }
+                    ],
+                    "isThirdPartyPickup": false,
+                    "accountOwnerName": "Fashion Store",
+                    "accountOwnerId": "1b4018ec-48bf-4a59-9eae-547403e11afc",
+                    "parentAccountName": "Fashion Store",
+                    "originalId": null
+                  },
+                  {
+                    "id": "792893547449051",
+                    "name": "Bleu PUP",
+                    "description": "Bleu Store",
+                    "instructions": "You must present a document to collect your order",
+                    "formatted_address": "undefined",
+                    "address": {
+                      "postalCode": "18550-000",
+                      "country": {
+                        "acronym": "BRA",
+                        "name": "Brasil"
+                      },
+                      "city": "Boituva",
+                      "state": "SP",
+                      "neighborhood": "Tancredo Neves",
+                      "street": "BTV-250",
+                      "number": "01",
+                      "complement": "Second floor",
+                      "reference": "Next to the city hall",
+                      "location": {
+                        "latitude": -23.2863329,
+                        "longitude": -47.6783742
+                      }
+                    },
+                    "isActive": true,
+                    "distance": 1574240387072,
+                    "seller": "Recurrency",
+                    "_sort": [
+                      1574240390000
+                    ],
+                    "businessHours": [
+                      {
+                        "dayOfWeek": 1,
+                        "openingTime": "09:00:00",
+                        "closingTime": "18:00:00"
+                      },
+                      {
+                        "dayOfWeek": 2,
+                        "openingTime": "09:00:00",
+                        "closingTime": "18:00:00"
+                      },
+                      {
+                        "dayOfWeek": 3,
+                        "openingTime": "09:00:00",
+                        "closingTime": "18:00:00"
+                      },
+                      {
+                        "dayOfWeek": 4,
+                        "openingTime": "09:00:00",
+                        "closingTime": "18:00:00"
+                      },
+                      {
+                        "dayOfWeek": 5,
+                        "openingTime": "09:00:00",
+                        "closingTime": "18:00:00"
+                      }
+                    ],
+                    "tagsLabel": [
+                      "kr47",
+                      "yk15"
+                    ],
+                    "pickupHolidays": [
+                      {
+                        "date": "2024-12-28T03:00:00Z",
+                        "hourBegin": "09:00",
+                        "hourEnd": "13:00"
+                      }
+                    ],
+                    "isThirdPartyPickup": false,
+                    "accountOwnerName": "sportsstore",
+                    "accountOwnerId": "9ddcfba5-3855-49ec-b61e-b2847b9314cc",
+                    "parentAccountName": "sportsstore",
+                    "originalId": "b8e7ca56"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/catalog_system/pvt/products/GetProductAndSkuIds": {
       "get": {
         "tags": [
@@ -36758,6 +36963,192 @@
   },
   "components": {
     "schemas": {
+      "PickupPoint": {
+        "type": "object",
+        "description": "Pickup point information.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "[Pickup point](https://help.vtex.com/en/tutorial/pickup-points--2fljn6wLjn8M4lJHA6HP3R) ID."
+          },
+          "name": {
+            "type": "string",
+            "description": "Pickup point name displayed to customers at checkout."
+          },
+          "description": {
+            "type": "string",
+            "description": "Pickup point description displayed to customers at checkout."
+          },
+          "instructions": {
+            "type": "string",
+            "description": "Instructions for customers when collecting their package."
+          },
+          "formatted_address": {
+            "type": "string",
+            "description": "Formatted address.",
+            "nullable": true
+          },
+          "address": {
+            "type": "object",
+            "description": "Pickup point address information.",
+            "properties": {
+              "postalCode": {
+                "type": "string",
+                "description": "Pickup point address postal code."
+              },
+              "country": {
+                "type": "object",
+                "description": "Information about the pickup point address country.",
+                "properties": {
+                  "acronym": {
+                    "type": "string",
+                    "description": "Three-digit country code of the pickup point address, in [ISO 3166 ALPHA-3](https://www.iban.com/country-codes) format."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Country name of the pickup point address."
+                  }
+                }
+              },
+              "city": {
+                "type": "string",
+                "description": "Pickup point address city."
+              },
+              "state": {
+                "type": "string",
+                "description": "Pickup point address state."
+              },
+              "neighborhood": {
+                "type": "string",
+                "description": "Pickup point address neighborhood."
+              },
+              "street": {
+                "type": "string",
+                "description": "Pickup point address street."
+              },
+              "number": {
+                "type": "string",
+                "description": "Pickup point address number."
+              },
+              "complement": {
+                "type": "string",
+                "description": "Pickup point address complement."
+              },
+              "reference": {
+                "type": "string",
+                "description": "Reference point to help the customer find the pickup point."
+              },
+              "location": {
+                "type": "object",
+                "description": "Pickup point address geolocation coordinates.",
+                "properties": {
+                  "latitude": {
+                    "type": "number",
+                    "description": "Latitude coordinate."
+                  },
+                  "longitude": {
+                    "type": "number",
+                    "description": "Longitude coordinate."
+                  }
+                }
+              }
+            }
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Defines if the pickup point is active (`true`) or inactive (`false`)."
+          },
+          "distance": {
+            "type": "number",
+            "description": "Pickup point configured distance."
+          },
+          "seller": {
+            "type": "string",
+            "description": "Seller that corresponds to the pickup point."
+          },
+          "_sort": {
+            "type": "array",
+            "description": "Sort array.",
+            "items": {
+              "type": "number",
+              "description": "Pickup point sort information."
+            }
+          },
+          "businessHours": {
+            "type": "array",
+            "description": "Pickup point business hours configurations.",
+            "items": {
+              "type": "object",
+              "description": "Business hours configurations from Monday to Friday.",
+              "properties": {
+                "dayOfWeek": {
+                  "type": "integer",
+                  "description": "Day of the week identification, as in `1` = Monday, `2` = Tuesday, `3` = Wednesday, `4` = Thursday, and `5` = Friday."
+                },
+                "openingTime": {
+                  "type": "string",
+                  "description": "Opening time in `HH:MM:SS` format."
+                },
+                "closingTime": {
+                  "type": "string",
+                  "description": "Closing time in `HH:MM:SS` format."
+                }
+              }
+            }
+          },
+          "tagsLabel": {
+            "type": "array",
+            "description": "Tags that identify a group of pickup points.",
+            "items": {
+              "type": "string",
+              "description": "Pickup point tag label."
+            }
+          },
+          "pickupHolidays": {
+            "type": "array",
+            "description": "[Holidays](https://help.vtex.com/en/tutorial/registering-holidays--2ItOthSEAoyAmcwsuiO6Yk) configured for the pickup point.",
+            "items": {
+              "type": "object",
+              "description": "Holiday information.",
+              "properties": {
+                "date": {
+                  "type": "string",
+                  "description": "Holiday date and time, in [ISO 8601 time zone offset format](https://learn.microsoft.com/en-us/rest/api/storageservices/formatting-datetime-values), as in `YYYY-MM-DDThh:mm:ss.ssZ`."
+                },
+                "hourBegin": {
+                  "type": "string",
+                  "description": "Holiday beginning time in `HH:MM` format."
+                },
+                "hourEnd": {
+                  "type": "string",
+                  "description": "Holiday ending time in `HH:MM` format."
+                }
+              }
+            }
+          },
+          "isThirdPartyPickup": {
+            "type": "boolean",
+            "description": "Defines if the pickup point is third-party (`true`) or not (`false`)."
+          },
+          "accountOwnerName": {
+            "type": "string",
+            "description": "Account owner name."
+          },
+          "accountOwnerId": {
+            "type": "string",
+            "description": "Account owner ID."
+          },
+          "parentAccountName": {
+            "type": "string",
+            "description": "Parent account name."
+          },
+          "originalId": {
+            "type": "string",
+            "description": "Original ID.",
+            "nullable": true
+          }
+        }
+      },
       "CreateNewDocument": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
This PR adds 3 loaders to VTEX app
- Page type loaders, which returns the page type of a term or the current req path.
- List pickup points, which returns a list of all the pickup points in your store.
- List pickup points by location, which returns a list of collection points near a location.

## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

