### PR TITLE
feat(vtex, commerce): add stale-while-revalidate for vtex extension loaders

### DIFF
--- a/commerce/loaders/product/extensions/detailsPage.ts
+++ b/commerce/loaders/product/extensions/detailsPage.ts
@@ -12,3 +12,5 @@ export default function ProductDetailsExt(
 ): Promise<ProductDetailsPage | null> {
   return extend(props);
 }
+
+export const cache = "stale-while-revalidate";

--- a/commerce/loaders/product/extensions/list.ts
+++ b/commerce/loaders/product/extensions/list.ts
@@ -12,3 +12,5 @@ export default function ProductsExt(
 ): Promise<Product[] | null> {
   return extend(props);
 }
+
+export const cache = "stale-while-revalidate";

--- a/commerce/loaders/product/extensions/listingPage.ts
+++ b/commerce/loaders/product/extensions/listingPage.ts
@@ -12,3 +12,5 @@ export default function ProductDetailsExt(
 ): Promise<ProductListingPage | null> {
   return extend(props);
 }
+
+export const cache = "stale-while-revalidate";

--- a/vtex/loaders/collections/list.ts
+++ b/vtex/loaders/collections/list.ts
@@ -42,3 +42,5 @@ export default async function loader(
 
   return stringList;
 }
+
+export const cache = "stale-while-revalidate";

--- a/vtex/loaders/product/extend.ts
+++ b/vtex/loaders/product/extend.ts
@@ -156,3 +156,5 @@ export default async (
 
   return p;
 };
+
+export const cache = "stale-while-revalidate";

--- a/vtex/loaders/product/extensions/detailsPage.ts
+++ b/vtex/loaders/product/extensions/detailsPage.ts
@@ -28,4 +28,6 @@ async (page: ProductDetailsPage | null) => {
   };
 };
 
+export const cache = "stale-while-revalidate";
+
 export default loader;

--- a/vtex/loaders/product/extensions/list.ts
+++ b/vtex/loaders/product/extensions/list.ts
@@ -20,4 +20,6 @@ async (products: Product[] | null) =>
     )
     : products;
 
+export const cache = "stale-while-revalidate";
+
 export default loader;

--- a/vtex/loaders/product/extensions/listingPage.ts
+++ b/vtex/loaders/product/extensions/listingPage.ts
@@ -28,4 +28,6 @@ async (page: ProductListingPage | null) => {
   };
 };
 
+export const cache = "stale-while-revalidate";
+
 export default loader;

--- a/vtex/loaders/product/extensions/suggestions.ts
+++ b/vtex/loaders/product/extensions/suggestions.ts
@@ -28,4 +28,6 @@ async (suggestion: Suggestion | null) => {
   };
 };
 
+export const cache = "stale-while-revalidate";
+
 export default loader;

--- a/vtex/loaders/product/wishlist.ts
+++ b/vtex/loaders/product/wishlist.ts
@@ -69,4 +69,6 @@ const loader = async (
   };
 };
 
+export const cache = "stale-while-revalidate";
+
 export default loader;


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?
This PR adds export const cache = 'stale-while-revalidate' to enable cache async render sections

## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

