### PR TITLE
Revert "feat(vtex, commerce): add stale-while-revalidate for vtex ext…

### DIFF
--- a/commerce/loaders/product/extensions/detailsPage.ts
+++ b/commerce/loaders/product/extensions/detailsPage.ts
@@ -12,5 +12,3 @@ export default function ProductDetailsExt(
 ): Promise<ProductDetailsPage | null> {
   return extend(props);
 }
-
-export const cache = "stale-while-revalidate";

--- a/commerce/loaders/product/extensions/list.ts
+++ b/commerce/loaders/product/extensions/list.ts
@@ -12,5 +12,3 @@ export default function ProductsExt(
 ): Promise<Product[] | null> {
   return extend(props);
 }
-
-export const cache = "stale-while-revalidate";

--- a/commerce/loaders/product/extensions/listingPage.ts
+++ b/commerce/loaders/product/extensions/listingPage.ts
@@ -12,5 +12,3 @@ export default function ProductDetailsExt(
 ): Promise<ProductListingPage | null> {
   return extend(props);
 }
-
-export const cache = "stale-while-revalidate";

--- a/vtex/loaders/collections/list.ts
+++ b/vtex/loaders/collections/list.ts
@@ -42,5 +42,3 @@ export default async function loader(
 
   return stringList;
 }
-
-export const cache = "stale-while-revalidate";

--- a/vtex/loaders/product/extend.ts
+++ b/vtex/loaders/product/extend.ts
@@ -156,5 +156,3 @@ export default async (
 
   return p;
 };
-
-export const cache = "stale-while-revalidate";

--- a/vtex/loaders/product/extensions/detailsPage.ts
+++ b/vtex/loaders/product/extensions/detailsPage.ts
@@ -28,6 +28,4 @@ async (page: ProductDetailsPage | null) => {
   };
 };
 
-export const cache = "stale-while-revalidate";
-
 export default loader;

--- a/vtex/loaders/product/extensions/list.ts
+++ b/vtex/loaders/product/extensions/list.ts
@@ -20,6 +20,4 @@ async (products: Product[] | null) =>
     )
     : products;
 
-export const cache = "stale-while-revalidate";
-
 export default loader;

--- a/vtex/loaders/product/extensions/listingPage.ts
+++ b/vtex/loaders/product/extensions/listingPage.ts
@@ -28,6 +28,4 @@ async (page: ProductListingPage | null) => {
   };
 };
 
-export const cache = "stale-while-revalidate";
-
 export default loader;

--- a/vtex/loaders/product/extensions/suggestions.ts
+++ b/vtex/loaders/product/extensions/suggestions.ts
@@ -28,6 +28,4 @@ async (suggestion: Suggestion | null) => {
   };
 };
 
-export const cache = "stale-while-revalidate";
-
 export default loader;

--- a/vtex/loaders/product/wishlist.ts
+++ b/vtex/loaders/product/wishlist.ts
@@ -69,6 +69,4 @@ const loader = async (
   };
 };
 
-export const cache = "stale-while-revalidate";
-
 export default loader;


### PR DESCRIPTION
…ension loaders (#790)"

This reverts commit 4e4cd0d04555b04bf8e6a153e57508c78e64d79c.

Loaders that doesn't implement cacheKey won't vary properly when `enable_loader_cache=true`

<!-- deno-fmt-ignore-file -->
## What is this contribution about?

## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

