### PR TITLE
feat(vtex, commerce): add no cache for product extension loaders

### DIFF
--- a/commerce/loaders/product/extensions/detailsPage.ts
+++ b/commerce/loaders/product/extensions/detailsPage.ts
@@ -12,3 +12,5 @@ export default function ProductDetailsExt(
 ): Promise<ProductDetailsPage | null> {
   return extend(props);
 }
+
+export const cache = "no-cache";

--- a/commerce/loaders/product/extensions/listingPage.ts
+++ b/commerce/loaders/product/extensions/listingPage.ts
@@ -12,3 +12,5 @@ export default function ProductDetailsExt(
 ): Promise<ProductListingPage | null> {
   return extend(props);
 }
+
+export const cache = "no-cache";

--- a/compat/$live/loaders/state.ts
+++ b/compat/$live/loaders/state.ts
@@ -4,7 +4,8 @@ import { Loader } from "deco/blocks/loader.ts";
 import { Page } from "deco/blocks/page.tsx";
 import { Section } from "deco/blocks/section.ts";
 import { Resolvable } from "deco/engine/core/resolver.ts";
-import { Apps, LoaderContext } from "deco/mod.ts";
+import { LoaderContext } from "deco/mod.ts";
+import { Apps } from "deco/blocks/app.ts";
 
 /**
  * @titleBy key

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
     "std/": "https://deno.land/std@0.204.0/",
     "partytown/": "https://deno.land/x/partytown@0.4.8/",
     "deco-sites/std/": "https://denopkg.com/deco-sites/std@1.26.8/",
-    "deco/": "https://denopkg.com/deco-cx/deco@629dcda5176250b32f599d7d966ff45856b37c90/",
+    "deco/": "https://denopkg.com/deco-cx/deco@1.92.0/",
     "@std/assert": "jsr:@std/assert@^1.0.2",
     "@std/async": "jsr:@std/async@^0.224.1",
     "@std/crypto": "jsr:@std/crypto@1.0.0-rc.1",

--- a/deno.json
+++ b/deno.json
@@ -7,8 +7,8 @@
     "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.3.0",
     "std/": "https://deno.land/std@0.204.0/",
     "partytown/": "https://deno.land/x/partytown@0.4.8/",
-    "deco-sites/std/": "https://denopkg.com/deco-sites/std@1.26.7/",
-    "deco/": "https://denopkg.com/deco-cx/deco@1.83.5/",
+    "deco-sites/std/": "https://denopkg.com/deco-sites/std@1.26.8/",
+    "deco/": "https://denopkg.com/deco-cx/deco@629dcda5176250b32f599d7d966ff45856b37c90/",
     "@std/assert": "jsr:@std/assert@^1.0.2",
     "@std/async": "jsr:@std/async@^0.224.1",
     "@std/crypto": "jsr:@std/crypto@1.0.0-rc.1",
@@ -24,7 +24,16 @@
     "@std/path": "jsr:@std/path@^0.225.2",
     "@std/semver": "jsr:@std/semver@^0.224.3",
     "@std/streams": "jsr:@std/streams@^1.0.0",
-    "@std/testing": "jsr:@std/testing@^1.0.0"
+    "@std/testing": "jsr:@std/testing@^1.0.0",
+    "@cliffy/prompt": "jsr:@cliffy/prompt@^1.0.0-rc.5",
+    "@core/asyncutil": "jsr:@core/asyncutil@^1.0.2",
+    "@deco/durable": "jsr:@deco/durable@^0.5.3",
+    "@deco/warp": "jsr:@deco/warp@^0.3.4",
+    "@hono/hono": "jsr:@hono/hono@^4.5.4",
+    "@std/cli": "jsr:@std/cli@^1.0.3",
+    "@zaubrik/djwt": "jsr:@zaubrik/djwt@^3.0.2",
+    "fast-json-patch": "npm:fast-json-patch@^3.1.1",
+    "simple-git": "npm:simple-git@^3.25.0"
   },
   "lock": false,
   "tasks": {

--- a/vtex/loaders/product/extend.ts
+++ b/vtex/loaders/product/extend.ts
@@ -120,6 +120,8 @@ const reviewsExt = async (
   return toReview(products, ratings, reviews);
 };
 
+export const cache = "no-cache";
+
 export default async (
   {
     products,

--- a/vtex/loaders/product/extensions/detailsPage.ts
+++ b/vtex/loaders/product/extensions/detailsPage.ts
@@ -28,4 +28,6 @@ async (page: ProductDetailsPage | null) => {
   };
 };
 
+export const cache = "no-cache";
+
 export default loader;

--- a/vtex/loaders/product/extensions/listingPage.ts
+++ b/vtex/loaders/product/extensions/listingPage.ts
@@ -28,4 +28,6 @@ async (page: ProductListingPage | null) => {
   };
 };
 
+export const cache = "no-cache";
+
 export default loader;


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?
Add cache=no-cache to allow sections that depend on these loaders to be cached when rendered by /deco/render. related to https://github.com/deco-cx/deco/pull/788

## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

