### PR TITLE
fix: disable anthropic stream chunk decoding

### DIFF
--- a/anthropic/actions/stream.ts
+++ b/anthropic/actions/stream.ts
@@ -179,5 +179,7 @@ export default async function chat(
     );
   }
 
-  return readFromStream(response, false);
+  return readFromStream(response, {
+    shouldDecodeChunk: false,
+  });
 }

--- a/anthropic/actions/stream.ts
+++ b/anthropic/actions/stream.ts
@@ -179,5 +179,5 @@ export default async function chat(
     );
   }
 
-  return readFromStream(response);
+  return readFromStream(response, false);
 }

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
     "std/": "https://deno.land/std@0.204.0/",
     "partytown/": "https://deno.land/x/partytown@0.4.8/",
     "deco-sites/std/": "https://denopkg.com/deco-sites/std@1.26.8/",
-    "deco/": "https://denopkg.com/deco-cx/deco@1.92.3/",
+    "deco/": "https://denopkg.com/deco-cx/deco@1.92.5/",
     "@std/assert": "jsr:@std/assert@^1.0.2",
     "@std/async": "jsr:@std/async@^0.224.1",
     "@std/crypto": "jsr:@std/crypto@1.0.0-rc.1",

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
     "std/": "https://deno.land/std@0.204.0/",
     "partytown/": "https://deno.land/x/partytown@0.4.8/",
     "deco-sites/std/": "https://denopkg.com/deco-sites/std@1.26.8/",
-    "deco/": "https://denopkg.com/deco-cx/deco@1.92.0/",
+    "deco/": "https://denopkg.com/deco-cx/deco@1.92.3/",
     "@std/assert": "jsr:@std/assert@^1.0.2",
     "@std/async": "jsr:@std/async@^0.224.1",
     "@std/crypto": "jsr:@std/crypto@1.0.0-rc.1",


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?
Disable stream chunk decoding while reading from stream

## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

