### PR TITLE
fix: remove first slash of the pathname on auction detail

### DIFF
--- a/linx/loaders/auction/detailsPage.ts
+++ b/linx/loaders/auction/detailsPage.ts
@@ -15,7 +15,7 @@ const loader = async (
 ): Promise<AuctionDetail | null> => {
   const { api, cdn } = ctx;
   const upstream = new URL(req.url);
-  const splat = upstream.pathname;
+  const splat = upstream.pathname.slice(1);
 
   const response = await api["GET /*splat"]({
     splat,


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?

from `//leilao/12345` (breaks) -> `/leilao/12345`

## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

