### PR TITLE
Avoid stream and clone

### DIFF
--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -166,7 +166,7 @@ export default function Proxy({
 
     const contentType = response.headers.get("Content-Type");
 
-    let newBodyStream = null;
+    let newBody = await response.text();
 
     if (
       contentType?.includes("text/html") &&
@@ -174,39 +174,24 @@ export default function Proxy({
       includeScriptsToHead.includes.length > 0
     ) {
       // Use a more efficient approach to insert scripts
-      const insertScriptsStream = new TransformStream({
-        async transform(chunk, controller) {
-          const chunkStr = new TextDecoder().decode(await chunk);
 
-          // Find the position of <head> tag
-          const headEndPos = chunkStr.indexOf("</head>");
-          if (headEndPos !== -1) {
-            // Split the chunk at </head> position
-            const beforeHeadEnd = chunkStr.substring(0, headEndPos);
-            const afterHeadEnd = chunkStr.substring(headEndPos);
+      // Find the position of <head> tag
+      const headEndPos = newBody.indexOf("</head>");
+      if (headEndPos !== -1) {
+        // Split the response body at </head> position
+        const beforeHeadEnd = newBody.substring(0, headEndPos);
+        const afterHeadEnd = newBody.substring(headEndPos);
 
-            // Prepare scripts to insert
-            let scriptsInsert = "";
-            for (const script of (includeScriptsToHead?.includes ?? [])) {
-              scriptsInsert += typeof script.src === "string"
-                ? script.src
-                : script.src(req);
-            }
+        // Prepare scripts to insert
+        let scriptsInsert = "";
+        for (const script of (includeScriptsToHead?.includes ?? [])) {
+          scriptsInsert += typeof script.src === "string"
+            ? script.src
+            : script.src(req);
+        }
 
-            // Combine and encode the new chunk
-            const newChunkStr = beforeHeadEnd + scriptsInsert + afterHeadEnd;
-
-            controller.enqueue(new TextEncoder().encode(newChunkStr));
-          } else {
-            // If </head> not found, pass the chunk unchanged
-            controller.enqueue(chunk);
-          }
-        },
-      });
-
-      // Modify the response body by piping through the transform stream
-      if (response.body) {
-        newBodyStream = response.body.pipeThrough(insertScriptsStream);
+        // Combine the new response body
+        newBody = beforeHeadEnd + scriptsInsert + afterHeadEnd;
       }
     }
 
@@ -225,8 +210,6 @@ export default function Proxy({
         );
       }
     }
-
-    const newBody = newBodyStream === null ? response.body : newBodyStream;
 
     let text: undefined | string = undefined;
 

--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -166,7 +166,7 @@ export default function Proxy({
 
     const contentType = response.headers.get("Content-Type");
 
-    let newBody = await response.text();
+    let newBody: ReadableStream<Uint8Array> | string | null = response.body;
 
     if (
       contentType?.includes("text/html") &&
@@ -174,7 +174,7 @@ export default function Proxy({
       includeScriptsToHead.includes.length > 0
     ) {
       // Use a more efficient approach to insert scripts
-
+      newBody = await response.text();
       // Find the position of <head> tag
       const headEndPos = newBody.indexOf("</head>");
       if (headEndPos !== -1) {

--- a/website/loaders/asset.ts
+++ b/website/loaders/asset.ts
@@ -17,7 +17,7 @@ const loader = async (props: Props) => {
 
   const original = await fetchSafe(url.href, STALE);
 
-  const response = new Response(original.clone().body, original);
+  const response = new Response(original.body, original);
   response.headers.set(
     "cache-control",
     "public, s-maxage=15552000, max-age=15552000, immutable",


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?

Streams on deno increases memory usage.

We did some tests considering a program that uses a stream to process a proxied fetch and found a high memory usage both on 1.44.4 and 1.46.1:

```
matheusgr@xpto % deno run -A stats.ts 1.46.1-stream.txt 
Mean: 155601.2
Median: 156768
25th Percentile: 147616
50th Percentile (Median): 156768
75th Percentile: 167136
Standard Deviation: 17387.814910448065
95% Confidence Interval: [152490.12517228883, 158712.2748277112]
```

Non-streamed version (read all body before processing and send it):

```
matheusgr@xpto % deno run -A stats.ts 1.46.1-copy.txt  
Mean: 73920.8
Median: 74216
25th Percentile: 64848
50th Percentile (Median): 74216
75th Percentile: 84032
Standard Deviation: 15291.060129805699
95% Confidence Interval: [71184.88220332093, 76656.71779667908]
```

## Loom
> Record a quick screencast describing your changes to show the team and help reviewers.

## Link
> Please provide a link to a branch that demonstrates this pull request in action.

