### PR TITLE
feat(blog): get all categories

### DIFF
--- a/blog/loaders/GetCategories.ts
+++ b/blog/loaders/GetCategories.ts
@@ -1,0 +1,69 @@
+/**
+ * Retrieves a listing page of blog posts.
+ *
+ * @param props - The props for the blog post listing.
+ * @param req - The request object.
+ * @param ctx - The application context.
+ * @returns A promise that resolves to an array of blog posts.
+ */
+import { RequestURLParam } from "../../website/functions/requestToParam.ts";
+import { AppContext } from "../mod.ts";
+import { Category } from "../types.ts";
+import { getRecordsByPath } from "../utils/records.ts";
+
+const COLLECTION_PATH = "collections/blog/categories";
+const ACCESSOR = "category";
+
+export interface Props {
+  /**
+   * @title Category Slug
+   * @description Get the category data from a specific slug.
+   */
+  slug?: RequestURLParam;
+  /**
+   * @title Items count
+   * @description Number of categories to return
+   */
+  count?: number;
+  /**
+   * @title Sort
+   * @description The sorting option. Default is "title_desc"
+   */
+  sortBy?: "title_asc" | "title_desc";
+}
+
+/**
+ * @title BlogPostList
+ * @description Retrieves a list of blog posts.
+ *
+ * @param props - The props for the blog post list.
+ * @param req - The request object.
+ * @param ctx - The application context.
+ * @returns A promise that resolves to an array of blog posts.
+ */
+export default async function GetCategories(
+  { count, slug, sortBy = "title_desc" }: Props,
+  _req: Request,
+  ctx: AppContext,
+): Promise<Category[] | null> {
+  const categories = await getRecordsByPath<Category>(
+    ctx,
+    COLLECTION_PATH,
+    ACCESSOR,
+  );
+
+  if (!categories?.length) {
+    return null;
+  }
+
+  if (slug) {
+    return categories.filter((c) => c.slug === slug);
+  }
+
+  const sortedCategories = categories.sort((a, b) => {
+    const comparison = a.name.localeCompare(b.name);
+    return sortBy.endsWith("_desc") ? comparison : -comparison;
+  });
+
+  return count ? sortedCategories.slice(0, count) : sortedCategories;
+}

--- a/blog/manifest.gen.ts
+++ b/blog/manifest.gen.ts
@@ -9,6 +9,7 @@ import * as $$$4 from "./loaders/BlogpostList.ts";
 import * as $$$5 from "./loaders/BlogpostListing.ts";
 import * as $$$2 from "./loaders/BlogPostPage.ts";
 import * as $$$6 from "./loaders/Category.ts";
+import * as $$$7 from "./loaders/GetCategories.ts";
 import * as $$$$$$0 from "./sections/Seo/SeoBlogPost.tsx";
 import * as $$$$$$1 from "./sections/Seo/SeoBlogPostListing.tsx";
 import * as $$$$$$2 from "./sections/Template.tsx";
@@ -22,6 +23,7 @@ const manifest = {
     "blog/loaders/BlogpostListing.ts": $$$5,
     "blog/loaders/BlogPostPage.ts": $$$2,
     "blog/loaders/Category.ts": $$$6,
+    "blog/loaders/GetCategories.ts": $$$7,
   },
   "sections": {
     "blog/sections/Seo/SeoBlogPost.tsx": $$$$$$0,

--- a/blog/utils/handlePosts.ts
+++ b/blog/utils/handlePosts.ts
@@ -9,6 +9,7 @@ import { VALID_SORT_ORDERS } from "./constants.ts";
  */
 export const sortPosts = (blogPosts: BlogPost[], sortBy: SortBy) => {
   const splittedSort = sortBy.split("_");
+
   const sortMethod = splittedSort[0] in blogPosts[0]
     ? splittedSort[0] as keyof BlogPost
     : "date";
@@ -26,8 +27,12 @@ export const sortPosts = (blogPosts: BlogPost[], sortBy: SortBy) => {
     if (!b[sortMethod]) {
       return -1; // If post b doesn't have sort method, put it after post a
     }
-    const comparison = new Date(b.date).getTime() -
-      new Date(a.date).getTime(); // Sort in descending order
+    const comparison = sortMethod === "date"
+      ? new Date(b.date).getTime() -
+        new Date(a.date).getTime()
+      : a[sortMethod]?.toString().localeCompare(
+        b[sortMethod]?.toString() ?? "",
+      ) ?? 0;
     return sortOrder === "desc" ? comparison : -comparison; // Invert sort depending of desc or asc
   });
 };


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?
This PR fix the blogpost listing order -> now, the order works properly;
And adds a new loader to get all blogpost categories

