### PR TITLE
Allow users to specify search params on route path

### DIFF
--- a/website/handlers/router.ts
+++ b/website/handlers/router.ts
@@ -99,8 +99,16 @@ export const router = (
     }
 
     for (const { pathTemplate: routePath, handler } of routes) {
+      let url;
+      if (URL.canParse(routePath)) {
+        url = new URL(routePath);
+      } else {
+        url = new URL(routePath, "http://localhost:8000");
+      }
+
       const pattern = urlPatternCache[routePath] ??= new URLPattern({
-        pathname: routePath,
+        pathname: url.pathname,
+        search: url.search,
       });
       const res = pattern.exec(req.url);
       const groups = res?.pathname.groups ?? {};

--- a/website/handlers/router.ts
+++ b/website/handlers/router.ts
@@ -99,17 +99,18 @@ export const router = (
     }
 
     for (const { pathTemplate: routePath, handler } of routes) {
-      let url;
-      if (URL.canParse(routePath)) {
-        url = new URL(routePath);
-      } else {
-        url = new URL(routePath, "http://localhost:8000");
-      }
-
-      const pattern = urlPatternCache[routePath] ??= new URLPattern({
-        pathname: url.pathname,
-        search: url.search,
-      });
+      const pattern = urlPatternCache[routePath] ??= (() => {
+        let url;
+        if (URL.canParse(routePath)) {
+          url = new URL(routePath);
+        } else {
+          url = new URL(routePath, "http://localhost:8000");
+        }
+        return new URLPattern({
+          pathname: url.pathname,
+          search: url.search,
+        });
+      })();
       const res = pattern.exec(req.url);
       const groups = res?.pathname.groups ?? {};
 


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Allow users to specify search params on route path to be used by URLPattern.

URLPattern already support search params, we are not using it so far, but we have now included. Users needs to specify following URLPattern [documentation](https://developer.mozilla.org/en-US/docs/Web/API/URLPattern).

Example usecase in the linked issue.

## Issue Link

Please link to the relevant issue that this pull request addresses:

- Issue: [#823 ](https://github.com/deco-cx/apps/issues/823)