### PR TITLE
Keep signal prop accessible on vtex context on serverside

### DIFF
--- a/vtex/hooks/context.ts
+++ b/vtex/hooks/context.ts
@@ -13,9 +13,9 @@ export interface Context {
 
 const loading = signal<boolean>(true);
 const context = {
-  cart: IS_BROWSER && signal<OrderForm | null>(null) || null,
-  user: IS_BROWSER && signal<Person | null>(null) || null,
-  wishlist: IS_BROWSER && signal<WishlistItem[] | null>(null) || null,
+  cart: IS_BROWSER && signal<OrderForm | null>(null) || { value: null },
+  user: IS_BROWSER && signal<Person | null>(null) || { value: null },
+  wishlist: IS_BROWSER && signal<WishlistItem[] | null>(null) || { value: null },
 };
 
 let queue = Promise.resolve();


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

HOTFIX: Code may use signal even on server side. Avoid break signal compatibility by setting a null value.

## Issue Link

Please link to the relevant issue that this pull request addresses:

- Issue: [#ISSUE_NUMBER](link_to_issue)

## Loom Video

> Record a quick screencast describing your changes to help the team understand and review your contribution. This will greatly assist in the review process.

## Demonstration Link

> Provide a link to a branch or environment where this pull request can be tested and seen in action.
