### PR TITLE
fix(shopify): add `filters` to productListingPage cacheKey 

### DIFF
--- a/shopify/loaders/ProductListingPage.ts
+++ b/shopify/loaders/ProductListingPage.ts
@@ -217,6 +217,14 @@ export const cacheKey = (props: Props, req: Request): string | null => {
     startCursor,
     sort,
   });
+  
+  url.searchParams.forEach((value, key) => {
+    if(!key.startsWith("filter.")) return;
+
+    searchParams.append(key, value);
+  });
+
+  searchParams.sort();
 
   url.search = searchParams.toString();
 


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?
This PR solves the problem of the shopify loaders/productListingPage not varying the cacheKey based on the filters querystring that comes from the URL
## Issue Link

- fixes: [#838](https://github.com/deco-cx/apps/issues/838)

## Demonstration Link

> https://sites-issue-838-g--env.decocdn.com/men?sort=price-ascending&page=0
