### PR TITLE
feat: Add coupon codes at segment and create list and listingPage extensions for sessions with coupon

### DIFF
--- a/admin/widgets.ts
+++ b/admin/widgets.ts
@@ -69,4 +69,3 @@ export type CSVWidget = string;
  * @accept application/pdf
  */
 export type PDFWidget = string;
-

--- a/vnda/loaders/extensions/price/list.ts
+++ b/vnda/loaders/extensions/price/list.ts
@@ -1,0 +1,21 @@
+import { Product } from "../../../../commerce/types.ts";
+import { ExtensionOf } from "../../../../website/loaders/extension.ts";
+import { AppContext } from "../../../mod.ts";
+import { fetchAndApplyPrices } from "../../../utils/transform.ts";
+
+export interface Props {
+  priceCurrency: string;
+}
+
+const loader = (
+  { priceCurrency }: Props,
+  req: Request,
+  ctx: AppContext,
+): ExtensionOf<Product[] | null> =>
+(products: Product[] | null) => {
+  if (!Array.isArray(products)) return products;
+
+  return fetchAndApplyPrices(products, priceCurrency, req, ctx);
+};
+
+export default loader;

--- a/vnda/loaders/extensions/price/listingPage.ts
+++ b/vnda/loaders/extensions/price/listingPage.ts
@@ -1,0 +1,35 @@
+import { ProductListingPage } from "../../../../commerce/types.ts";
+import { ExtensionOf } from "../../../../website/loaders/extension.ts";
+import { AppContext } from "../../../mod.ts";
+import { fetchAndApplyPrices } from "../../../utils/transform.ts";
+
+export interface Props {
+  priceCurrency: string;
+}
+
+const loader = (
+  { priceCurrency }: Props,
+  req: Request,
+  ctx: AppContext,
+): ExtensionOf<ProductListingPage | null> =>
+async (props: ProductListingPage | null) => {
+  if (!props) return props;
+
+  const { products, ...page } = props;
+
+  if (!Array.isArray(products)) return props;
+
+  const extendedProducts = await fetchAndApplyPrices(
+    products,
+    priceCurrency,
+    req,
+    ctx,
+  );
+
+  return {
+    ...page,
+    products: extendedProducts,
+  };
+};
+
+export default loader;

--- a/vnda/manifest.gen.ts
+++ b/vnda/manifest.gen.ts
@@ -9,20 +9,24 @@ import * as $$$$$$$$$3 from "./actions/cart/updateItem.ts";
 import * as $$$$$$$$$4 from "./actions/notifyme.ts";
 import * as $$$$0 from "./handlers/sitemap.ts";
 import * as $$$0 from "./loaders/cart.ts";
-import * as $$$1 from "./loaders/productDetailsPage.ts";
-import * as $$$2 from "./loaders/productDetailsPageVideo.ts";
-import * as $$$3 from "./loaders/productList.ts";
-import * as $$$4 from "./loaders/productListingPage.ts";
-import * as $$$5 from "./loaders/proxy.ts";
+import * as $$$1 from "./loaders/extensions/price/list.ts";
+import * as $$$2 from "./loaders/extensions/price/listingPage.ts";
+import * as $$$3 from "./loaders/productDetailsPage.ts";
+import * as $$$4 from "./loaders/productDetailsPageVideo.ts";
+import * as $$$5 from "./loaders/productList.ts";
+import * as $$$6 from "./loaders/productListingPage.ts";
+import * as $$$7 from "./loaders/proxy.ts";
 
 const manifest = {
   "loaders": {
     "vnda/loaders/cart.ts": $$$0,
-    "vnda/loaders/productDetailsPage.ts": $$$1,
-    "vnda/loaders/productDetailsPageVideo.ts": $$$2,
-    "vnda/loaders/productList.ts": $$$3,
-    "vnda/loaders/productListingPage.ts": $$$4,
-    "vnda/loaders/proxy.ts": $$$5,
+    "vnda/loaders/extensions/price/list.ts": $$$1,
+    "vnda/loaders/extensions/price/listingPage.ts": $$$2,
+    "vnda/loaders/productDetailsPage.ts": $$$3,
+    "vnda/loaders/productDetailsPageVideo.ts": $$$4,
+    "vnda/loaders/productList.ts": $$$5,
+    "vnda/loaders/productListingPage.ts": $$$6,
+    "vnda/loaders/proxy.ts": $$$7,
   },
   "handlers": {
     "vnda/handlers/sitemap.ts": $$$$0,


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Coupon URL promotions are applied when the price is queried through this endpoint. I suspect they are using the original price of the product, in its object, instead of the return from this endpoint

The store is currently on Admin v1 and there is some problem with the Extensions because the Admin does not render the button to choose any extension. If we use the JSON setting to fill the `resolveType` there is this 404 error.
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/1d7a87e4-f21a-417b-b5d6-9c08cfd82033">

## Demonstration Link

- Store: www.bolovo.com.br

### Case
- /produto/meia-outro-lado-2001?skuId=9190000790207&cc=45D544EBDA
- This product should render "R$ 49.50" only entering on this URL
<img width="1234" alt="image" src="https://github.com/user-attachments/assets/369c642e-e947-4985-b743-774cc7c809ef">

