### PR TITLE
priorization pages

### DIFF
--- a/website/loaders/pages.ts
+++ b/website/loaders/pages.ts
@@ -67,7 +67,7 @@ export default async function Pages(
   });
 
   if (props?.external?.preferRoutes) {
-    allPages.map(({ pathTemplate, ...pageProps }: Route) => {
+    return allPages.map(({ pathTemplate, ...pageProps }: Route) => {
       const isException = props.external?.exceptionRoutes?.some((path) =>
         path === pathTemplate
       );
@@ -78,7 +78,7 @@ export default async function Pages(
       return ({
         pathTemplate: isException
           ? pathTemplate
-          : `${pathTemplate}?${queryString}${separator}rdc=true`,
+          : `${pathTemplate}?${queryString}${separator}*rdc=true*`,
         ...pageProps,
       });
     });

--- a/website/loaders/pages.ts
+++ b/website/loaders/pages.ts
@@ -20,7 +20,7 @@ async function getAllPages(ctx: AppContext): Promise<Route[]> {
       continue;
     }
     routes.push({
-      pathTemplate: pathTemplate,
+      pathTemplate,
       handler: {
         value: {
           __resolveType: "website/handlers/fresh.ts",

--- a/website/loaders/pages.ts
+++ b/website/loaders/pages.ts
@@ -35,20 +35,16 @@ async function getAllPages(ctx: AppContext): Promise<Route[]> {
   return routes;
 }
 
-export interface ExternalProps {
-  /**
-   * @title Prioritize External Routes
-   * @description If there is the same route on the deco and externally, as in proxies, the EXTERNAL route will be used. You can also test with the parameter "rdc=true"
-   */
-  preferRoutes?: boolean;
-  /**
-   * @description Deco routes that will ignore the previous rule. If the same route exists on the deco and externally, the DECO route will be used
-   */
-  exceptionRoutes?: SiteRoute[];
-}
-
 export interface Props {
-  external?: ExternalProps;
+  /**
+   * @title Hide pages in deco
+   * @description Don't route the client to any deco page. Important: those page are still accessible if you set the "rdc=true" query string.
+   */
+  hidePagesInDeco?: boolean;
+  /**
+   * @description Deco routes that will ignore the previous rule. If the same route exists on other routes loader, the deco page will be used.
+   */
+  alwaysVisiblePages?: SiteRoute[];
 }
 
 /**
@@ -66,9 +62,9 @@ export default async function Pages(
     __resolveType: "once",
   });
 
-  if (props?.external?.preferRoutes) {
+  if (props?.hidePagesInDeco) {
     return allPages.map(({ pathTemplate, ...pageProps }: Route) => {
-      const isException = props.external?.exceptionRoutes?.some((path) =>
+      const isException = props.alwaysVisiblePages?.some((path) =>
         path === pathTemplate
       );
       const url = new URL(pathTemplate, req.url);


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Now you can make a partial go-live and proxy the other pages. 

https://sites-fila-store--proxy-pages.decocdn.com/sale

https://sites-fila-store--proxy-pages.decocdn.com/sale?rdc=true

Essa imagem representa uma página de categoria na deco (Isso é porque a variant não está cadastrada com um always) 

<img width="1438" alt="Captura de Tela 2024-09-25 às 20 20 45" src="https://github.com/user-attachments/assets/95efa714-e013-425b-a5c3-f43f800a9708">


https://www.loom.com/share/6d10fedeaca345f0ac06d03edde2b632?sid=a468d6cc-f8af-41cc-956d-138822ceecc3
