### PR TITLE
tavano fix wrong sku

### DIFF
--- a/shopify/utils/transform.ts
+++ b/shopify/utils/transform.ts
@@ -42,10 +42,10 @@ export const toProductPage = (
   const skuId = maybeSkuId
     ? getVariantIdFromId(maybeSkuId)
     : product.variants.nodes[0]?.id;
-  const sku = product.variants.nodes.find((node) => node.id === skuId);
+  let sku = product.variants.nodes.find((node) => node.id === skuId);
 
   if (!sku) {
-    throw new Error(`Missing sku ${skuId} on product ${product.title}`);
+    sku = product.variants.nodes[0];
   }
 
   return {

--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -96,14 +96,13 @@ export const pickSku = <T extends ProductVTEX | LegacyProductVTEX>(
 ): T["items"][number] => {
   const skuId = maybeSkuId ?? findFirstAvailable(product.items)?.itemId ??
     product.items[0]?.itemId;
-
   for (const item of product.items) {
     if (item.itemId === skuId) {
       return item;
     }
   }
 
-  throw new Error(`Missing sku ${skuId} on product ${product.productName}`);
+  return product.items[0];
 };
 
 const toAccessoryOrSparePartFor = <T extends ProductVTEX | LegacyProductVTEX>(


### PR DESCRIPTION
I don't think we should broke if the skuId in queryParams doesn't exists on the list, just get the first one.