### PR TITLE
Opt keep empty paths on http client

### DIFF
--- a/utils/http.ts
+++ b/utils/http.ts
@@ -85,7 +85,7 @@ export const createHttpClient = <T>(
     headers: defaultHeaders,
     processHeaders = (headers?: Headers) => headers,
     fetcher = fetchSafe,
-    keepEmptyPath
+    keepEmptyPath,
   }: HttpClientOptions,
 ): ClientOf<T> => {
   // Base should always endwith / so when concatenating with path we get the right URL
@@ -125,7 +125,9 @@ export const createHttpClient = <T>(
             return param;
           })
           .filter((x) =>
-            typeof x === "string" ? (keepEmptyPath || x.length) : typeof x === "number"
+            typeof x === "string"
+              ? (keepEmptyPath || x.length)
+              : typeof x === "number"
           )
           .join("/");
         const url = new URL(compiled, base);

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -76,6 +76,8 @@ export interface HttpClientOptions {
   headers?: Headers;
   processHeaders?: (headers?: Headers) => Headers | undefined;
   fetcher?: typeof fetch;
+  // Keep empty path segments in the URL
+  keepEmptyPath?: boolean;
 }
 export const createHttpClient = <T>(
   {
@@ -83,6 +85,7 @@ export const createHttpClient = <T>(
     headers: defaultHeaders,
     processHeaders = (headers?: Headers) => headers,
     fetcher = fetchSafe,
+    keepEmptyPath
   }: HttpClientOptions,
 ): ClientOf<T> => {
   // Base should always endwith / so when concatenating with path we get the right URL
@@ -122,7 +125,7 @@ export const createHttpClient = <T>(
             return param;
           })
           .filter((x) =>
-            typeof x === "string" && x.length || typeof x === "number"
+            typeof x === "string" ? (keepEmptyPath || x.length) : typeof x === "number"
           )
           .join("/");
         const url = new URL(compiled, base);

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -76,8 +76,8 @@ export interface HttpClientOptions {
   headers?: Headers;
   processHeaders?: (headers?: Headers) => Headers | undefined;
   fetcher?: typeof fetch;
-  // Keep empty path segments in the URL
-  keepEmptyPath?: boolean;
+  // Keep empty segments in the URL
+  keepEmptySegments?: boolean;
 }
 export const createHttpClient = <T>(
   {
@@ -85,7 +85,7 @@ export const createHttpClient = <T>(
     headers: defaultHeaders,
     processHeaders = (headers?: Headers) => headers,
     fetcher = fetchSafe,
-    keepEmptyPath,
+    keepEmptySegments,
   }: HttpClientOptions,
 ): ClientOf<T> => {
   // Base should always endwith / so when concatenating with path we get the right URL
@@ -126,7 +126,7 @@ export const createHttpClient = <T>(
           })
           .filter((x) =>
             typeof x === "string"
-              ? (keepEmptyPath || x.length)
+              ? (keepEmptySegments || x.length)
               : typeof x === "number"
           )
           .join("/");


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Some httpclients may need empty segments, specially at the end of the URL.