### PR TITLE
Avoid throw on related legacy products when all Promise fails

### DIFF
--- a/vtex/loaders/legacy/relatedProductsLoader.ts
+++ b/vtex/loaders/legacy/relatedProductsLoader.ts
@@ -89,12 +89,6 @@ async function loader(
     }, { ...STALE, headers: withSegmentCookie(segment) })
     .then((res) => res.json());
 
-  if (products && !Array.isArray(products)) {
-    throw new Error(
-      `Error while fetching VTEX data ${JSON.stringify(products)}`,
-    );
-  }
-
   // unique Ids
   const relatedIds = [...new Set(
     products.slice(0, count).map((p) => pickSku(p).itemId),

--- a/vtex/loaders/legacy/relatedProductsLoader.ts
+++ b/vtex/loaders/legacy/relatedProductsLoader.ts
@@ -89,6 +89,12 @@ async function loader(
     }, { ...STALE, headers: withSegmentCookie(segment) })
     .then((res) => res.json());
 
+  if (products && !Array.isArray(products)) {
+    throw new Error(
+      `Error while fetching VTEX data ${JSON.stringify(products)}`,
+    );
+  }
+
   // unique Ids
   const relatedIds = [...new Set(
     products.slice(0, count).map((p) => pickSku(p).itemId),
@@ -119,14 +125,6 @@ async function loader(
         (result as PromiseRejectedResult).reason,
       );
     });
-
-  const allPromisesFailed = relatedProductsResults.every(
-    (result) => result.status === "rejected",
-  );
-
-  if (allPromisesFailed) {
-    throw new Error("Failed to load related products for all batches.");
-  }
 
   if (hideUnavailableItems && relatedProducts) {
     const inStock = (p: Product) =>


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Before #878, relatedProducts didn't thrown exception if all products fail.

We are reverting it due to:
- changing established behavior
- related products isn't a critical loader

We may later improve that behavior.