### PR TITLE
feat(shopify): adding public Url to be proxied on shopify

### DIFF
--- a/shopify/loaders/proxy.ts
+++ b/shopify/loaders/proxy.ts
@@ -27,7 +27,7 @@ const decoSiteMapUrl = "/sitemap/deco.xml";
 const buildProxyRoutes = (
   {
     ctx,
-    ctx: { storeName },
+    ctx: { storeName, publicUrl },
     extraPaths,
     includeSiteMap,
     generateDecoSiteMap,
@@ -40,11 +40,13 @@ const buildProxyRoutes = (
     ctx: AppContext;
   },
 ) => {
-  const publicUrl = new URL(`https://${storeName}.myshopify.com`);
+  const urlToUse = publicUrl ? 
+    new URL(publicUrl.startsWith("http") ? publicUrl : `https://${publicUrl}`) :
+    new URL(`https://${storeName}.myshopify.com`);
+
+  const hostname = urlToUse.hostname;
 
   try {
-    const hostname = publicUrl.hostname;
-
     // Rejects TLD mystore.com, keep this if Shopify doesn't support
     if (!hostname || hostname.split(".").length <= 2) {
       throw new Error(`Invalid hostname from '${publicUrl}'`);

--- a/shopify/mod.ts
+++ b/shopify/mod.ts
@@ -16,6 +16,11 @@ export interface Props {
    */
   storeName: string;
   /**
+   * @title Public store URL
+   * @description Domain that is registered on License Manager (e.g: www.mystore.com.br)
+   */
+  publicUrl?: string;
+  /**
    * @title Access Token
    * @description Shopify storefront access token.
    */


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

### Addition of `publicUrl` in Shopify Proxy Loader

This PR implements the addition of a new property, `publicUrl`, to the Shopify proxy loader. The goal is to prevent issues with registered domains that have redirects, ensuring that the correct URLs are used during requests and avoiding bugs related to proxies.

### Changes Made

- **Updated `buildProxyRoutes` function**: 
  - The function now accepts a new parameter, `publicUrl`, which can be provided through the context.
  - If `publicUrl` is present, it will be used to construct the proxy URL; otherwise, the default Shopify store domain (`https://${storeName}.myshopify.com`) will be used.

```javascript
const urlToUse = publicUrl ? 
  new URL(publicUrl.startsWith("http") ? publicUrl : `https://${publicUrl}`) :
  new URL(`https://${storeName}.myshopify.com`);
```

- **Hostname Validation**: 
  - Logic was added to check if the `hostname` is valid, ensuring that only domains with at least two levels are accepted. This validation helps prevent issues when dealing with unsupported domains.

### Documentation

- **Added JSDoc**:
  - Documentation has been updated to include the new `publicUrl` property, which represents the domain registered in the License Manager, e.g., `www.mystore.com.br`.

```javascript
/**
 * @title Public store URL
 * @description Domain that is registered on License Manager (e.g: www.mystore.com.br)
 */
publicUrl?: string;
```

### Final Considerations

This change enhances the robustness of the proxy system, ensuring that redirects are handled correctly and preventing potential navigation errors for users.
