### PR TITLE
[Shopify] Feat: adds signUp action

### DIFF
--- a/shopify/actions/user/signIn.ts
+++ b/shopify/actions/user/signIn.ts
@@ -20,7 +20,7 @@ interface AccessTokenResponse {
 
 /**
  * @title Shopify Integration
- * @description SignInWithEmailAndPassword Action
+ * @description Sign In With Email And Password Action
  */
 const action = async (
   props: Props,

--- a/shopify/actions/user/signUp.ts
+++ b/shopify/actions/user/signUp.ts
@@ -1,0 +1,41 @@
+import type { AppContext } from "../../mod.ts";
+import { RegisterAccount } from "../../utils/storefront/queries.ts";
+import {
+  CustomerCreateInput,
+  CustomerCreatePayload,
+} from "../../utils/storefront/storefront.graphql.gen.ts";
+
+interface Props {
+  email: string;
+  /**
+   * @format password
+   */
+  password: string;
+  firstName: string;
+  lastName: string;
+  acceptsMarketing?: boolean;
+}
+
+/**
+ * @title Shopify Integration
+ * @description Register Account Action
+ */
+const action = async (
+  props: Props,
+  _req: Request,
+  ctx: AppContext,
+): Promise<CustomerCreatePayload> => {
+  const { storefront } = ctx;
+
+  const data = await storefront.query<
+    { customerCreate: CustomerCreatePayload },
+    CustomerCreateInput
+  >({
+    variables: props,
+    ...RegisterAccount,
+  });
+
+  return data.customerCreate;
+};
+
+export default action;

--- a/shopify/loaders/proxy.ts
+++ b/shopify/loaders/proxy.ts
@@ -40,9 +40,9 @@ const buildProxyRoutes = (
     ctx: AppContext;
   },
 ) => {
-  const urlToUse = publicUrl ? 
-    new URL(publicUrl.startsWith("http") ? publicUrl : `https://${publicUrl}`) :
-    new URL(`https://${storeName}.myshopify.com`);
+  const urlToUse = publicUrl
+    ? new URL(publicUrl.startsWith("http") ? publicUrl : `https://${publicUrl}`)
+    : new URL(`https://${storeName}.myshopify.com`);
 
   const hostname = urlToUse.hostname;
 

--- a/shopify/manifest.gen.ts
+++ b/shopify/manifest.gen.ts
@@ -7,6 +7,7 @@ import * as $$$$$$$$$1 from "./actions/cart/updateCoupons.ts";
 import * as $$$$$$$$$2 from "./actions/cart/updateItems.ts";
 import * as $$$$$$$$$3 from "./actions/order/draftOrderCalculate.ts";
 import * as $$$$$$$$$4 from "./actions/user/signIn.ts";
+import * as $$$$$$$$$5 from "./actions/user/signUp.ts";
 import * as $$$$0 from "./handlers/sitemap.ts";
 import * as $$$4 from "./loaders/cart.ts";
 import * as $$$0 from "./loaders/ProductDetailsPage.ts";
@@ -35,6 +36,7 @@ const manifest = {
     "shopify/actions/cart/updateItems.ts": $$$$$$$$$2,
     "shopify/actions/order/draftOrderCalculate.ts": $$$$$$$$$3,
     "shopify/actions/user/signIn.ts": $$$$$$$$$4,
+    "shopify/actions/user/signUp.ts": $$$$$$$$$5,
   },
   "name": "shopify",
   "baseUrl": import.meta.url,

--- a/shopify/utils/storefront/queries.ts
+++ b/shopify/utils/storefront/queries.ts
@@ -387,6 +387,32 @@ export const AddItemToCart = {
   }`,
 };
 
+export const RegisterAccount = {
+  query: gql`mutation RegisterAccount(
+      $email: String!,
+      $password: String!,
+      $firstName: String,
+      $lastName: String,
+      $acceptsMarketing: Boolean = false
+    ) {
+    customerCreate(input: {
+      email: $email,
+      password: $password,
+      firstName: $firstName,
+      lastName: $lastName,
+      acceptsMarketing: $acceptsMarketing,
+    }) {
+      customer {
+        id
+      }
+      customerUserErrors {
+        code
+        message
+      }
+    }
+  }`,
+};
+
 export const AddCoupon = {
   fragments: [Cart],
   query: gql`mutation AddCoupon($cartId: ID!, $discountCodes: [String!]!) {


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

This PR is a complement to [PR #890](https://github.com/deco-cx/apps/pull/890), where I implemented the user hook and the signIn action.

### What was added

- **signUp Action**: I am now implementing the signUp action, which will allow users to complete the registration flow directly from the frontend, without the need for a proxy to Shopify.

Return:

![image](https://github.com/user-attachments/assets/79018767-2688-4de7-9ea1-522e9bfc27f3)

When the email has already been taken:

![image](https://github.com/user-attachments/assets/4d9791a7-7f96-495a-a25c-33a04213d3ab)

This update aims to enhance the user experience by streamlining the login and registration processes.
