### PR TITLE
add replace on shopify

### DIFF
--- a/shopify/loaders/proxy.ts
+++ b/shopify/loaders/proxy.ts
@@ -1,4 +1,5 @@
 import { Route } from "../../website/flags/audience.ts";
+import { TextReplace } from "../../website/handlers/proxy.ts";
 import { AppContext } from "../mod.ts";
 import { withDigestCookie } from "../utils/password.ts";
 
@@ -32,11 +33,13 @@ const buildProxyRoutes = (
     includeSiteMap,
     generateDecoSiteMap,
     excludePathsFromDecoSiteMap,
+    replaces,
   }: {
     extraPaths: string[];
     includeSiteMap?: string[];
     generateDecoSiteMap?: boolean;
     excludePathsFromDecoSiteMap: string[];
+    replaces: TextReplace[];
     ctx: AppContext;
   },
 ) => {
@@ -65,6 +68,7 @@ const buildProxyRoutes = (
           url: urlToProxy,
           host: hostToUse,
           customHeaders: withDigestCookie(ctx),
+          replaces,
         },
       },
     });
@@ -126,6 +130,7 @@ export interface Props {
    * @title Exclude paths from /deco-sitemap.xml
    */
   excludePathsFromDecoSiteMap?: string[];
+  replaces?: TextReplace[];
 }
 
 /**
@@ -137,6 +142,7 @@ function loader(
     includeSiteMap = [],
     generateDecoSiteMap = true,
     excludePathsFromDecoSiteMap = [],
+    replaces = [],
   }: Props,
   _req: Request,
   ctx: AppContext,
@@ -146,6 +152,7 @@ function loader(
     excludePathsFromDecoSiteMap,
     includeSiteMap,
     extraPaths: extraPathsToProxy,
+    replaces,
     ctx,
   });
 }


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Allow proxy on shopify to replace content.

Example:

- some shopify JS may refer the internal domain (site.myshopify.com) that provides an graphql API. This API is accessible only thought a server due to missing CORS headers, so it need a proxy to access it. We can replace this domain with our server so it has a way to access it.
