### PR TITLE
fix: include filter price in facets

### DIFF
--- a/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -102,7 +102,7 @@ export interface Props {
   pageHref?: string;
 
   /**
-   * @description Include price in facets
+   * @title Include price in facets
    */
   priceFacets?: boolean;
 }


### PR DESCRIPTION
Hi guys, I added a new prop to send the price filter in facets. I identified an issue where, when applying the price filter, some filters are displayed even though they don't have corresponding products.

Here's a video with the demonstration.

Video: https://github.com/user-attachments/assets/1431e0dc-890d-40d4-8a0d-ac17326d2a1f











