### PR TITLE
fix: include filter price in facets

### DIFF
--- a/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -132,6 +132,11 @@ export interface Props {
    * @description The URL of the page, used to override URL from request
    */
   pageHref?: string;
+
+  /**
+   * @title Include price in facets
+   */
+  priceFacets?: boolean;
 }
 const searchArgsOf = (props: Props, url: URL) => {
   const hideUnavailableItems = props.hideUnavailableItems;
@@ -264,7 +269,7 @@ const loader = async (
     ? filtersFromPathname(pageTypes)
     : baseSelectedFacets;
   const selected = withDefaultFacets(selectedFacets, ctx);
-  const fselected = selected.filter((f) => f.key !== "price");
+  const fselected = props.priceFacets ? selected : selected.filter((f) => f.key !== "price");
   const isInSeachFormat = Boolean(selected.length) || Boolean(args.query);
   const pathQuery = queryFromPathname(isInSeachFormat, pageTypes, url.pathname);
   const searchArgs = { ...args, query: args.query || pathQuery };


### PR DESCRIPTION
Hi guys, I added a new prop to send the price filter in facets. I identified an issue where, when applying the price filter, some filters are displayed even though they don't have corresponding products.

Here's a video with the demonstration.

Video: https://github.com/user-attachments/assets/1431e0dc-890d-40d4-8a0d-ac17326d2a1f