### PR TITLE
feat: add new prop and body item to cancel order action

### DIFF
--- a/vtex/actions/orders/cancel.ts
+++ b/vtex/actions/orders/cancel.ts
@@ -5,6 +5,7 @@ import { CanceledOrder } from "../../utils/types.ts";
 interface Props {
   orderId: string;
   reason: string;
+  requestedByUser: boolean;
 }
 
 async function action(
@@ -19,13 +20,13 @@ async function action(
     return null;
   }
 
-  const { orderId, reason } = props;
+  const { orderId, reason, requestedByUser } = props;
 
   const response = await vcsDeprecated
     ["POST /api/oms/pvt/orders/:orderId/cancel"](
       { orderId },
       {
-        body: { reason },
+        body: { reason, requestedByUser },
         headers: {
           cookie,
         },

--- a/vtex/utils/client.ts
+++ b/vtex/utils/client.ts
@@ -257,6 +257,7 @@ export interface VTEXCommerceStable {
     response: CanceledOrder;
     body: {
       reason: string;
+      requestedByUser: boolean;
     };
   };
 }


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

- **Interface Update**: Added the `requestedByUser` property to the `Props` interface.

Reference: https://developers.vtex.com/docs/guides/order-canceling-improvements

```markdown
  ```typescript
  interface Props {
    orderId: string;
    reason: string;
    requestedByUser: boolean; // New property added
  }
  ```

- **Action Function Update**: Updated the action function to include the `requestedByUser` in the request body.
  
  ```typescript
  async function action(props: Props) {
    const { orderId, reason, requestedByUser } = props;

    const response = await vcsDeprecated
      ["POST /api/oms/pvt/orders/:orderId/cancel"](
        { orderId },
        {
          body: { reason, requestedByUser }, // New property included
          headers: { cookie },
        }
      );
  }
  ```

- **VTEXCommerceStable Interface**: Added `requestedByUser` to the `VTEXCommerceStable` interface.

  ```typescript
  export interface VTEXCommerceStable {
    response: CanceledOrder;
    body: {
      reason: string;
      requestedByUser: boolean; // New property added
    };
  }
  ```

## Reason

The addition of the `requestedByUser` property helps track who is requesting the order cancellation, improving user action monitoring.