### PR TITLE
Removed window from this hook to support Deno 2.

### DIFF
--- a/vtex/hooks/useCart.ts
+++ b/vtex/hooks/useCart.ts
@@ -57,7 +57,7 @@ export const itemToAnalyticsItem = (
   item_name: item.name ?? item.skuName ?? "",
   item_variant: item.skuName,
   item_brand: item.additionalInfo.brandName ?? "",
-  item_url: new URL(item.detailUrl, globalThis.window.location.href).href,
+  item_url: new URL(item.detailUrl, globalThis.location.href).href,
   ...(mapItemCategoriesToAnalyticsCategories(item)),
 });
 


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?
Removed window from this hook to support Deno 2.
The window used in this hook in globalThis has been [discontinued](https://docs.deno.com/runtime/reference/migration_guide/#:~:text=Use%20globalThis%20instead.). The [storefront template](https://github.com/deco-sites/storefront/blob/36c5dc2fa759426dc7ebde1f47cc6cf55226a037/sdk/cart/vtex/loader.ts#L24) uses this hook here in vtex stores.

## Issue Link

Please link to the relevant issue that this pull request addresses:

- Issue: [#ISSUE_NUMBER](link_to_issue)

## Loom Video

> Record a quick screencast describing your changes to help the team understand and review your contribution. This will greatly assist in the review process.

## Demonstration Link

> Provide a link to a branch or environment where this pull request can be tested and seen in action.
