### PR TITLE
feat: add date-time type on widgets

### DIFF
--- a/admin/widgets.ts
+++ b/admin/widgets.ts
@@ -25,6 +25,11 @@ export type SiteRoute = string;
 export type MapWidget = string;
 
 /**
+ * @format date-time
+ */
+export type DateTime = string;
+
+/**
  * @format textarea
  */
 export type TextArea = string;

--- a/admin/widgets.ts
+++ b/admin/widgets.ts
@@ -25,9 +25,14 @@ export type SiteRoute = string;
 export type MapWidget = string;
 
 /**
+ * @format date
+ */
+export type DateWidget = string;
+
+/**
  * @format date-time
  */
-export type DateTime = string;
+export type DateTimeWidget = string;
 
 /**
  * @format textarea


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

This PR introduces a new widget type to the Deco.cx CMS: **DateTime**, which enables the selection and display of both date and time.

- **Type**: `DateTime` (format `string`)

![image](https://github.com/user-attachments/assets/79e46b3c-82f1-48ab-843f-d2823188b33e)

With this addition, users can easily include date and time fields in their content structures, providing greater flexibility for managing date-related content.
