### PR TITLE
feat(blog): add related posts

### DIFF
--- a/blog/loaders/BlogRelatedPosts.ts
+++ b/blog/loaders/BlogRelatedPosts.ts
@@ -78,7 +78,13 @@ export default async function BlogRelatedPosts(
     ACCESSOR,
   );
 
-  const handledPosts = handlePosts(posts, pageSort, slug, term, excludePostSlug);
+  const handledPosts = handlePosts(
+    posts,
+    pageSort,
+    slug,
+    term,
+    excludePostSlug,
+  );
 
   if (!handledPosts) {
     return null;

--- a/blog/loaders/BlogRelatedPosts.ts
+++ b/blog/loaders/BlogRelatedPosts.ts
@@ -1,5 +1,6 @@
 /**
- * Retrieves a list of blog related posts.
+ * @title BlogRelatedPosts
+ * @description Retrieves a list of blog related posts.
  *
  * @param props - The props for the blog related post list.
  * @param req - The request object.

--- a/blog/loaders/BlogRelatedPosts.ts
+++ b/blog/loaders/BlogRelatedPosts.ts
@@ -30,7 +30,7 @@ export interface Props {
    * @title Category Slug
    * @description Filter by a specific category slug.
    */
-  slug?: RequestURLParam | RequestURLParam[];
+  slug?: RequestURLParam | string[];
   /**
    * @title Page sorting parameter
    * @description The sorting option. Default is "date_desc"
@@ -41,10 +41,10 @@ export interface Props {
    */
   query?: string;
   /**
-   * @title Exclude Slug
-   * @description Excludes a slug from the list
+   * @title Exclude Post Slug
+   * @description Excludes a post slug from the list
    */
-  excludeSlug?: string;
+  excludePostSlug?: RequestURLParam | string;
 }
 
 /**
@@ -56,11 +56,14 @@ export interface Props {
  * @param ctx - The application context.
  * @returns A promise that resolves to an array of blog related posts.
  */
+
+export type BlogRelatedPosts = BlogPost[] | null;
+
 export default async function BlogRelatedPosts(
-  { page, count, slug, sortBy, query, excludeSlug }: Props,
+  { page, count, slug, sortBy, query, excludePostSlug }: Props,
   req: Request,
   ctx: AppContext,
-): Promise<BlogPost[] | null> {
+): Promise<BlogRelatedPosts> {
   const url = new URL(req.url);
   const postsPerPage = Number(count ?? url.searchParams.get("count") ?? 12);
   const pageNumber = Number(page ?? url.searchParams.get("page") ?? 1);
@@ -74,7 +77,7 @@ export default async function BlogRelatedPosts(
     ACCESSOR,
   );
 
-  const handledPosts = handlePosts(posts, pageSort, slug, term, excludeSlug);
+  const handledPosts = handlePosts(posts, pageSort, slug, term, excludePostSlug);
 
   if (!handledPosts) {
     return null;

--- a/blog/loaders/BlogRelatedPosts.ts
+++ b/blog/loaders/BlogRelatedPosts.ts
@@ -1,10 +1,10 @@
 /**
- * Retrieves a list of blog posts.
+ * Retrieves a list of blog related posts.
  *
- * @param props - The props for the blog post list.
+ * @param props - The props for the blog related post list.
  * @param req - The request object.
  * @param ctx - The application context.
- * @returns A promise that resolves to an array of blog posts.
+ * @returns A promise that resolves to an array of blog related posts.
  */
 import { RequestURLParam } from "../../website/functions/requestToParam.ts";
 import { AppContext } from "../mod.ts";
@@ -30,7 +30,7 @@ export interface Props {
    * @title Category Slug
    * @description Filter by a specific category slug.
    */
-  slug?: RequestURLParam;
+  slug?: RequestURLParam | RequestURLParam[];
   /**
    * @title Page sorting parameter
    * @description The sorting option. Default is "date_desc"
@@ -40,26 +40,31 @@ export interface Props {
    * @description Overrides the query term at url
    */
   query?: string;
+  /**
+   * @title Exclude Slug
+   * @description Excludes a slug from the list
+   */
+  excludeSlug?: string;
 }
 
 /**
- * @title BlogPostList
- * @description Retrieves a list of blog posts.
+ * @title BlogRelatedPosts
+ * @description Retrieves a list of blog related posts.
  *
- * @param props - The props for the blog post list.
+ * @param props - The props for the blog related post list.
  * @param req - The request object.
  * @param ctx - The application context.
- * @returns A promise that resolves to an array of blog posts.
+ * @returns A promise that resolves to an array of blog related posts.
  */
-export default async function BlogPostList(
-  { page, count, slug, sortBy, query }: Props,
+export default async function BlogRelatedPosts(
+  { page, count, slug, sortBy, query, excludeSlug }: Props,
   req: Request,
   ctx: AppContext,
 ): Promise<BlogPost[] | null> {
   const url = new URL(req.url);
   const postsPerPage = Number(count ?? url.searchParams.get("count") ?? 12);
   const pageNumber = Number(page ?? url.searchParams.get("page") ?? 1);
-  const pageSort = sortBy ?? url.searchParams.get("sortBy") as SortBy ??
+  const pageSort = sortBy ?? (url.searchParams.get("sortBy") as SortBy) ??
     "date_desc";
   const term = query ?? url.searchParams.get("q") ?? undefined;
 
@@ -69,7 +74,7 @@ export default async function BlogPostList(
     ACCESSOR,
   );
 
-  const handledPosts = handlePosts(posts, pageSort, slug, term);
+  const handledPosts = handlePosts(posts, pageSort, slug, term, excludeSlug);
 
   if (!handledPosts) {
     return null;

--- a/blog/manifest.gen.ts
+++ b/blog/manifest.gen.ts
@@ -16,7 +16,7 @@ import * as $$$$$$1 from "./sections/Seo/SeoBlogPostListing.tsx";
 import * as $$$$$$2 from "./sections/Template.tsx";
 
 const manifest = {
-  loaders: {
+  "loaders": {
     "blog/loaders/Author.ts": $$$0,
     "blog/loaders/Blogpost.ts": $$$3,
     "blog/loaders/BlogPostItem.ts": $$$1,
@@ -27,13 +27,13 @@ const manifest = {
     "blog/loaders/GetCategories.ts": $$$7,
     "blog/loaders/BlogRelatedPosts.ts": $$$8,
   },
-  sections: {
+  "sections": {
     "blog/sections/Seo/SeoBlogPost.tsx": $$$$$$0,
     "blog/sections/Seo/SeoBlogPostListing.tsx": $$$$$$1,
     "blog/sections/Template.tsx": $$$$$$2,
   },
-  name: "blog",
-  baseUrl: import.meta.url,
+  "name": "blog",
+  "baseUrl": import.meta.url,
 };
 
 export type Manifest = typeof manifest;

--- a/blog/manifest.gen.ts
+++ b/blog/manifest.gen.ts
@@ -10,12 +10,13 @@ import * as $$$5 from "./loaders/BlogpostListing.ts";
 import * as $$$2 from "./loaders/BlogPostPage.ts";
 import * as $$$6 from "./loaders/Category.ts";
 import * as $$$7 from "./loaders/GetCategories.ts";
+import * as $$$8 from "./loaders/BlogRelatedPosts.ts";
 import * as $$$$$$0 from "./sections/Seo/SeoBlogPost.tsx";
 import * as $$$$$$1 from "./sections/Seo/SeoBlogPostListing.tsx";
 import * as $$$$$$2 from "./sections/Template.tsx";
 
 const manifest = {
-  "loaders": {
+  loaders: {
     "blog/loaders/Author.ts": $$$0,
     "blog/loaders/Blogpost.ts": $$$3,
     "blog/loaders/BlogPostItem.ts": $$$1,
@@ -24,14 +25,15 @@ const manifest = {
     "blog/loaders/BlogPostPage.ts": $$$2,
     "blog/loaders/Category.ts": $$$6,
     "blog/loaders/GetCategories.ts": $$$7,
+    "blog/loaders/BlogRelatedPosts.ts": $$$8,
   },
-  "sections": {
+  sections: {
     "blog/sections/Seo/SeoBlogPost.tsx": $$$$$$0,
     "blog/sections/Seo/SeoBlogPostListing.tsx": $$$$$$1,
     "blog/sections/Template.tsx": $$$$$$2,
   },
-  "name": "blog",
-  "baseUrl": import.meta.url,
+  name: "blog",
+  baseUrl: import.meta.url,
 };
 
 export type Manifest = typeof manifest;

--- a/blog/utils/handlePosts.ts
+++ b/blog/utils/handlePosts.ts
@@ -59,6 +59,22 @@ export const filterPostsByTerm = (posts: BlogPost[], term: string) =>
   );
 
 /**
+ * Returns an filtered BlogPost list
+ *
+ * @param posts Posts to be handled
+ * @param slug Category Slug to be filter
+ */
+export const filterRelatedPosts = (
+  posts: BlogPost[],
+  slug: string[],
+  excludeSlug?: string,
+) =>
+  posts.filter(
+    ({ categories, slug: postSlug }) =>
+      categories.find((c) => slug.includes(c.slug)) && postSlug !== excludeSlug,
+  );
+
+/**
  * Returns an filtered and sorted BlogPost list
  *
  * @param posts Posts to be handled
@@ -77,11 +93,14 @@ export const slicePosts = (
 
 export const filterPosts = (
   posts: BlogPost[],
-  slug?: string,
+  slug?: string | string[],
   term?: string,
+  excludeSlug?: string,
 ): BlogPost[] => {
   if (term) return filterPostsByTerm(posts, term);
-  if (slug) return filterPostsByCategory(posts, slug);
+  if (typeof slug === "string") return filterPostsByCategory(posts, slug);
+  if (Array.isArray(slug)) return filterRelatedPosts(posts, slug, excludeSlug);
+
   return posts;
 };
 
@@ -96,10 +115,11 @@ export const filterPosts = (
 export default function handlePosts(
   posts: BlogPost[],
   sortBy: SortBy,
-  slug?: string,
+  slug?: string | string[],
   term?: string,
+  excludeSlug?: string,
 ) {
-  const filteredPosts = filterPosts(posts, slug, term);
+  const filteredPosts = filterPosts(posts, slug, term, excludeSlug);
 
   if (!filteredPosts || filteredPosts.length === 0) {
     return null;

--- a/blog/utils/handlePosts.ts
+++ b/blog/utils/handlePosts.ts
@@ -67,11 +67,11 @@ export const filterPostsByTerm = (posts: BlogPost[], term: string) =>
 export const filterRelatedPosts = (
   posts: BlogPost[],
   slug: string[],
-  excludeSlug?: string,
+  excludePostSlug?: string,
 ) =>
   posts.filter(
     ({ categories, slug: postSlug }) =>
-      categories.find((c) => slug.includes(c.slug)) && postSlug !== excludeSlug,
+      categories.find((c) => slug.includes(c.slug)) && postSlug !== excludePostSlug,
   );
 
 /**
@@ -95,11 +95,11 @@ export const filterPosts = (
   posts: BlogPost[],
   slug?: string | string[],
   term?: string,
-  excludeSlug?: string,
+  excludePostSlug?: string,
 ): BlogPost[] => {
   if (term) return filterPostsByTerm(posts, term);
   if (typeof slug === "string") return filterPostsByCategory(posts, slug);
-  if (Array.isArray(slug)) return filterRelatedPosts(posts, slug, excludeSlug);
+  if (Array.isArray(slug)) return filterRelatedPosts(posts, slug, excludePostSlug);
 
   return posts;
 };
@@ -117,9 +117,9 @@ export default function handlePosts(
   sortBy: SortBy,
   slug?: string | string[],
   term?: string,
-  excludeSlug?: string,
+  excludePostSlug?: string,
 ) {
-  const filteredPosts = filterPosts(posts, slug, term, excludeSlug);
+  const filteredPosts = filterPosts(posts, slug, term, excludePostSlug);
 
   if (!filteredPosts || filteredPosts.length === 0) {
     return null;

--- a/blog/utils/handlePosts.ts
+++ b/blog/utils/handlePosts.ts
@@ -67,11 +67,9 @@ export const filterPostsByTerm = (posts: BlogPost[], term: string) =>
 export const filterRelatedPosts = (
   posts: BlogPost[],
   slug: string[],
-  excludePostSlug?: string,
 ) =>
   posts.filter(
-    ({ categories, slug: postSlug }) =>
-      categories.find((c) => slug.includes(c.slug)) && postSlug !== excludePostSlug,
+    ({ categories }) => categories.find((c) => slug.includes(c.slug)),
   );
 
 /**
@@ -95,11 +93,12 @@ export const filterPosts = (
   posts: BlogPost[],
   slug?: string | string[],
   term?: string,
-  excludePostSlug?: string,
 ): BlogPost[] => {
   if (term) return filterPostsByTerm(posts, term);
   if (typeof slug === "string") return filterPostsByCategory(posts, slug);
-  if (Array.isArray(slug)) return filterRelatedPosts(posts, slug, excludePostSlug);
+  if (Array.isArray(slug)) {
+    return filterRelatedPosts(posts, slug);
+  }
 
   return posts;
 };
@@ -109,8 +108,9 @@ export const filterPosts = (
  *
  * @param posts Posts to be handled
  * @param sortBy Sort option (must be: "date_desc" | "date_asc" | "title_asc" | "title_desc" )
- * @param slug Category slug to be filter
+ * @param slug Category slug or an array of slugs to be filtered
  * @param term Term to be filter
+ * @param excludePostSlug Post slug to be excluded
  */
 export default function handlePosts(
   posts: BlogPost[],
@@ -119,7 +119,9 @@ export default function handlePosts(
   term?: string,
   excludePostSlug?: string,
 ) {
-  const filteredPosts = filterPosts(posts, slug, term, excludePostSlug);
+  const filteredPosts = filterPosts(posts, slug, term).filter(
+    ({ slug: postSlug }) => postSlug !== excludePostSlug,
+  );
 
   if (!filteredPosts || filteredPosts.length === 0) {
     return null;


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?

This PR was made to add the option to search related posts.
The search is carried out according to the category/categories of the post.
An optional "excludeSlug" prop was also added to exclude the current post from the return list.

Example: 

<img width="1440" alt="Captura de Tela 2024-12-17 às 20 52 43" src="https://github.com/user-attachments/assets/c007aaa1-be79-4aaa-8e5b-5596d9b4b762" />
