### PR TITLE
fix: implementation of sortField and sortOrder fields

### DIFF
--- a/konfidency/loaders/productDetailsPage.ts
+++ b/konfidency/loaders/productDetailsPage.ts
@@ -5,6 +5,16 @@ import { toReview } from "../utils/transform.ts";
 import { logger } from "@deco/deco/o11y";
 export interface Props {
   /**
+ * @description Rating type, default: helpfulScore
+ * @default "helpfulScore"
+ */
+  sortField?: "helpfulScore" | "created" | "rating";
+  /**
+   * @description Default value: asc
+   * @default "asc"
+   */
+  sortOrder?: "asc" | "desc";
+  /**
    * @description The default value is 5
    */
   pageSize?: number;
@@ -14,7 +24,7 @@ export interface Props {
   page?: number;
 }
 export default function productDetailsPage(
-  { pageSize = 5, page = 1 }: Props,
+  { pageSize = 5, page = 1, sortField = "helpfulScore", sortOrder = "asc" }: Props,
   _req: Request,
   ctx: AppContext,
 ): ExtensionOf<ProductDetailsPage | null> {
@@ -24,8 +34,9 @@ export default function productDetailsPage(
       return null;
     }
     try {
-      const reviews = await api["GET /:customer/:sku/summary"]({
+      const reviews = await api["GET /:customer/:sku/summary/:sortField,:sortOrder"]({
         customer,
+        "sortField,:sortOrder": `${sortField},${sortOrder}`,
         page,
         pageSize,
         sku: productDetailsPage.product.inProductGroupWithID as string,

--- a/konfidency/utils/client.ts
+++ b/konfidency/utils/client.ts
@@ -1,7 +1,7 @@
 import type { PDPReview, WriteReview, ResponseWriteReview } from "./types.ts";
 
 export interface API {
-  "GET /:customer/:sku/summary": {
+  "GET /:customer/:sku/summary/:sortField,:sortOrder": {
     response: PDPReview;
     searchParams: {
       page: number;


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?
Solution to the problem with intermittent responses to Konfidency reviews on PDP

Provide a brief description of the changes or improvements you are proposing in this pull request.
As analyzed in the Konfidency documentation, we found a problem in the request on [product evaluation endPoint], where previously the sortField and sortOrder values ​​were not passed, resulting in a lack of evaluation data

## Loom video
https://www.loom.com/share/602525ae12d94b239a2d2cad7adf08ab?sid=4725c5cd-f9de-44ca-a4a8-a9202efb983e