### PR TITLE
feat(blog): expose unique identifier

### DIFF
--- a/blog/types.ts
+++ b/blog/types.ts
@@ -58,6 +58,8 @@ export interface BlogPost {
    * @title Extra Props
    */
   extraProps?: ExtraProps[];
+  /** @hide true */
+  id: string;
 }
 
 export interface ExtraProps {

--- a/blog/types.ts
+++ b/blog/types.ts
@@ -59,7 +59,7 @@ export interface BlogPost {
    */
   extraProps?: ExtraProps[];
   /** @hide true */
-  id: string;
+  id?: string;
 }
 
 export interface ExtraProps {

--- a/blog/utils/records.ts
+++ b/blog/utils/records.ts
@@ -11,5 +11,11 @@ export async function getRecordsByPath<T>(
   const current = Object.entries(resolvables).flatMap(([key, value]) => {
     return key.startsWith(path) ? value : [];
   });
-  return (current as Record<string, T>[]).map((item) => item[accessor]);
+  return (current as Record<string, T>[]).map((item) => {
+    const id = (item.name as string).split(path)[1]?.replace("/", "");
+    return {
+      ...item[accessor],
+      id,
+    };
+  });
 }


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

This PR aims to add the unique id of the blog post.

As the post can be 100% edited (including the slug), we added this id to have a unique identifier.


Aiming at a scenario in which we save comments using the post_slug in the comments table, if there were any changes to the slug due to an error or anything else, we would lose all data registered in the system due to this change.
![{07EE2404-F2E0-4185-B50A-EB3C6DE31511}](https://github.com/user-attachments/assets/b9a773b5-2976-4eb4-ae4f-16eb9322f6e8)

