### PR TITLE
fix: reviews ordenation

### DIFF
--- a/konfidency/actions/submitReviews.ts
+++ b/konfidency/actions/submitReviews.ts
@@ -10,10 +10,13 @@ export interface Props {
   review: WriteReview;
 }
 
-export default async function action(props: Props, _req: Request, ctx: AppContext): Promise<ResponseWriteReview | null> {
-
-  const { customer, api } = ctx
-  const { review, sku } = props
+export default async function action(
+  props: Props,
+  _req: Request,
+  ctx: AppContext,
+): Promise<ResponseWriteReview | null> {
+  const { customer, api } = ctx;
+  const { review, sku } = props;
 
   try {
     const response = await api[`POST /:customer/:sku/review`]({
@@ -23,13 +26,12 @@ export default async function action(props: Props, _req: Request, ctx: AppContex
       body: {
         ...review,
       },
-    }).then((r) => r.json())
-    return await response
+    }).then((r) => r.json());
+    return await response;
   } catch (error) {
     const errorObj = error as { name: string; message: string };
     logger.error(`{ errorName: ${errorObj.name},  
     errorMessage: ${errorObj.message} }`);
-    return null
+    return null;
   }
-
 }

--- a/konfidency/loaders/productDetailsPage.ts
+++ b/konfidency/loaders/productDetailsPage.ts
@@ -5,9 +5,9 @@ import { toReview } from "../utils/transform.ts";
 import { logger } from "@deco/deco/o11y";
 export interface Props {
   /**
- * @description Rating type, default: helpfulScore
- * @default "helpfulScore"
- */
+   * @description Rating type, default: helpfulScore
+   * @default "helpfulScore"
+   */
   sortField?: "helpfulScore" | "created" | "rating";
   /**
    * @description Default value: asc
@@ -24,7 +24,8 @@ export interface Props {
   page?: number;
 }
 export default function productDetailsPage(
-  { pageSize = 5, page = 1, sortField = "helpfulScore", sortOrder = "asc" }: Props,
+  { pageSize = 5, page = 1, sortField = "helpfulScore", sortOrder = "asc" }:
+    Props,
   _req: Request,
   ctx: AppContext,
 ): ExtensionOf<ProductDetailsPage | null> {
@@ -34,13 +35,14 @@ export default function productDetailsPage(
       return null;
     }
     try {
-      const reviews = await api["GET /:customer/:sku/summary/:sortField,:sortOrder"]({
-        customer,
-        "sortField,:sortOrder": `${sortField},${sortOrder}`,
-        page,
-        pageSize,
-        sku: productDetailsPage.product.inProductGroupWithID as string,
-      }).then((res) => res.json());
+      const reviews = await api
+        ["GET /:customer/:sku/summary/:sortField,:sortOrder"]({
+          customer,
+          "sortField,:sortOrder": `${sortField},${sortOrder}`,
+          page,
+          pageSize,
+          sku: productDetailsPage.product.inProductGroupWithID as string,
+        }).then((res) => res.json());
       const { aggregateRating, review } = toReview(reviews.reviews[0]);
       return {
         ...productDetailsPage,

--- a/konfidency/manifest.gen.ts
+++ b/konfidency/manifest.gen.ts
@@ -2,8 +2,8 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/productDetailsPage.ts";
 import * as $$$$$$$$$0 from "./actions/submitReviews.ts";
+import * as $$$0 from "./loaders/productDetailsPage.ts";
 
 const manifest = {
   "loaders": {

--- a/konfidency/utils/client.ts
+++ b/konfidency/utils/client.ts
@@ -1,4 +1,4 @@
-import type { PDPReview, WriteReview, ResponseWriteReview } from "./types.ts";
+import type { PDPReview, ResponseWriteReview, WriteReview } from "./types.ts";
 
 export interface API {
   "GET /:customer/:sku/summary/:sortField,:sortOrder": {
@@ -10,7 +10,7 @@ export interface API {
   };
 
   "POST /:customer/:sku/review": {
-    response: ResponseWriteReview
+    response: ResponseWriteReview;
     body: WriteReview;
-  }
+  };
 }

--- a/konfidency/utils/types.ts
+++ b/konfidency/utils/types.ts
@@ -52,17 +52,17 @@ export interface WriteReview {
 }
 
 export interface ResponseWriteReview {
-  helpful: number;      
-  unhelpful: number;     
-  verified: boolean;     
-  status: string;       
-  _id: string;        
-  created: string;       
-  customer: string;     
-  userId: string;       
-  name: string;          
-  sku: string;           
-  text: string;          
-  recommended: boolean;  
-  rating: number;        
+  helpful: number;
+  unhelpful: number;
+  verified: boolean;
+  status: string;
+  _id: string;
+  created: string;
+  customer: string;
+  userId: string;
+  name: string;
+  sku: string;
+  text: string;
+  recommended: boolean;
+  rating: number;
 }

--- a/verified-reviews/utils/client.ts
+++ b/verified-reviews/utils/client.ts
@@ -20,15 +20,6 @@ export interface PaginationOptions {
     | "helpfulrating_DESC";
 }
 
-// creating an object to keep backward compatibility
-const orderMap = {
-  date_desc: "date_desc",
-  date_ASC: "date_asc",
-  rate_DESC: "rate_desc",
-  rate_ASC: "rate_asc",
-  helpfulrating_DESC: "most_helpful",
-} as const;
-
 const MessageError = {
   ratings:
     "🔴⭐ Error on call ratings of Verified Review - probably unidentified product",
@@ -96,14 +87,12 @@ export const createClient = (params: ConfigVerifiedReviews | undefined) => {
   };
   /** @description https://documenter.getpostman.com/view/2336519/SVzw6MK5#daf51360-c79e-451a-b627-33bdd0ef66b8 */
   const reviews = (
-    { productId, count = 5, offset = 0, order: _order = "date_desc" }:
+    { productId, count, offset = 0, order = "date_desc" }:
       & PaginationOptions
       & {
         productId: string | string[];
       },
   ) => {
-    const order = orderMap[_order];
-
     const payload = {
       query: "reviews",
       product: Array.isArray(productId) ? productId : [productId],
@@ -122,7 +111,7 @@ export const createClient = (params: ConfigVerifiedReviews | undefined) => {
 
   const fullReview = async ({
     productId,
-    count = 5,
+    count,
     offset = 0,
     order,
   }: PaginationOptions & {

--- a/verified-reviews/utils/client.ts
+++ b/verified-reviews/utils/client.ts
@@ -18,7 +18,17 @@ export interface PaginationOptions {
     | "rate_DESC"
     | "rate_ASC"
     | "helpfulrating_DESC";
+  useOrdenationCompatibility?: boolean;
 }
+
+// creating an object to keep backward compatibility
+const orderMap = {
+  date_desc: "date_desc",
+  date_ASC: "date_asc",
+  rate_DESC: "rate_desc",
+  rate_ASC: "rate_asc",
+  helpfulrating_DESC: "helpfulrating_desc",
+};
 
 const MessageError = {
   ratings:
@@ -87,12 +97,14 @@ export const createClient = (params: ConfigVerifiedReviews | undefined) => {
   };
   /** @description https://documenter.getpostman.com/view/2336519/SVzw6MK5#daf51360-c79e-451a-b627-33bdd0ef66b8 */
   const reviews = (
-    { productId, count, offset = 0, order = "date_desc" }:
+    { productId, count = 5, offset = 0, order: _order = "date_desc", useOrdenationCompatibility = false }:
       & PaginationOptions
       & {
         productId: string | string[];
       },
   ) => {
+    const order = useOrdenationCompatibility ? orderMap[_order] : _order;
+
     const payload = {
       query: "reviews",
       product: Array.isArray(productId) ? productId : [productId],
@@ -111,7 +123,7 @@ export const createClient = (params: ConfigVerifiedReviews | undefined) => {
 
   const fullReview = async ({
     productId,
-    count,
+    count = 5,
     offset = 0,
     order,
   }: PaginationOptions & {

--- a/verified-reviews/utils/client.ts
+++ b/verified-reviews/utils/client.ts
@@ -21,9 +21,7 @@ export interface PaginationOptions {
     | "helpfulrating_DESC"
     | string;
   /**
-   * @description Indicates whether to customize the order of the results.
-   * If true, the order will be based on the provided order parameter.
-   * If false, the default order will be used.
+   * @description Determines if the order of results should be customized based on the provided parameter.
    */
   customizeOrder?: boolean;
 }

--- a/verified-reviews/utils/client.ts
+++ b/verified-reviews/utils/client.ts
@@ -12,13 +12,20 @@ export type ClientVerifiedReviews = ReturnType<typeof createClient>;
 export interface PaginationOptions {
   count?: number;
   offset?: number;
+  // legacy compatible parameters that will map to "orderMap" parameters, but we generally recommend using a custom parameter.
   order?:
     | "date_desc"
     | "date_ASC"
     | "rate_DESC"
     | "rate_ASC"
-    | "helpfulrating_DESC";
-  useOrdenationCompatibility?: boolean;
+    | "helpfulrating_DESC"
+    | string;
+  /**
+   * @description Indicates whether to customize the order of the results.
+   * If true, the order will be based on the provided order parameter.
+   * If false, the default order will be used.
+   */
+  customizeOrder?: boolean;
 }
 
 // creating an object to keep backward compatibility
@@ -27,8 +34,8 @@ const orderMap = {
   date_ASC: "date_asc",
   rate_DESC: "rate_desc",
   rate_ASC: "rate_asc",
-  helpfulrating_DESC: "helpfulrating_desc",
-};
+  helpfulrating_DESC: "most_helpful",
+} as const;
 
 const MessageError = {
   ratings:
@@ -97,13 +104,13 @@ export const createClient = (params: ConfigVerifiedReviews | undefined) => {
   };
   /** @description https://documenter.getpostman.com/view/2336519/SVzw6MK5#daf51360-c79e-451a-b627-33bdd0ef66b8 */
   const reviews = (
-    { productId, count = 5, offset = 0, order: _order = "date_desc", useOrdenationCompatibility = false }:
+    { productId, count = 5, offset = 0, order: _order = "date_desc", customizeOrder = false }:
       & PaginationOptions
       & {
         productId: string | string[];
       },
   ) => {
-    const order = useOrdenationCompatibility ? orderMap[_order] : _order;
+    const order = customizeOrder ? orderMap[_order as keyof typeof orderMap] : _order;
 
     const payload = {
       query: "reviews",

--- a/verified-reviews/utils/client.ts
+++ b/verified-reviews/utils/client.ts
@@ -108,7 +108,7 @@ export const createClient = (params: ConfigVerifiedReviews | undefined) => {
         productId: string | string[];
       },
   ) => {
-    const order = customizeOrder ? orderMap[_order as keyof typeof orderMap] : _order;
+    const order = customizeOrder ? _order : orderMap[_order as keyof typeof orderMap];
 
     const payload = {
       query: "reviews",


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

The Verified reviews have some custom atributes for some clients. Some clients use date_ASC" others use "date_asc. The PR's suggestion would be to leave a toggle in the admin, so when the client is one that uses the lowercase sorting options, simply activate the toggle.

## Issue Link

Please link to the relevant issue that this pull request addresses:

- Issue: [#ISSUE_NUMBER](link_to_issue)

## Loom Video

> https://www.loom.com/share/cdd5dadf33304f70a3d6fe3e66f4c736?sid=b2bc9490-ade6-4614-b10b-c43bec0b483c

## Demonstration Link

> https://sites-oficina-reserva--feat-reviews.decocdn.com/camiseta-pima-premium-gola-c-preta-0079110040/p?skuId=8965
