### PR TITLE
Fix empty cart type

### DIFF
--- a/verified-reviews/utils/client.ts
+++ b/verified-reviews/utils/client.ts
@@ -102,13 +102,21 @@ export const createClient = (params: ConfigVerifiedReviews | undefined) => {
   };
   /** @description https://documenter.getpostman.com/view/2336519/SVzw6MK5#daf51360-c79e-451a-b627-33bdd0ef66b8 */
   const reviews = (
-    { productId, count = 5, offset = 0, order: _order = "date_desc", customizeOrder = false }:
+    {
+      productId,
+      count = 5,
+      offset = 0,
+      order: _order = "date_desc",
+      customizeOrder = false,
+    }:
       & PaginationOptions
       & {
         productId: string | string[];
       },
   ) => {
-    const order = customizeOrder ? _order : orderMap[_order as keyof typeof orderMap];
+    const order = customizeOrder
+      ? _order
+      : orderMap[_order as keyof typeof orderMap];
 
     const payload = {
       query: "reviews",

--- a/vtex/actions/analytics/sendEvent.ts
+++ b/vtex/actions/analytics/sendEvent.ts
@@ -16,7 +16,9 @@ export type Props =
   }
   | {
     type: "page.empty_cart";
-    products: [];
+    // Empty array is converted to a invalid json schema... so, let it be anything.
+    // deno-lint-ignore ban-types
+    products: {};
   }
   | {
     type: "page.confirmation";

--- a/vtex/loaders/promotion/getPromotionById.ts
+++ b/vtex/loaders/promotion/getPromotionById.ts
@@ -9,7 +9,7 @@ interface Props {
   idCalculatorConfiguration: string;
 }
 
-export const defaultVisibility = 'private' 
+export const defaultVisibility = "private";
 
 export default async function loader(
   props: Props,

--- a/vtex/utils/openapi/vcs.openapi.json
+++ b/vtex/utils/openapi/vcs.openapi.json
@@ -8,908 +8,908 @@
   },
   "paths": {
     "/api/rnb/pvt/calculatorconfiguration/{idCalculatorConfiguration}": {
-            "get": {
-                "tags": [
-                    "Promotions and taxes"
-                ],
-                "summary": "Get promotion or tax by ID",
-                "description": "Retrieves a specific promotion by its Promotion ID or a specific tax by its tax ID.\r\n\r\n## Permissions\r\n\r\nAny user or [application key](https://developers.vtex.com/docs/guides/api-authentication-using-application-keys) must have at least one of the appropriate [License Manager resources](https://help.vtex.com/en/tutorial/license-manager-resources--3q6ztrC8YynQf6rdc6euk3) to be able to successfully run this request. Otherwise they will receive a status code `403` error. These are the applicable resources for this endpoint:\r\n\r\n| **Product** | **Category** | **Resource** |\r\n| --------------- | ----------------- | ----------------- |\r\n| Rates and Benefits | Manage benefits and rates | **GerenciarPromocoesETarifas** |\r\n\r\nThere are no applicable [predefined roles](https://help.vtex.com/en/tutorial/predefined-roles--jGDurZKJHvHJS13LnO7Dy) for this resource list. You must [create a custom role](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#creating-a-role) and add at least one of the resources above in order to use this endpoint. To learn more about machine authentication at VTEX, see [Authentication overview](https://developers.vtex.com/docs/guides/authentication).\r\n\r\n>\u2757 To prevent integrations from having excessive permissions, consider the [best practices for managing app keys](https://help.vtex.com/en/tutorial/best-practices-application-keys--7b6nD1VMHa49aI5brlOvJm) when assigning License Manager roles to integrations.",
-                "operationId": "GetCalculatorConfigurationById",
-                "parameters": [
-                    {
-                        "name": "Content-Type",
-                        "in": "header",
-                        "description": "Type of the content being sent.",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "application/json"
-                        }
-                    },
-                    {
-                        "name": "Accept",
-                        "in": "header",
-                        "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "default": "application/json"
-                        }
-                    },
-                    {
-                        "name": "idCalculatorConfiguration",
-                        "in": "path",
-                        "description": "Promotion ID or tax ID.",
-                        "required": true,
-                        "style": "simple",
-                        "schema": {
-                            "type": "string",
-                            "example": "d8a1cd2e-b667-4054-b3ae-b79124c7218e"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "example": {
-                                    "idCalculatorConfiguration": "d8a1cd2e-b667-4054-b3ae-b79124c7218e",
-                                    "name": "Social Seller Promotion",
-                                    "beginDateUtc": "2020-05-01T18:47:15.89Z",
-                                    "lastModified": "2021-02-23T20:58:38.7963862Z",
-                                    "daysAgoOfPurchases": 0,
-                                    "isActive": true,
-                                    "isArchived": false,
-                                    "isFeatured": false,
-                                    "disableDeal": false,
-                                    "activeDaysOfWeek": [],
-                                    "offset": -3,
-                                    "activateGiftsMultiplier": false,
-                                    "newOffset": -3.0,
-                                    "maxPricesPerItems": [],
-                                    "cumulative": false,
-                                    "discountType": "percentual",
-                                    "nominalShippingDiscountValue": 0.0,
-                                    "absoluteShippingDiscountValue": 0.0,
-                                    "nominalDiscountValue": 0.0,
-                                    "nominalDiscountType": "item",
-                                    "maximumUnitPriceDiscount": 0.0,
-                                    "percentualDiscountValue": 10.0,
-                                    "rebatePercentualDiscountValue": 0.0,
-                                    "percentualShippingDiscountValue": 0.0,
-                                    "percentualTax": 0.0,
-                                    "shippingPercentualTax": 0.0,
-                                    "percentualDiscountValueList1": 0.0,
-                                    "percentualDiscountValueList2": 0.0,
-                                    "skusGift": {
-                                        "quantitySelectable": 0
-                                    },
-                                    "nominalRewardValue": 0.0,
-                                    "percentualRewardValue": 0.0,
-                                    "orderStatusRewardValue": "invoiced",
-                                    "maxNumberOfAffectedItems": 0,
-                                    "maxNumberOfAffectedItemsGroupKey": "perCart",
-                                    "applyToAllShippings": false,
-                                    "nominalTax": 0.0,
-                                    "origin": "marketplace",
-                                    "idSellerIsInclusive": false,
-                                    "idsSalesChannel": [],
-                                    "areSalesChannelIdsExclusive": false,
-                                    "marketingTags": [],
-                                    "marketingTagsAreNotInclusive": false,
-                                    "paymentsMethods": [
-                                        {
-                                            "id": "202",
-                                            "name": "Dinheiro (202)"
-                                        },
-                                        {
-                                            "id": "2",
-                                            "name": "Visa (2)"
-                                        }
-                                    ],
-                                    "stores": [],
-                                    "campaigns": [],
-                                    "conditionsIds": [
-                                        "372e1868-2c0e-4437-be45-1ef8c9cab735"
-                                    ],
-                                    "storesAreInclusive": false,
-                                    "categories": [],
-                                    "categoriesAreInclusive": false,
-                                    "brands": [],
-                                    "brandsAreInclusive": false,
-                                    "products": [],
-                                    "productsAreInclusive": false,
-                                    "skus": [],
-                                    "skusAreInclusive": true,
-                                    "utmSource": "georgeSource",
-                                    "utmCampaign": "georgeTest",
-                                    "collections1BuyTogether": [],
-                                    "collections2BuyTogether": [],
-                                    "minimumQuantityBuyTogether": 0,
-                                    "quantityToAffectBuyTogether": 0,
-                                    "enableBuyTogetherPerSku": false,
-                                    "listSku1BuyTogether": [
-                                        {
-                                            "id": "2",
-                                            "name": "gustaBT"
-                                        },
-                                        {
-                                            "id": "5",
-                                            "name": "exampleSKU"
-                                        }
-                                    ],
-                                    "listSku2BuyTogether": [
-                                        {
-                                            "id": "3",
-                                            "name": "anotherSKU"
-                                        },
-                                        {
-                                            "id": "6",
-                                            "name": "exampleProduct"
-                                        }
-                                    ],
-                                    "coupon": [],
-                                    "totalValueFloor": 0,
-                                    "totalValueCeling": 0,
-                                    "totalValueIncludeAllItems": false,
-                                    "totalValueMode": "IncludeMatchedItems",
-                                    "collections": [],
-                                    "collectionsIsInclusive": false,
-                                    "restrictionsBins": [],
-                                    "cardIssuers": [],
-                                    "totalValuePurchase": 0,
-                                    "slasIds": [],
-                                    "isSlaSelected": false,
-                                    "isFirstBuy": false,
-                                    "firstBuyIsProfileOptimistic": false,
-                                    "compareListPriceAndPrice": false,
-                                    "isDifferentListPriceAndPrice": false,
-                                    "zipCodeRanges": [
-                                        {
-                                            "zipCodeFrom": "20000-000",
-                                            "zipCodeTo": "20000-100",
-                                            "inclusive": true
-                                        }
-                                    ],
-                                    "countries": [
-                                        "BRA"
-                                    ],
-                                    "itemMaxPrice": 0.0,
-                                    "itemMinPrice": 0.0,
-                                    "installment": 0,
-                                    "isMinMaxInstallments": false,
-                                    "minInstallment": 0,
-                                    "maxInstallment": 0,
-                                    "merchants": [],
-                                    "clusterExpressions": [],
-                                    "paymentsRules": [],
-                                    "giftListTypes": [],
-                                    "productsSpecifications": [],
-                                    "affiliates": [],
-                                    "maxUsage": 0,
-                                    "maxUsagePerClient": 0,
-                                    "shouldDistributeDiscountAmongMatchedItems": false,
-                                    "multipleUsePerClient": false,
-                                    "accumulateWithManualPrice": false,
-                                    "type": "regular",
-                                    "useNewProgressiveAlgorithm": false,
-                                    "percentualDiscountValueList": []
-                                },
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "idCalculatorConfiguration": {
-                                            "type": "string",
-                                            "description": "Promotion ID."
-                                        },
-                                        "name": {
-                                            "type": "string",
-                                            "description": "Promotion Name."
-                                        },
-                                        "description": {
-                                            "type": "string",
-                                            "description": "Promotion internal description."
-                                        },
-                                        "beginDateUtc": {
-                                            "type": "string",
-                                            "description": "Promotion Begin Date (UTC)."
-                                        },
-                                        "endDateUtc": {
-                                            "type": "string",
-                                            "description": "Promotion End Date (UTC)."
-                                        },
-                                        "lastModified": {
-                                            "type": "string",
-                                            "description": "When the Promotion was last modified."
-                                        },
-                                        "daysAgoOfPurchases": {
-                                            "type": "integer",
-                                            "description": "Number of days that are considered to add the purchase history."
-                                        },
-                                        "isActive": {
-                                            "type": "boolean",
-                                            "description": "If set as `true` the Promotion is activated. If set as `false` the Promotion is deactivated."
-                                        },
-                                        "isArchived": {
-                                            "type": "boolean",
-                                            "description": "If set as `true` the Promotion is archived. If set as `false` the Promotion is not archived."
-                                        },
-                                        "isFeatured": {
-                                            "type": "boolean",
-                                            "description": "Insert a flag with the promotion name used in the product's window display and page."
-                                        },
-                                        "disableDeal": {
-                                            "type": "boolean",
-                                            "deprecated": true,
-                                            "description": "Indicates whether a deal is disabled (`true`) or not (`false`)."
-                                        },
-                                        "activeDaysOfWeek": {
-                                            "type": "array",
-                                            "description": "Defines which days of the week the promotion will applied.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Day of the week that the promotion will be valid."
-                                            }
-                                        },
-                                        "offset": {
-                                            "type": "integer",
-                                            "description": "Time offset from UTC in seconds."
-                                        },
-                                        "activateGiftsMultiplier": {
-                                            "type": "boolean",
-                                            "description": "If set as `true`, it activates gifts Multiplier."
-                                        },
-                                        "newOffset": {
-                                            "type": "number",
-                                            "description": "New time offset from UTC in seconds."
-                                        },
-                                        "maxPricesPerItems": {
-                                            "type": "array",
-                                            "deprecated": true,
-                                            "description": "List of max price per items.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Max price."
-                                            }
-                                        },
-                                        "cumulative": {
-                                            "type": "boolean",
-                                            "description": "Defines if a promotion can accumulate with another one. (`true`) or not (`false`)."
-                                        },
-                                        "discountType": {
-                                            "type": "string",
-                                            "description": "The type of discount that will apply to the promotion."
-                                        },
-                                        "nominalShippingDiscountValue": {
-                                            "type": "number",
-                                            "description": "Exact discount to be applied for the shipping value."
-                                        },
-                                        "absoluteShippingDiscountValue": {
-                                            "type": "number",
-                                            "description": "Maximum value for the shipping."
-                                        },
-                                        "nominalDiscountValue": {
-                                            "type": "number",
-                                            "description": "Exact discount to be applied for the total purchase value."
-                                        },
-                                        "nominalDiscountType": {
-                                            "type": "string",
-                                            "description": "Controls the behavior of the `NominalDiscount` effect. This field only accepts two string values:\n\n -`item`: applies the intended nominal discount on every item present on the cart. \n\n -`cart`: keeps the behavior as it currently is: the whole order/cart receives a nominal discount that is distributed among the items."
-                                        },
-                                        "maximumUnitPriceDiscount": {
-                                            "type": "number",
-                                            "description": "The maximum price for each item of the purchase will be the price set up."
-                                        },
-                                        "percentualDiscountValue": {
-                                            "type": "number",
-                                            "description": "Percentage discount to be applied for total purchase value."
-                                        },
-                                        "rebatePercentualDiscountValue": {
-                                            "type": "number",
-                                            "description": "Percentual Shipping Discount Value."
-                                        },
-                                        "percentualShippingDiscountValue": {
-                                            "type": "number",
-                                            "description": "Percentage discount to be applied for shipping value."
-                                        },
-                                        "percentualTax": {
-                                            "type": "number",
-                                            "description": "Percentual tax over purchase total value."
-                                        },
-                                        "shippingPercentualTax": {
-                                            "type": "number",
-                                            "description": "Shipping Percentual tax over purchase total value."
-                                        },
-                                        "percentualDiscountValueList1": {
-                                            "type": "number",
-                                            "description": "Valid discounts for the SKUs in `listSku1BuyTogether`, discount list used for Buy Together Promotions."
-                                        },
-                                        "percentualDiscountValueList2": {
-                                            "type": "number",
-                                            "description": "Equivalent to `percentualDiscountValueList1`."
-                                        },
-                                        "skusGift": {
-                                            "type": "object",
-                                            "description": "SKU Gift Object. Total discount on the product value set as a gift.",
-                                            "properties": {
-                                                "quantitySelectable": {
-                                                    "type": "integer",
-                                                    "description": "Quantity of SKU Gifts."
-                                                },
-                                                "gifts": {
-                                                    "type": "integer",
-                                                    "description": "Array with SKU Gifts IDs."
-                                                }
-                                            }
-                                        },
-                                        "nominalRewardValue": {
-                                            "type": "number",
-                                            "description": "Nominal value for rewards program."
-                                        },
-                                        "percentualRewardValue": {
-                                            "type": "number",
-                                            "description": "Percentage value for rewards program."
-                                        },
-                                        "orderStatusRewardValue": {
-                                            "type": "string",
-                                            "description": "Order status reward value."
-                                        },
-                                        "maxNumberOfAffectedItems": {
-                                            "type": "integer",
-                                            "description": "The maximum number of affected items for a promotion."
-                                        },
-                                        "maxNumberOfAffectedItemsGroupKey": {
-                                            "type": "string",
-                                            "description": "The maximum number of affected items by group key for a promotion."
-                                        },
-                                        "applyToAllShippings": {
-                                            "type": "boolean",
-                                            "description": "Promotion will be applied to all kind of shipping."
-                                        },
-                                        "nominalTax": {
-                                            "type": "number",
-                                            "description": "Nominal tax."
-                                        },
-                                        "origin": {
-                                            "type": "string",
-                                            "description": "Origin of the promotion, `marketplace` or `Fulfillment`. Read [Difference between orders with marketplace and fulfillment sources](https://help.vtex.com/en/tutorial/what-are-orders-with-marketplace-source-and-orders-with-fulfillment-source--6eVYrmUAwMOeKICU2KuG06) for more information."
-                                        },
-                                        "idSeller": {
-                                            "type": "string",
-                                            "description": "Seller Name."
-                                        },
-                                        "idSellerIsInclusive": {
-                                            "type": "boolean",
-                                            "description": "If set to `true`, this promotion will be applied to any seller present on the idSeller field. If set to `false`, sellers present on that field will make this promotion not to be applied."
-                                        },
-                                        "idsSalesChannel": {
-                                            "type": "array",
-                                            "description": "List of Trade Policies that activate this promotion.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Trade policy ID."
-                                            }
-                                        },
-                                        "areSalesChannelIdsExclusive": {
-                                            "type": "boolean",
-                                            "description": "If set to `false`, this promotion will be applied to any trade policies present on the `idsSalesChannel` field. If set to `true`, trade policies present on that field will make this promotion not to be applied."
-                                        },
-                                        "marketingTags": {
-                                            "type": "array",
-                                            "description": "Promotion Marketing tags.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Promotion Marketing tag."
-                                            }
-                                        },
-                                        "marketingTagsAreNotInclusive": {
-                                            "type": "boolean",
-                                            "description": "If set to `false`, this promotion will be applied to any marketing tag present on the `marketingTags` field. If set to `true`, marketing tags present on that field will make this promotion not to be applied."
-                                        },
-                                        "paymentsMethods": {
-                                            "type": "array",
-                                            "description": "Array composed by all the Payments Methods.",
-                                            "items": {
-                                                "type": "object",
-                                                "description": "Object with information of the Payment Method.",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string",
-                                                        "description": "Payment Method ID."
-                                                    },
-                                                    "name": {
-                                                        "type": "string",
-                                                        "description": "Payment Method Name."
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "stores": {
-                                            "type": "array",
-                                            "deprecated": true,
-                                            "description": "List of stores.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Store."
-                                            }
-                                        },
-                                        "campaigns": {
-                                            "type": "array",
-                                            "description": "Campaign Audiences that activate this promotion.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Campaign audience."
-                                            }
-                                        },
-                                        "conditionsIds": {
-                                            "type": "array",
-                                            "description": "Array with conditions IDs.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Condition ID."
-                                            }
-                                        },
-                                        "storesAreInclusive": {
-                                            "type": "boolean",
-                                            "deprecated": true,
-                                            "description": "If set to `true`, this promotion will be applied to any store present on the `stores` field. If set to `false`, stores present on that field will make this promotion not to be applied."
-                                        },
-                                        "categories": {
-                                            "type": "array",
-                                            "description": "Object composed by the categories that will activate or deactivate the promotion.",
-                                            "items": {
-                                                "type": "object",
-                                                "description": "Object with information of the category.",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string",
-                                                        "description": "Category ID."
-                                                    },
-                                                    "name": {
-                                                        "type": "string",
-                                                        "description": "Category Name."
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "categoriesAreInclusive": {
-                                            "type": "boolean",
-                                            "description": "If set to `true`, this promotion will be applied to any category present on the `categories` field. If set to `false`, categories present on that field will make this promotion not to be applied."
-                                        },
-                                        "brands": {
-                                            "type": "array",
-                                            "description": "Object composed by the brands that will activate or deactivate the promotion.",
-                                            "items": {
-                                                "type": "object",
-                                                "description": "Object with information of the brand.",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string",
-                                                        "description": "Brand ID."
-                                                    },
-                                                    "name": {
-                                                        "type": "string",
-                                                        "description": "Brand Name."
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "brandsAreInclusive": {
-                                            "type": "boolean",
-                                            "description": "If set to `true`, this promotion will be applied to any brand present on the `brands` field. If set to `false`, brands present on that field will make this promotion not to be applied."
-                                        },
-                                        "products": {
-                                            "type": "array",
-                                            "description": "Object composed by the products that will activate or deactivate the promotion.",
-                                            "items": {
-                                                "type": "object",
-                                                "description": "Object with information of the product.",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string",
-                                                        "description": "Product ID."
-                                                    },
-                                                    "name": {
-                                                        "type": "string",
-                                                        "description": "Product Name."
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "productsAreInclusive": {
-                                            "type": "boolean",
-                                            "description": "If set to `true`, this promotion will be applied to any product present on the `products` field. If set to `false`, products present on that field will make this promotion not to be applied."
-                                        },
-                                        "skus": {
-                                            "type": "array",
-                                            "description": "Object composed by the SKUs that will activate or deactivate the promotion.",
-                                            "items": {
-                                                "type": "object",
-                                                "required": [
-                                                    "id",
-                                                    "name"
-                                                ],
-                                                "description": "Object with information of the SKU.",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string",
-                                                        "description": "SKU ID.",
-                                                        "nullable": false
-                                                    },
-                                                    "name": {
-                                                        "type": "string",
-                                                        "description": "SKU Name.",
-                                                        "nullable": false
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "skusAreInclusive": {
-                                            "type": "boolean",
-                                            "description": "If set to `true`, this promotion will be applied to any SKU present on the `skus` field. If set to `false`, SKUs present on that field will make this promotion not to be applied."
-                                        },
-                                        "utmSource": {
-                                            "type": "string",
-                                            "description": "Coupon utmSource code."
-                                        },
-                                        "utmCampaign": {
-                                            "type": "string",
-                                            "description": "Coupon utmCampaign code."
-                                        },
-                                        "collections1BuyTogether": {
-                                            "type": "array",
-                                            "description": "Collections that will generate the promotion, type **Buy Together**, **More for less**, **Progressive Discount**, **Buy One Get One**.",
-                                            "items": {
-                                                "type": "object",
-                                                "description": "Object containing the ID and Name of the collection to be added to the first list of the **Buy Together** promotion.",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string",
-                                                        "description": "ID of the collection to be added to the first list of the **Buy Together** promotion."
-                                                    },
-                                                    "name": {
-                                                        "type": "string",
-                                                        "description": "Name of the collection to be added to the first list of the **Buy Together** promotion."
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "collections2BuyTogether": {
-                                            "type": "array",
-                                            "deprecated": true,
-                                            "description": "Collections that will generate the promotion, type **Buy Together**, **More for less**, **Progressive Discount** or **Buy One Get One**.",
-                                            "items": {
-                                                "type": "object",
-                                                "description": "Object containing the ID and Name of the collection to be added to the first list of the **Buy Together** promotion.",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string",
-                                                        "description": "ID of the collection to be added to the first list of the **Buy Together** promotion."
-                                                    },
-                                                    "name": {
-                                                        "type": "string",
-                                                        "description": "Name of the collection to be added to the first list of the **Buy Together** promotion."
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "minimumQuantityBuyTogether": {
-                                            "type": "integer",
-                                            "description": "Minimum quantity for **Buy Together** promotion."
-                                        },
-                                        "quantityToAffectBuyTogether": {
-                                            "type": "integer",
-                                            "description": "Quantity to affect **Buy Together** promotion."
-                                        },
-                                        "enableBuyTogetherPerSku": {
-                                            "type": "boolean",
-                                            "description": "Enable **Buy Together** per SKU."
-                                        },
-                                        "listSku1BuyTogether": {
-                                            "type": "array",
-                                            "description": "Array of objects, each containing ID and Name of an SKU to be added in the first list of the **Buy Together** promotion. Learn more about this type of promotion in the [Creating a Buy Together promotion](https://help.vtex.com/en/tutorial/buy-together--tutorials_323) documentation.",
-                                            "items": {
-                                                "type": "object",
-                                                "description": "Object containing the ID and Name of the SKU to be added to the first list of the **Buy Together** promotion. Learn more about this type of promotion in the [Creating a Buy Together promotion](https://help.vtex.com/en/tutorial/buy-together--tutorials_323) documentation.",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string",
-                                                        "description": "ID of the SKU to be added to the first list of the **Buy Together** promotion."
-                                                    },
-                                                    "name": {
-                                                        "type": "string",
-                                                        "description": "Name of the SKU to be added to the first list of the **Buy Together** promotion."
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "listSku2BuyTogether": {
-                                            "type": "array",
-                                            "description": "Array of objects, each containing ID and Name of an SKU to be added to the second list of the **Buy Together** promotion. Learn more about this type of promotion in the [Creating a Buy Together promotion](https://help.vtex.com/en/tutorial/buy-together--tutorials_323) documentation.",
-                                            "items": {
-                                                "type": "object",
-                                                "description": "Object containing the ID and Name of the SKU to be added to the second list of the **Buy Together** promotion. Learn more about this type of promotion in the [Creating a Buy Together promotion](https://help.vtex.com/en/tutorial/buy-together--tutorials_323) documentation.",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string",
-                                                        "description": "ID of the SKU to be added to the second list of the **Buy Together** promotion."
-                                                    },
-                                                    "name": {
-                                                        "type": "string",
-                                                        "description": "Name of the SKU to be added to the second list of the **Buy Together** promotion."
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "coupon": {
-                                            "type": "array",
-                                            "deprecated": true,
-                                            "description": "List of coupons.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Coupon code."
-                                            }
-                                        },
-                                        "totalValueFloor": {
-                                            "type": "number",
-                                            "description": "Minimum chart value to activate the promotion."
-                                        },
-                                        "totalValueCeling": {
-                                            "type": "number",
-                                            "description": "Maximum chart value to activate the promotion."
-                                        },
-                                        "totalValueIncludeAllItems": {
-                                            "type": "boolean",
-                                            "deprecated": true,
-                                            "description": "Total value including all items."
-                                        },
-                                        "totalValueMode": {
-                                            "type": "string",
-                                            "description": "If products that already are receiving a promotion, will be considered on the chart total value. There are three options available: `IncludeMatchedItems`, `ExcludeMatchedItems`, `AllItems`."
-                                        },
-                                        "collections": {
-                                            "type": "array",
-                                            "description": "Array composed by the collections that will be activated or deactivated the promotion.",
-                                            "items": {
-                                                "type": "object",
-                                                "description": "Object with information of the collection.",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string",
-                                                        "description": "Collection ID."
-                                                    },
-                                                    "name": {
-                                                        "type": "string",
-                                                        "description": "Collection Name."
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "collectionsIsInclusive": {
-                                            "type": "boolean",
-                                            "description": "If set to `true`, this promotion will be applied to any collection present on the `collections` field. If set to `false`, collections present on that field will make this promotion not to be applied."
-                                        },
-                                        "restrictionsBins": {
-                                            "type": "array",
-                                            "description": "The discount will be granted if the card's BIN is given.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Card's BIN."
-                                            }
-                                        },
-                                        "cardIssuers": {
-                                            "type": "array",
-                                            "deprecated": true,
-                                            "description": "List of card issuers.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Card issuer."
-                                            }
-                                        },
-                                        "totalValuePurchase": {
-                                            "type": "number",
-                                            "description": "Total value a client must have in past orders to active the promotion."
-                                        },
-                                        "slasIds": {
-                                            "type": "array",
-                                            "description": "The discount will be granted if the shipping method is the same as the one given.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Shipping method."
-                                            }
-                                        },
-                                        "isSlaSelected": {
-                                            "type": "boolean",
-                                            "description": "Applies selected discount only when one of the defined shipping method is selected by the customer."
-                                        },
-                                        "isFirstBuy": {
-                                            "type": "boolean",
-                                            "description": "Applies the discount only if it's a first buy."
-                                        },
-                                        "firstBuyIsProfileOptimistic": {
-                                            "type": "boolean",
-                                            "description": "Applies the discount even if the user is not logged."
-                                        },
-                                        "compareListPriceAndPrice": {
-                                            "type": "boolean",
-                                            "description": "If the **List Price** and **Price** are the same."
-                                        },
-                                        "isDifferentListPriceAndPrice": {
-                                            "type": "boolean",
-                                            "description": "Applies the promotion only if the list price and price is different."
-                                        },
-                                        "zipCodeRanges": {
-                                            "type": "array",
-                                            "description": "Range of the zip code that applies the promotion.",
-                                            "items": {
-                                                "type": "object",
-                                                "description": "Object with information of the Zip Code.",
-                                                "properties": {
-                                                    "zipCodeFrom": {
-                                                        "type": "string",
-                                                        "description": "Initial Zip Code."
-                                                    },
-                                                    "zipCodeTo": {
-                                                        "type": "string",
-                                                        "description": "Final Zip Code."
-                                                    },
-                                                    "inclusive": {
-                                                        "type": "boolean",
-                                                        "description": "Defines if the zip code range is included in the promotion."
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "countries": {
-                                            "type": "array",
-                                            "description": "List of countries that are activated for this promotion.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Three-digit country code."
-                                            }
-                                        },
-                                        "itemMaxPrice": {
-                                            "type": "number",
-                                            "description": "Maximum price of the item."
-                                        },
-                                        "itemMinPrice": {
-                                            "type": "number",
-                                            "description": "Minimum price of the item."
-                                        },
-                                        "installment": {
-                                            "type": "integer",
-                                            "deprecated": true,
-                                            "description": "Installment."
-                                        },
-                                        "isMinMaxInstallments": {
-                                            "type": "boolean",
-                                            "description": "Set if the promotion will be applied considering a minimum and maximum values for installments."
-                                        },
-                                        "minInstallment": {
-                                            "type": "integer",
-                                            "description": "Minimum value for installment."
-                                        },
-                                        "maxInstallment": {
-                                            "type": "integer",
-                                            "description": "Maximum value for installment."
-                                        },
-                                        "merchants": {
-                                            "type": "array",
-                                            "deprecated": true,
-                                            "description": "List of merchants.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Merchant."
-                                            }
-                                        },
-                                        "clusterExpressions": {
-                                            "type": "array",
-                                            "description": "Criteria to select a customer cluster. Each item in this array should follow the format of an equality function (`{propertyname}={value}`) or the format of a contains function (`{propertyname} contains {value}`). In both options, `{propertyname}` must be replaced with the name of the field in the data entity, and `{value}` must be replaced with the value determined in Master Data. Find more information about these criteria in [Filling in the Customer cluster field](https://help.vtex.com/tutorial/creating-promotion-for-a-customer-cluster--tutorials_342#filling-in-the-customer-cluster-field).",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Cluster expression."
-                                            }
-                                        },
-                                        "multipleSkusCause": {
-                                            "type": "object",
-                                            "description": "Object composed by a list of SKUs on a Multiple Effects promotion. Structure: `\"{SkuId}\": {PercentageDiscount}`. There is a limit of 400 SKUs for this type of promotion.",
-                                            "additionalProperties": {
-                                                "type": "string",
-                                                "description": "SKU ID."
-                                            }
-                                        },
-                                        "paymentsRules": {
-                                            "type": "array",
-                                            "deprecated": true,
-                                            "description": "List of payment rules.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Payment rule."
-                                            }
-                                        },
-                                        "giftListTypes": {
-                                            "type": "array",
-                                            "description": "Gifts List Type.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Gift List Type."
-                                            }
-                                        },
-                                        "productsSpecifications": {
-                                            "type": "array",
-                                            "deprecated": true,
-                                            "description": "List of product specifications.",
-                                            "items": {
-                                                "type": "string",
-                                                "description": "Product specification."
-                                            }
-                                        },
-                                        "affiliates": {
-                                            "type": "array",
-                                            "description": "Marketplace order identifier. The discount will apply to selected affiliates.",
-                                            "items": {
-                                                "type": "object",
-                                                "description": "Object with information of the affiliate.",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string",
-                                                        "description": "Affiliate ID."
-                                                    },
-                                                    "name": {
-                                                        "type": "string",
-                                                        "description": "Affiliate Name."
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "maxUsage": {
-                                            "type": "integer",
-                                            "description": "Defines how many times the promotion can be used."
-                                        },
-                                        "maxUsagePerClient": {
-                                            "type": "integer",
-                                            "description": "Defines if the promotion can be used multiple times per client."
-                                        },
-                                        "shouldDistributeDiscountAmongMatchedItems": {
-                                            "type": "boolean",
-                                            "description": "Should distribute discount among matched items."
-                                        },
-                                        "multipleUsePerClient": {
-                                            "type": "boolean",
-                                            "description": "Defines if the promotion can be used multiple times per client."
-                                        },
-                                        "accumulateWithManualPrice": {
-                                            "type": "boolean",
-                                            "description": "Allows the promotion to apply to products whose prices have been manually added by a call center operator."
-                                        },
-                                        "type": {
-                                            "type": "string",
-                                            "description": "Defines what is the type of the promotion or indicates if it is a tax. Possible values: `regular` ([Regular Promotion](https://help.vtex.com/tutorial/regular-promotion--tutorials_327)), `combo` ([Buy Together](https://help.vtex.com/en/tutorial/buy-together--tutorials_323)), `forThePriceOf` ([More for Less](https://help.vtex.com/en/tutorial/creating-a-more-for-less-promotion--tutorials_325)), `progressive` ([Progressive Discount](https://help.vtex.com/en/tutorial/progressive-discount--tutorials_324)), `buyAndWin` ([Buy One Get One](https://help.vtex.com/en/tutorial/buy-one-get-one--tutorials_322)), `maxPricePerItem` (Deprecated), `campaign` ([Campaign Promotion](https://help.vtex.com/en/tutorial/campaign-promotion--1ChYXhK2AQGuS6wAqS8Ume)), `tax` (Tax), `multipleEffects` (Multiple Effects)."
-                                        },
-                                        "useNewProgressiveAlgorithm": {
-                                            "type": "boolean",
-                                            "description": "Use new progressive algorithm."
-                                        },
-                                        "percentualDiscountValueList": {
-                                            "type": "array",
-                                            "description": "Percentual discount value list.",
-                                            "items": {
-                                                "type": "number",
-                                                "description": "Percentual discount value."
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
+      "get": {
+        "tags": [
+          "Promotions and taxes"
+        ],
+        "summary": "Get promotion or tax by ID",
+        "description": "Retrieves a specific promotion by its Promotion ID or a specific tax by its tax ID.\r\n\r\n## Permissions\r\n\r\nAny user or [application key](https://developers.vtex.com/docs/guides/api-authentication-using-application-keys) must have at least one of the appropriate [License Manager resources](https://help.vtex.com/en/tutorial/license-manager-resources--3q6ztrC8YynQf6rdc6euk3) to be able to successfully run this request. Otherwise they will receive a status code `403` error. These are the applicable resources for this endpoint:\r\n\r\n| **Product** | **Category** | **Resource** |\r\n| --------------- | ----------------- | ----------------- |\r\n| Rates and Benefits | Manage benefits and rates | **GerenciarPromocoesETarifas** |\r\n\r\nThere are no applicable [predefined roles](https://help.vtex.com/en/tutorial/predefined-roles--jGDurZKJHvHJS13LnO7Dy) for this resource list. You must [create a custom role](https://help.vtex.com/en/tutorial/roles--7HKK5Uau2H6wxE1rH5oRbc#creating-a-role) and add at least one of the resources above in order to use this endpoint. To learn more about machine authentication at VTEX, see [Authentication overview](https://developers.vtex.com/docs/guides/authentication).\r\n\r\n>\u2757 To prevent integrations from having excessive permissions, consider the [best practices for managing app keys](https://help.vtex.com/en/tutorial/best-practices-application-keys--7b6nD1VMHa49aI5brlOvJm) when assigning License Manager roles to integrations.",
+        "operationId": "GetCalculatorConfigurationById",
+        "parameters": [
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "description": "Type of the content being sent.",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
             }
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "HTTP Client Negotiation Accept Header. Indicates the types of responses the client can understand.",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            }
+          },
+          {
+            "name": "idCalculatorConfiguration",
+            "in": "path",
+            "description": "Promotion ID or tax ID.",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string",
+              "example": "d8a1cd2e-b667-4054-b3ae-b79124c7218e"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "example": {
+                  "idCalculatorConfiguration": "d8a1cd2e-b667-4054-b3ae-b79124c7218e",
+                  "name": "Social Seller Promotion",
+                  "beginDateUtc": "2020-05-01T18:47:15.89Z",
+                  "lastModified": "2021-02-23T20:58:38.7963862Z",
+                  "daysAgoOfPurchases": 0,
+                  "isActive": true,
+                  "isArchived": false,
+                  "isFeatured": false,
+                  "disableDeal": false,
+                  "activeDaysOfWeek": [],
+                  "offset": -3,
+                  "activateGiftsMultiplier": false,
+                  "newOffset": -3.0,
+                  "maxPricesPerItems": [],
+                  "cumulative": false,
+                  "discountType": "percentual",
+                  "nominalShippingDiscountValue": 0.0,
+                  "absoluteShippingDiscountValue": 0.0,
+                  "nominalDiscountValue": 0.0,
+                  "nominalDiscountType": "item",
+                  "maximumUnitPriceDiscount": 0.0,
+                  "percentualDiscountValue": 10.0,
+                  "rebatePercentualDiscountValue": 0.0,
+                  "percentualShippingDiscountValue": 0.0,
+                  "percentualTax": 0.0,
+                  "shippingPercentualTax": 0.0,
+                  "percentualDiscountValueList1": 0.0,
+                  "percentualDiscountValueList2": 0.0,
+                  "skusGift": {
+                    "quantitySelectable": 0
+                  },
+                  "nominalRewardValue": 0.0,
+                  "percentualRewardValue": 0.0,
+                  "orderStatusRewardValue": "invoiced",
+                  "maxNumberOfAffectedItems": 0,
+                  "maxNumberOfAffectedItemsGroupKey": "perCart",
+                  "applyToAllShippings": false,
+                  "nominalTax": 0.0,
+                  "origin": "marketplace",
+                  "idSellerIsInclusive": false,
+                  "idsSalesChannel": [],
+                  "areSalesChannelIdsExclusive": false,
+                  "marketingTags": [],
+                  "marketingTagsAreNotInclusive": false,
+                  "paymentsMethods": [
+                    {
+                      "id": "202",
+                      "name": "Dinheiro (202)"
+                    },
+                    {
+                      "id": "2",
+                      "name": "Visa (2)"
+                    }
+                  ],
+                  "stores": [],
+                  "campaigns": [],
+                  "conditionsIds": [
+                    "372e1868-2c0e-4437-be45-1ef8c9cab735"
+                  ],
+                  "storesAreInclusive": false,
+                  "categories": [],
+                  "categoriesAreInclusive": false,
+                  "brands": [],
+                  "brandsAreInclusive": false,
+                  "products": [],
+                  "productsAreInclusive": false,
+                  "skus": [],
+                  "skusAreInclusive": true,
+                  "utmSource": "georgeSource",
+                  "utmCampaign": "georgeTest",
+                  "collections1BuyTogether": [],
+                  "collections2BuyTogether": [],
+                  "minimumQuantityBuyTogether": 0,
+                  "quantityToAffectBuyTogether": 0,
+                  "enableBuyTogetherPerSku": false,
+                  "listSku1BuyTogether": [
+                    {
+                      "id": "2",
+                      "name": "gustaBT"
+                    },
+                    {
+                      "id": "5",
+                      "name": "exampleSKU"
+                    }
+                  ],
+                  "listSku2BuyTogether": [
+                    {
+                      "id": "3",
+                      "name": "anotherSKU"
+                    },
+                    {
+                      "id": "6",
+                      "name": "exampleProduct"
+                    }
+                  ],
+                  "coupon": [],
+                  "totalValueFloor": 0,
+                  "totalValueCeling": 0,
+                  "totalValueIncludeAllItems": false,
+                  "totalValueMode": "IncludeMatchedItems",
+                  "collections": [],
+                  "collectionsIsInclusive": false,
+                  "restrictionsBins": [],
+                  "cardIssuers": [],
+                  "totalValuePurchase": 0,
+                  "slasIds": [],
+                  "isSlaSelected": false,
+                  "isFirstBuy": false,
+                  "firstBuyIsProfileOptimistic": false,
+                  "compareListPriceAndPrice": false,
+                  "isDifferentListPriceAndPrice": false,
+                  "zipCodeRanges": [
+                    {
+                      "zipCodeFrom": "20000-000",
+                      "zipCodeTo": "20000-100",
+                      "inclusive": true
+                    }
+                  ],
+                  "countries": [
+                    "BRA"
+                  ],
+                  "itemMaxPrice": 0.0,
+                  "itemMinPrice": 0.0,
+                  "installment": 0,
+                  "isMinMaxInstallments": false,
+                  "minInstallment": 0,
+                  "maxInstallment": 0,
+                  "merchants": [],
+                  "clusterExpressions": [],
+                  "paymentsRules": [],
+                  "giftListTypes": [],
+                  "productsSpecifications": [],
+                  "affiliates": [],
+                  "maxUsage": 0,
+                  "maxUsagePerClient": 0,
+                  "shouldDistributeDiscountAmongMatchedItems": false,
+                  "multipleUsePerClient": false,
+                  "accumulateWithManualPrice": false,
+                  "type": "regular",
+                  "useNewProgressiveAlgorithm": false,
+                  "percentualDiscountValueList": []
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "idCalculatorConfiguration": {
+                      "type": "string",
+                      "description": "Promotion ID."
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Promotion Name."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Promotion internal description."
+                    },
+                    "beginDateUtc": {
+                      "type": "string",
+                      "description": "Promotion Begin Date (UTC)."
+                    },
+                    "endDateUtc": {
+                      "type": "string",
+                      "description": "Promotion End Date (UTC)."
+                    },
+                    "lastModified": {
+                      "type": "string",
+                      "description": "When the Promotion was last modified."
+                    },
+                    "daysAgoOfPurchases": {
+                      "type": "integer",
+                      "description": "Number of days that are considered to add the purchase history."
+                    },
+                    "isActive": {
+                      "type": "boolean",
+                      "description": "If set as `true` the Promotion is activated. If set as `false` the Promotion is deactivated."
+                    },
+                    "isArchived": {
+                      "type": "boolean",
+                      "description": "If set as `true` the Promotion is archived. If set as `false` the Promotion is not archived."
+                    },
+                    "isFeatured": {
+                      "type": "boolean",
+                      "description": "Insert a flag with the promotion name used in the product's window display and page."
+                    },
+                    "disableDeal": {
+                      "type": "boolean",
+                      "deprecated": true,
+                      "description": "Indicates whether a deal is disabled (`true`) or not (`false`)."
+                    },
+                    "activeDaysOfWeek": {
+                      "type": "array",
+                      "description": "Defines which days of the week the promotion will applied.",
+                      "items": {
+                        "type": "string",
+                        "description": "Day of the week that the promotion will be valid."
+                      }
+                    },
+                    "offset": {
+                      "type": "integer",
+                      "description": "Time offset from UTC in seconds."
+                    },
+                    "activateGiftsMultiplier": {
+                      "type": "boolean",
+                      "description": "If set as `true`, it activates gifts Multiplier."
+                    },
+                    "newOffset": {
+                      "type": "number",
+                      "description": "New time offset from UTC in seconds."
+                    },
+                    "maxPricesPerItems": {
+                      "type": "array",
+                      "deprecated": true,
+                      "description": "List of max price per items.",
+                      "items": {
+                        "type": "string",
+                        "description": "Max price."
+                      }
+                    },
+                    "cumulative": {
+                      "type": "boolean",
+                      "description": "Defines if a promotion can accumulate with another one. (`true`) or not (`false`)."
+                    },
+                    "discountType": {
+                      "type": "string",
+                      "description": "The type of discount that will apply to the promotion."
+                    },
+                    "nominalShippingDiscountValue": {
+                      "type": "number",
+                      "description": "Exact discount to be applied for the shipping value."
+                    },
+                    "absoluteShippingDiscountValue": {
+                      "type": "number",
+                      "description": "Maximum value for the shipping."
+                    },
+                    "nominalDiscountValue": {
+                      "type": "number",
+                      "description": "Exact discount to be applied for the total purchase value."
+                    },
+                    "nominalDiscountType": {
+                      "type": "string",
+                      "description": "Controls the behavior of the `NominalDiscount` effect. This field only accepts two string values:\n\n -`item`: applies the intended nominal discount on every item present on the cart. \n\n -`cart`: keeps the behavior as it currently is: the whole order/cart receives a nominal discount that is distributed among the items."
+                    },
+                    "maximumUnitPriceDiscount": {
+                      "type": "number",
+                      "description": "The maximum price for each item of the purchase will be the price set up."
+                    },
+                    "percentualDiscountValue": {
+                      "type": "number",
+                      "description": "Percentage discount to be applied for total purchase value."
+                    },
+                    "rebatePercentualDiscountValue": {
+                      "type": "number",
+                      "description": "Percentual Shipping Discount Value."
+                    },
+                    "percentualShippingDiscountValue": {
+                      "type": "number",
+                      "description": "Percentage discount to be applied for shipping value."
+                    },
+                    "percentualTax": {
+                      "type": "number",
+                      "description": "Percentual tax over purchase total value."
+                    },
+                    "shippingPercentualTax": {
+                      "type": "number",
+                      "description": "Shipping Percentual tax over purchase total value."
+                    },
+                    "percentualDiscountValueList1": {
+                      "type": "number",
+                      "description": "Valid discounts for the SKUs in `listSku1BuyTogether`, discount list used for Buy Together Promotions."
+                    },
+                    "percentualDiscountValueList2": {
+                      "type": "number",
+                      "description": "Equivalent to `percentualDiscountValueList1`."
+                    },
+                    "skusGift": {
+                      "type": "object",
+                      "description": "SKU Gift Object. Total discount on the product value set as a gift.",
+                      "properties": {
+                        "quantitySelectable": {
+                          "type": "integer",
+                          "description": "Quantity of SKU Gifts."
+                        },
+                        "gifts": {
+                          "type": "integer",
+                          "description": "Array with SKU Gifts IDs."
+                        }
+                      }
+                    },
+                    "nominalRewardValue": {
+                      "type": "number",
+                      "description": "Nominal value for rewards program."
+                    },
+                    "percentualRewardValue": {
+                      "type": "number",
+                      "description": "Percentage value for rewards program."
+                    },
+                    "orderStatusRewardValue": {
+                      "type": "string",
+                      "description": "Order status reward value."
+                    },
+                    "maxNumberOfAffectedItems": {
+                      "type": "integer",
+                      "description": "The maximum number of affected items for a promotion."
+                    },
+                    "maxNumberOfAffectedItemsGroupKey": {
+                      "type": "string",
+                      "description": "The maximum number of affected items by group key for a promotion."
+                    },
+                    "applyToAllShippings": {
+                      "type": "boolean",
+                      "description": "Promotion will be applied to all kind of shipping."
+                    },
+                    "nominalTax": {
+                      "type": "number",
+                      "description": "Nominal tax."
+                    },
+                    "origin": {
+                      "type": "string",
+                      "description": "Origin of the promotion, `marketplace` or `Fulfillment`. Read [Difference between orders with marketplace and fulfillment sources](https://help.vtex.com/en/tutorial/what-are-orders-with-marketplace-source-and-orders-with-fulfillment-source--6eVYrmUAwMOeKICU2KuG06) for more information."
+                    },
+                    "idSeller": {
+                      "type": "string",
+                      "description": "Seller Name."
+                    },
+                    "idSellerIsInclusive": {
+                      "type": "boolean",
+                      "description": "If set to `true`, this promotion will be applied to any seller present on the idSeller field. If set to `false`, sellers present on that field will make this promotion not to be applied."
+                    },
+                    "idsSalesChannel": {
+                      "type": "array",
+                      "description": "List of Trade Policies that activate this promotion.",
+                      "items": {
+                        "type": "string",
+                        "description": "Trade policy ID."
+                      }
+                    },
+                    "areSalesChannelIdsExclusive": {
+                      "type": "boolean",
+                      "description": "If set to `false`, this promotion will be applied to any trade policies present on the `idsSalesChannel` field. If set to `true`, trade policies present on that field will make this promotion not to be applied."
+                    },
+                    "marketingTags": {
+                      "type": "array",
+                      "description": "Promotion Marketing tags.",
+                      "items": {
+                        "type": "string",
+                        "description": "Promotion Marketing tag."
+                      }
+                    },
+                    "marketingTagsAreNotInclusive": {
+                      "type": "boolean",
+                      "description": "If set to `false`, this promotion will be applied to any marketing tag present on the `marketingTags` field. If set to `true`, marketing tags present on that field will make this promotion not to be applied."
+                    },
+                    "paymentsMethods": {
+                      "type": "array",
+                      "description": "Array composed by all the Payments Methods.",
+                      "items": {
+                        "type": "object",
+                        "description": "Object with information of the Payment Method.",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Payment Method ID."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Payment Method Name."
+                          }
+                        }
+                      }
+                    },
+                    "stores": {
+                      "type": "array",
+                      "deprecated": true,
+                      "description": "List of stores.",
+                      "items": {
+                        "type": "string",
+                        "description": "Store."
+                      }
+                    },
+                    "campaigns": {
+                      "type": "array",
+                      "description": "Campaign Audiences that activate this promotion.",
+                      "items": {
+                        "type": "string",
+                        "description": "Campaign audience."
+                      }
+                    },
+                    "conditionsIds": {
+                      "type": "array",
+                      "description": "Array with conditions IDs.",
+                      "items": {
+                        "type": "string",
+                        "description": "Condition ID."
+                      }
+                    },
+                    "storesAreInclusive": {
+                      "type": "boolean",
+                      "deprecated": true,
+                      "description": "If set to `true`, this promotion will be applied to any store present on the `stores` field. If set to `false`, stores present on that field will make this promotion not to be applied."
+                    },
+                    "categories": {
+                      "type": "array",
+                      "description": "Object composed by the categories that will activate or deactivate the promotion.",
+                      "items": {
+                        "type": "object",
+                        "description": "Object with information of the category.",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Category ID."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Category Name."
+                          }
+                        }
+                      }
+                    },
+                    "categoriesAreInclusive": {
+                      "type": "boolean",
+                      "description": "If set to `true`, this promotion will be applied to any category present on the `categories` field. If set to `false`, categories present on that field will make this promotion not to be applied."
+                    },
+                    "brands": {
+                      "type": "array",
+                      "description": "Object composed by the brands that will activate or deactivate the promotion.",
+                      "items": {
+                        "type": "object",
+                        "description": "Object with information of the brand.",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Brand ID."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Brand Name."
+                          }
+                        }
+                      }
+                    },
+                    "brandsAreInclusive": {
+                      "type": "boolean",
+                      "description": "If set to `true`, this promotion will be applied to any brand present on the `brands` field. If set to `false`, brands present on that field will make this promotion not to be applied."
+                    },
+                    "products": {
+                      "type": "array",
+                      "description": "Object composed by the products that will activate or deactivate the promotion.",
+                      "items": {
+                        "type": "object",
+                        "description": "Object with information of the product.",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Product ID."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Product Name."
+                          }
+                        }
+                      }
+                    },
+                    "productsAreInclusive": {
+                      "type": "boolean",
+                      "description": "If set to `true`, this promotion will be applied to any product present on the `products` field. If set to `false`, products present on that field will make this promotion not to be applied."
+                    },
+                    "skus": {
+                      "type": "array",
+                      "description": "Object composed by the SKUs that will activate or deactivate the promotion.",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "description": "Object with information of the SKU.",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "SKU ID.",
+                            "nullable": false
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "SKU Name.",
+                            "nullable": false
+                          }
+                        }
+                      }
+                    },
+                    "skusAreInclusive": {
+                      "type": "boolean",
+                      "description": "If set to `true`, this promotion will be applied to any SKU present on the `skus` field. If set to `false`, SKUs present on that field will make this promotion not to be applied."
+                    },
+                    "utmSource": {
+                      "type": "string",
+                      "description": "Coupon utmSource code."
+                    },
+                    "utmCampaign": {
+                      "type": "string",
+                      "description": "Coupon utmCampaign code."
+                    },
+                    "collections1BuyTogether": {
+                      "type": "array",
+                      "description": "Collections that will generate the promotion, type **Buy Together**, **More for less**, **Progressive Discount**, **Buy One Get One**.",
+                      "items": {
+                        "type": "object",
+                        "description": "Object containing the ID and Name of the collection to be added to the first list of the **Buy Together** promotion.",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "ID of the collection to be added to the first list of the **Buy Together** promotion."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Name of the collection to be added to the first list of the **Buy Together** promotion."
+                          }
+                        }
+                      }
+                    },
+                    "collections2BuyTogether": {
+                      "type": "array",
+                      "deprecated": true,
+                      "description": "Collections that will generate the promotion, type **Buy Together**, **More for less**, **Progressive Discount** or **Buy One Get One**.",
+                      "items": {
+                        "type": "object",
+                        "description": "Object containing the ID and Name of the collection to be added to the first list of the **Buy Together** promotion.",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "ID of the collection to be added to the first list of the **Buy Together** promotion."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Name of the collection to be added to the first list of the **Buy Together** promotion."
+                          }
+                        }
+                      }
+                    },
+                    "minimumQuantityBuyTogether": {
+                      "type": "integer",
+                      "description": "Minimum quantity for **Buy Together** promotion."
+                    },
+                    "quantityToAffectBuyTogether": {
+                      "type": "integer",
+                      "description": "Quantity to affect **Buy Together** promotion."
+                    },
+                    "enableBuyTogetherPerSku": {
+                      "type": "boolean",
+                      "description": "Enable **Buy Together** per SKU."
+                    },
+                    "listSku1BuyTogether": {
+                      "type": "array",
+                      "description": "Array of objects, each containing ID and Name of an SKU to be added in the first list of the **Buy Together** promotion. Learn more about this type of promotion in the [Creating a Buy Together promotion](https://help.vtex.com/en/tutorial/buy-together--tutorials_323) documentation.",
+                      "items": {
+                        "type": "object",
+                        "description": "Object containing the ID and Name of the SKU to be added to the first list of the **Buy Together** promotion. Learn more about this type of promotion in the [Creating a Buy Together promotion](https://help.vtex.com/en/tutorial/buy-together--tutorials_323) documentation.",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "ID of the SKU to be added to the first list of the **Buy Together** promotion."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Name of the SKU to be added to the first list of the **Buy Together** promotion."
+                          }
+                        }
+                      }
+                    },
+                    "listSku2BuyTogether": {
+                      "type": "array",
+                      "description": "Array of objects, each containing ID and Name of an SKU to be added to the second list of the **Buy Together** promotion. Learn more about this type of promotion in the [Creating a Buy Together promotion](https://help.vtex.com/en/tutorial/buy-together--tutorials_323) documentation.",
+                      "items": {
+                        "type": "object",
+                        "description": "Object containing the ID and Name of the SKU to be added to the second list of the **Buy Together** promotion. Learn more about this type of promotion in the [Creating a Buy Together promotion](https://help.vtex.com/en/tutorial/buy-together--tutorials_323) documentation.",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "ID of the SKU to be added to the second list of the **Buy Together** promotion."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Name of the SKU to be added to the second list of the **Buy Together** promotion."
+                          }
+                        }
+                      }
+                    },
+                    "coupon": {
+                      "type": "array",
+                      "deprecated": true,
+                      "description": "List of coupons.",
+                      "items": {
+                        "type": "string",
+                        "description": "Coupon code."
+                      }
+                    },
+                    "totalValueFloor": {
+                      "type": "number",
+                      "description": "Minimum chart value to activate the promotion."
+                    },
+                    "totalValueCeling": {
+                      "type": "number",
+                      "description": "Maximum chart value to activate the promotion."
+                    },
+                    "totalValueIncludeAllItems": {
+                      "type": "boolean",
+                      "deprecated": true,
+                      "description": "Total value including all items."
+                    },
+                    "totalValueMode": {
+                      "type": "string",
+                      "description": "If products that already are receiving a promotion, will be considered on the chart total value. There are three options available: `IncludeMatchedItems`, `ExcludeMatchedItems`, `AllItems`."
+                    },
+                    "collections": {
+                      "type": "array",
+                      "description": "Array composed by the collections that will be activated or deactivated the promotion.",
+                      "items": {
+                        "type": "object",
+                        "description": "Object with information of the collection.",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Collection ID."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Collection Name."
+                          }
+                        }
+                      }
+                    },
+                    "collectionsIsInclusive": {
+                      "type": "boolean",
+                      "description": "If set to `true`, this promotion will be applied to any collection present on the `collections` field. If set to `false`, collections present on that field will make this promotion not to be applied."
+                    },
+                    "restrictionsBins": {
+                      "type": "array",
+                      "description": "The discount will be granted if the card's BIN is given.",
+                      "items": {
+                        "type": "string",
+                        "description": "Card's BIN."
+                      }
+                    },
+                    "cardIssuers": {
+                      "type": "array",
+                      "deprecated": true,
+                      "description": "List of card issuers.",
+                      "items": {
+                        "type": "string",
+                        "description": "Card issuer."
+                      }
+                    },
+                    "totalValuePurchase": {
+                      "type": "number",
+                      "description": "Total value a client must have in past orders to active the promotion."
+                    },
+                    "slasIds": {
+                      "type": "array",
+                      "description": "The discount will be granted if the shipping method is the same as the one given.",
+                      "items": {
+                        "type": "string",
+                        "description": "Shipping method."
+                      }
+                    },
+                    "isSlaSelected": {
+                      "type": "boolean",
+                      "description": "Applies selected discount only when one of the defined shipping method is selected by the customer."
+                    },
+                    "isFirstBuy": {
+                      "type": "boolean",
+                      "description": "Applies the discount only if it's a first buy."
+                    },
+                    "firstBuyIsProfileOptimistic": {
+                      "type": "boolean",
+                      "description": "Applies the discount even if the user is not logged."
+                    },
+                    "compareListPriceAndPrice": {
+                      "type": "boolean",
+                      "description": "If the **List Price** and **Price** are the same."
+                    },
+                    "isDifferentListPriceAndPrice": {
+                      "type": "boolean",
+                      "description": "Applies the promotion only if the list price and price is different."
+                    },
+                    "zipCodeRanges": {
+                      "type": "array",
+                      "description": "Range of the zip code that applies the promotion.",
+                      "items": {
+                        "type": "object",
+                        "description": "Object with information of the Zip Code.",
+                        "properties": {
+                          "zipCodeFrom": {
+                            "type": "string",
+                            "description": "Initial Zip Code."
+                          },
+                          "zipCodeTo": {
+                            "type": "string",
+                            "description": "Final Zip Code."
+                          },
+                          "inclusive": {
+                            "type": "boolean",
+                            "description": "Defines if the zip code range is included in the promotion."
+                          }
+                        }
+                      }
+                    },
+                    "countries": {
+                      "type": "array",
+                      "description": "List of countries that are activated for this promotion.",
+                      "items": {
+                        "type": "string",
+                        "description": "Three-digit country code."
+                      }
+                    },
+                    "itemMaxPrice": {
+                      "type": "number",
+                      "description": "Maximum price of the item."
+                    },
+                    "itemMinPrice": {
+                      "type": "number",
+                      "description": "Minimum price of the item."
+                    },
+                    "installment": {
+                      "type": "integer",
+                      "deprecated": true,
+                      "description": "Installment."
+                    },
+                    "isMinMaxInstallments": {
+                      "type": "boolean",
+                      "description": "Set if the promotion will be applied considering a minimum and maximum values for installments."
+                    },
+                    "minInstallment": {
+                      "type": "integer",
+                      "description": "Minimum value for installment."
+                    },
+                    "maxInstallment": {
+                      "type": "integer",
+                      "description": "Maximum value for installment."
+                    },
+                    "merchants": {
+                      "type": "array",
+                      "deprecated": true,
+                      "description": "List of merchants.",
+                      "items": {
+                        "type": "string",
+                        "description": "Merchant."
+                      }
+                    },
+                    "clusterExpressions": {
+                      "type": "array",
+                      "description": "Criteria to select a customer cluster. Each item in this array should follow the format of an equality function (`{propertyname}={value}`) or the format of a contains function (`{propertyname} contains {value}`). In both options, `{propertyname}` must be replaced with the name of the field in the data entity, and `{value}` must be replaced with the value determined in Master Data. Find more information about these criteria in [Filling in the Customer cluster field](https://help.vtex.com/tutorial/creating-promotion-for-a-customer-cluster--tutorials_342#filling-in-the-customer-cluster-field).",
+                      "items": {
+                        "type": "string",
+                        "description": "Cluster expression."
+                      }
+                    },
+                    "multipleSkusCause": {
+                      "type": "object",
+                      "description": "Object composed by a list of SKUs on a Multiple Effects promotion. Structure: `\"{SkuId}\": {PercentageDiscount}`. There is a limit of 400 SKUs for this type of promotion.",
+                      "additionalProperties": {
+                        "type": "string",
+                        "description": "SKU ID."
+                      }
+                    },
+                    "paymentsRules": {
+                      "type": "array",
+                      "deprecated": true,
+                      "description": "List of payment rules.",
+                      "items": {
+                        "type": "string",
+                        "description": "Payment rule."
+                      }
+                    },
+                    "giftListTypes": {
+                      "type": "array",
+                      "description": "Gifts List Type.",
+                      "items": {
+                        "type": "string",
+                        "description": "Gift List Type."
+                      }
+                    },
+                    "productsSpecifications": {
+                      "type": "array",
+                      "deprecated": true,
+                      "description": "List of product specifications.",
+                      "items": {
+                        "type": "string",
+                        "description": "Product specification."
+                      }
+                    },
+                    "affiliates": {
+                      "type": "array",
+                      "description": "Marketplace order identifier. The discount will apply to selected affiliates.",
+                      "items": {
+                        "type": "object",
+                        "description": "Object with information of the affiliate.",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Affiliate ID."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Affiliate Name."
+                          }
+                        }
+                      }
+                    },
+                    "maxUsage": {
+                      "type": "integer",
+                      "description": "Defines how many times the promotion can be used."
+                    },
+                    "maxUsagePerClient": {
+                      "type": "integer",
+                      "description": "Defines if the promotion can be used multiple times per client."
+                    },
+                    "shouldDistributeDiscountAmongMatchedItems": {
+                      "type": "boolean",
+                      "description": "Should distribute discount among matched items."
+                    },
+                    "multipleUsePerClient": {
+                      "type": "boolean",
+                      "description": "Defines if the promotion can be used multiple times per client."
+                    },
+                    "accumulateWithManualPrice": {
+                      "type": "boolean",
+                      "description": "Allows the promotion to apply to products whose prices have been manually added by a call center operator."
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "Defines what is the type of the promotion or indicates if it is a tax. Possible values: `regular` ([Regular Promotion](https://help.vtex.com/tutorial/regular-promotion--tutorials_327)), `combo` ([Buy Together](https://help.vtex.com/en/tutorial/buy-together--tutorials_323)), `forThePriceOf` ([More for Less](https://help.vtex.com/en/tutorial/creating-a-more-for-less-promotion--tutorials_325)), `progressive` ([Progressive Discount](https://help.vtex.com/en/tutorial/progressive-discount--tutorials_324)), `buyAndWin` ([Buy One Get One](https://help.vtex.com/en/tutorial/buy-one-get-one--tutorials_322)), `maxPricePerItem` (Deprecated), `campaign` ([Campaign Promotion](https://help.vtex.com/en/tutorial/campaign-promotion--1ChYXhK2AQGuS6wAqS8Ume)), `tax` (Tax), `multipleEffects` (Multiple Effects)."
+                    },
+                    "useNewProgressiveAlgorithm": {
+                      "type": "boolean",
+                      "description": "Use new progressive algorithm."
+                    },
+                    "percentualDiscountValueList": {
+                      "type": "array",
+                      "description": "Percentual discount value list.",
+                      "items": {
+                        "type": "number",
+                        "description": "Percentual discount value."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         },
+        "deprecated": false
+      }
+    },
     "/api/dataentities/{acronym}/search": {
       "get": {
         "tags": [

--- a/vtex/utils/types.ts
+++ b/vtex/utils/types.ts
@@ -1135,7 +1135,9 @@ export type SPEvent =
   }
   | {
     type: "page.empty_cart";
-    products: [];
+    // Empty array is converted to a invalid json schema... so, let it be anything.
+    // deno-lint-ignore ban-types
+    products: {};
   }
   | {
     type: "page.confirmation";


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

An empty array as type is converted to "Items: []" which is an invalid json.

By setting as a {} object, it will accept any empty object which is valid to represent anything really (but is not interpreted by a rjsf).

## Issue Link

- Issue: https://github.com/deco-cx/apps/issues/990