### PR TITLE
Feat: Enhance Product Data Handling in DecoCX Schema.org Transformation

### DIFF
--- a/vtex/loaders/intelligentSearch/productDetailsPage.ts
+++ b/vtex/loaders/intelligentSearch/productDetailsPage.ts
@@ -11,7 +11,11 @@ import { pageTypesToSeo } from "../../utils/legacy.ts";
 import { getSegmentFromBag, withSegmentCookie } from "../../utils/segment.ts";
 import { withIsSimilarTo } from "../../utils/similars.ts";
 import { pickSku, toProductPage } from "../../utils/transform.ts";
-import type { PageType, Product as VTEXProduct } from "../../utils/types.ts";
+import type {
+  AdvancedLoaderConfig,
+  PageType,
+  Product as VTEXProduct,
+} from "../../utils/types.ts";
 import PDPDefaultPath from "../paths/PDPDefaultPath.ts";
 
 export interface Props {
@@ -26,6 +30,11 @@ export interface Props {
    * @description Index of product pages with the `skuId` parameter
    */
   indexingSkus?: boolean;
+  /**
+   * @title Advanced Configuration
+   * @description Further change loader behaviour
+   */
+  advancedConfigs?: AdvancedLoaderConfig;
 }
 
 /**
@@ -130,6 +139,7 @@ const loader = async (
   const page = toProductPage(product, sku, kitItems, {
     baseUrl,
     priceCurrency: segment?.payload?.currencyCode ?? "BRL",
+    includeOriginalAttributes: props.advancedConfigs?.includeOriginalAttributes,
   });
 
   const isPageProduct = pageType.pageType === "Product";

--- a/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -26,6 +26,7 @@ import {
   toProduct,
 } from "../../utils/transform.ts";
 import type {
+  AdvancedLoaderConfig,
   Facet,
   Fuzzy,
   PageType,
@@ -142,6 +143,11 @@ export interface Props {
    * @title Include price in facets
    */
   priceFacets?: boolean;
+  /**
+   * @title Advanced Configuration
+   * @description Further change loader behaviour
+   */
+  advancedConfigs?: AdvancedLoaderConfig;
 }
 const searchArgsOf = (props: Props, url: URL) => {
   const hideUnavailableItems = props.hideUnavailableItems;
@@ -362,6 +368,8 @@ const loader = async (
         toProduct(p, p.items.find(getFirstItemAvailable) || p.items[0], 0, {
           baseUrl: baseUrl,
           priceCurrency: segment?.payload?.currencyCode ?? "BRL",
+          includeOriginalAttributes: props.advancedConfigs
+            ?.includeOriginalAttributes,
         })
       )
       .map((product) =>

--- a/vtex/loaders/intelligentSearch/suggestions.ts
+++ b/vtex/loaders/intelligentSearch/suggestions.ts
@@ -9,6 +9,7 @@ import {
 import { getSegmentFromBag, withSegmentCookie } from "../../utils/segment.ts";
 import { withIsSimilarTo } from "../../utils/similars.ts";
 import { toProduct } from "../../utils/transform.ts";
+import type { AdvancedLoaderConfig } from "../../utils/types.ts";
 
 export interface Props {
   query?: string;
@@ -23,6 +24,11 @@ export interface Props {
    * @deprecated Use product extensions instead
    */
   similars?: boolean;
+  /**
+   * @title Advanced Configuration
+   * @description Further change loader behaviour
+   */
+  advancedConfigs?: AdvancedLoaderConfig;
 }
 
 /**
@@ -79,6 +85,7 @@ const loaders = async (
   const options = {
     baseUrl: url,
     priceCurrency: segment?.payload?.currencyCode ?? "BRL",
+    includeOriginalAttributes: props.advancedConfigs?.includeOriginalAttributes,
   };
 
   return {

--- a/vtex/loaders/legacy/productDetailsPage.ts
+++ b/vtex/loaders/legacy/productDetailsPage.ts
@@ -6,7 +6,7 @@ import { toSegmentParams } from "../../utils/legacy.ts";
 import { getSegmentFromBag, withSegmentCookie } from "../../utils/segment.ts";
 import { withIsSimilarTo } from "../../utils/similars.ts";
 import { pickSku, toProductPage } from "../../utils/transform.ts";
-import type { LegacyProduct } from "../../utils/types.ts";
+import type { AdvancedLoaderConfig, LegacyProduct } from "../../utils/types.ts";
 import PDPDefaultPath from "../paths/PDPDefaultPath.ts";
 
 export interface Props {
@@ -22,6 +22,11 @@ export interface Props {
    * @description Index of product pages with the `skuId` parameter
    */
   indexingSkus?: boolean;
+  /**
+   * @title Advanced Configuration
+   * @description Further change loader behaviour
+   */
+  advancedConfigs?: AdvancedLoaderConfig;
 }
 
 /**
@@ -86,6 +91,7 @@ async function loader(
   const page = toProductPage(product, sku, kitItems, {
     baseUrl,
     priceCurrency: segment?.payload?.currencyCode ?? "BRL",
+    includeOriginalAttributes: props.advancedConfigs?.includeOriginalAttributes,
   });
 
   return {

--- a/vtex/loaders/legacy/productListingPage.ts
+++ b/vtex/loaders/legacy/productListingPage.ts
@@ -16,6 +16,7 @@ import { withIsSimilarTo } from "../../utils/similars.ts";
 import { parsePageType } from "../../utils/transform.ts";
 import { legacyFacetToFilter, toProduct } from "../../utils/transform.ts";
 import type {
+  AdvancedLoaderConfig,
   Item,
   LegacyFacet,
   LegacyProduct,
@@ -92,6 +93,12 @@ export interface Props {
    * @title Ignore case by checking for selected filter
    */
   ignoreCaseSelected?: boolean;
+
+  /**
+   * @title Advanced Configuration
+   * @description Further change loader behaviour
+   */
+  advancedConfigs?: AdvancedLoaderConfig;
 }
 
 export const sortOptions = [
@@ -277,6 +284,8 @@ const loader = async (
           {
             baseUrl,
             priceCurrency: segment?.payload?.currencyCode ?? "BRL",
+            includeOriginalAttributes: props.advancedConfigs
+              ?.includeOriginalAttributes,
           },
         )
       )

--- a/vtex/utils/pickAndOmit.ts
+++ b/vtex/utils/pickAndOmit.ts
@@ -1,0 +1,30 @@
+export function pick<
+  T extends object,
+  K extends keyof T = keyof T,
+>(
+  keys: K[],
+  obj: T | null | undefined,
+): Pick<T, K> | null {
+  if (!keys.length || !obj) {
+    return null;
+  }
+
+  const entries = keys.map((key) => [key, obj[key]]);
+
+  return Object.fromEntries(entries);
+}
+
+export function omit<T extends object, K extends keyof T>(
+  keys: K[],
+  obj: T | null | undefined,
+): Omit<T, K> | null {
+  if (!keys.length || !obj) {
+    return null;
+  }
+
+  const pickedKeys = (Object.keys(obj) as K[]).filter(
+    (key) => !keys.includes(key),
+  );
+
+  return pick(pickedKeys, obj) as unknown as Omit<T, K>;
+}

--- a/vtex/utils/types.ts
+++ b/vtex/utils/types.ts
@@ -1514,3 +1514,10 @@ export interface Promotion {
   maxNumberOfAffectedItems: number;
   maxNumberOfAffectedItemsGroupKey: string;
 }
+
+export interface AdvancedLoaderConfig {
+  /** @description Specifies an array of attribute names from the original object to be directly included in the transformed object. */
+  includeOriginalAttributes: string[];
+}
+
+export type Maybe<T> = T | null | undefined;


### PR DESCRIPTION
### General Information
[Discord Discussion](https://discord.com/channels/985687648595243068/1310591630608302150)

#### **Environment**
https://admin.deco.cx/sites/oficina-reserva/spaces/dashboard?env=fix%2Fsku-specs

#### **Loaders Modified**
- Legacy PLP / PDP
- Intelligent Search PLP / PDP

### **Problem**  
In the process of transforming DecoCX product data into the **schema.org** format, some important product attributes are being lost. These attributes might be necessary for specific use cases in the storefront, leading to limitations in the available data.  

### **Proposed Solution**  
To address this issue, we propose adding an **"Advanced Config"** property to some loaders. This property would include an attribute named **`originalAttributesToInclude`**, which would be an array of strings representing the key names of the original attributes to retain.  

These specified attributes would then be added to the `additionalProperties` field of the `isVariantOf` object, ensuring that the required data is preserved and accessible in the frontend.  

### **Additional Context**  
- **Feedback from @guitavano**: The product data on Deco is canonized, and the use of a generic `string[]` may be too broad.  
- One of the key challenges here is ensuring flexibility in accessing product attributes on the frontend without requiring separate PRs for every new attribute that might be needed.  

### **Acceptance Criteria**  
1. An **Advanced Config** prop is implemented in the relevant loaders.  
2. The **`originalAttributesToInclude`** array allows for retaining specific attributes during the schema transformation.  
3. Retained attributes are correctly added to the `additionalProperties` field in the `isVariantOf` object.  
4. Flexibility is achieved to add or remove attributes dynamically without requiring multiple PRs.  

### **Impact**  
This change would streamline the process of retaining essential product attributes, reduce the need for repetitive development efforts, and ensure more robust and adaptable storefront implementations.