### PR TITLE
[Shopify] - Feat: add shop loader and GraphQL query for shop information

### DIFF
--- a/shopify/loaders/shop.ts
+++ b/shopify/loaders/shop.ts
@@ -1,0 +1,33 @@
+import { AppContext } from "../mod.ts";
+import { GetShopInfo } from "../utils/storefront/queries.ts";
+import {
+  Shop,
+  ShopMetafieldsArgs,
+} from "../utils/storefront/storefront.graphql.gen.ts";
+import { Metafield } from "../utils/types.ts";
+
+export interface Props {
+  /**
+   * @title Metafields
+   * @description search for metafields
+   */
+  metafields?: Metafield[];
+}
+
+const loader = async (
+  props: Props,
+  _req: Request,
+  ctx: AppContext,
+): Promise<Shop> => {
+  const { storefront } = ctx;
+  const { metafields = [] } = props;
+
+  const shop = await storefront.query<{ shop: Shop }, ShopMetafieldsArgs>({
+      variables: { identifiers: metafields },
+      ...GetShopInfo,
+    }).then((data) => data.shop);
+
+  return shop;
+};
+
+export default loader;

--- a/shopify/manifest.gen.ts
+++ b/shopify/manifest.gen.ts
@@ -15,7 +15,8 @@ import * as $$$1 from "./loaders/ProductList.ts";
 import * as $$$2 from "./loaders/ProductListingPage.ts";
 import * as $$$5 from "./loaders/proxy.ts";
 import * as $$$3 from "./loaders/RelatedProducts.ts";
-import * as $$$6 from "./loaders/user.ts";
+import * as $$$6 from "./loaders/shop.ts";
+import * as $$$7 from "./loaders/user.ts";
 
 const manifest = {
   "loaders": {
@@ -25,7 +26,8 @@ const manifest = {
     "shopify/loaders/ProductListingPage.ts": $$$2,
     "shopify/loaders/proxy.ts": $$$5,
     "shopify/loaders/RelatedProducts.ts": $$$3,
-    "shopify/loaders/user.ts": $$$6,
+    "shopify/loaders/shop.ts": $$$6,
+    "shopify/loaders/user.ts": $$$7,
   },
   "handlers": {
     "shopify/handlers/sitemap.ts": $$$$0,

--- a/shopify/utils/storefront/queries.ts
+++ b/shopify/utils/storefront/queries.ts
@@ -261,10 +261,10 @@ const Customer = gql`
 
 export const CreateCart = {
   query: gql`mutation CreateCart {
-  payload: cartCreate { 
-    cart { id } 
-  }
-}`,
+    payload: cartCreate { 
+      cart { id } 
+    }
+  }`,
 };
 
 export const GetCart = {
@@ -276,8 +276,8 @@ export const GetProduct = {
   fragments: [Product, ProductVariant, Collection],
   query:
     gql`query GetProduct($handle: String, $identifiers: [HasMetafieldsIdentifier!]!) {
-    product(handle: $handle) { ...Product }
-  }`,
+      product(handle: $handle) { ...Product }
+    }`,
 };
 
 export const ListProducts = {
@@ -382,6 +382,60 @@ export const ProductRecommendations = {
     gql`query productRecommendations($productId: ID!, $identifiers: [HasMetafieldsIdentifier!]!) {
     productRecommendations(productId: $productId) {
       ...Product
+    }
+  }`,
+};
+
+export const GetShopInfo = {
+  query: gql`query GetShopInfo($identifiers: [HasMetafieldsIdentifier!]!) {
+    shop {
+      name
+      description
+      privacyPolicy {
+        title
+        body
+      }
+      refundPolicy {
+        title
+        body
+      }
+      shippingPolicy {
+        title
+        body
+      }
+      subscriptionPolicy {
+        title
+        body
+      }
+      termsOfService {
+        title
+        body
+      }
+      metafields(identifiers: $identifiers) {
+        description
+        key
+        namespace
+        type
+        value
+        reference {
+          ... on MediaImage {
+            image {
+              url
+            }
+          }
+        }
+        references(first: 250) {
+          edges {
+            node {
+              ... on MediaImage {
+                image {
+                  url
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }`,
 };


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

## Add loader to fetch store information via Shopify API  

### Motivation  
Shopify already provides store information automatically, and fetching it directly from the API is ideal for building custom pages. This approach eliminates the need to store static data, ensuring that the information remains up to date.  

### What was done  
- [x] Created a loader that queries the Shopify API and retrieves store details, including name, description, and store policies.  
- [x] Added support for fetching specific metafields, allowing greater flexibility for customization.  
- [x] Implemented the `GetShopInfo` query to retrieve relevant data and make it available in the application context. 

![image](https://github.com/user-attachments/assets/6b938df7-b014-4e4d-ab40-7ddbf7a0d39c)

### Impact  
This improvement makes the Shopify integration more dynamic, enabling future implementations to use store data without manual maintenance. Additionally, it enhances customization by exposing configurable metafields.  
