### PR TITLE
[Shopify]: add productType to product transformation

### DIFF
--- a/shopify/utils/transform.ts
+++ b/shopify/utils/transform.ts
@@ -131,6 +131,7 @@ export const toProduct = (
     id: productGroupID,
     variants,
     vendor,
+    productType,
   } = product;
   const {
     id: productID,
@@ -148,6 +149,12 @@ export const toProduct = (
     "name": "descriptionHtml",
     "value": product.descriptionHtml,
   };
+
+  const productTypeValue: PropertyValue = {
+    "@type": "PropertyValue",
+    "name": "productType",
+    "value": productType,
+  }
 
   const metafields = (product.metafields ?? [])
     .filter((metafield) => metafield && metafield.key && metafield.value)
@@ -175,6 +182,7 @@ export const toProduct = (
   const additionalProperty: PropertyValue[] = selectedOptions
     .map(toPropertyValue)
     .concat(descriptionHtml)
+    .concat(productTypeValue)
     .concat(metafields);
 
   const skuImages = nonEmptyArray([image]);


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

**Pull Request Description:**

This Pull Request adds the `productType` value returned by Shopify to the product's additional properties. The change ensures that the `productType`, which was previously not being considered, is now correctly included. The implementation details are as follows:

1. The `productType` value is extracted from the `product` object returned by Shopify.
2. A new `PropertyValue` object is created with the name `"productType"`, and its value is set to the `productType` value from the product.
3. This new `PropertyValue` is concatenated with other additional properties, such as the product description and metafields, within the `additionalProperty` array.

Example:

![image](https://github.com/user-attachments/assets/ea69022d-aa8d-42d4-9df4-bbd998039d8f)

**Context:**

In the current repository, there is some confusion with the `type` object returned by the Deco.cx CMS, which follows the schema.org `Product` standard. This structure differs from the value returned by Shopify's `productType`. To address this and ensure data integrity, we decided to include the `productType` value directly in the product's additional properties, making it easier to work with this data in the application.

![image](https://github.com/user-attachments/assets/0624db6f-5c1b-4aed-9d4b-e7c97be380e7)

This change is necessary for implementing a feature for Zeedog Italy. It will allow us to correctly handle and display the product type as required by the feature's specifications.
