### PR TITLE
Refactor(SEO): show structured data only to bots/crawlers

### DIFF
--- a/commerce/sections/Seo/SeoPDPV2.tsx
+++ b/commerce/sections/Seo/SeoPDPV2.tsx
@@ -28,7 +28,7 @@ export interface Props {
 }
 
 /** @title Product details */
-export function loader(_props: Props, req: Request, ctx: AppContext) {
+export function loader(_props: Props, _req: Request, ctx: AppContext) {
   const props = _props as Partial<Props>;
   const {
     titleTemplate = "",
@@ -62,9 +62,7 @@ export function loader(_props: Props, req: Request, ctx: AppContext) {
     jsonLD.product.isVariantOf.hasVariant = [];
   }
 
-  const url = new URL(req.url);
-  const shouldShowJsonLDs = url.searchParams.has("__d") || ctx.isBot ||
-    props.forceJsonLDs;
+  const shouldShowJsonLDs = ctx.isBot || props.forceJsonLDs;
   const jsonLDs = shouldShowJsonLDs && jsonLD ? [jsonLD] : [];
 
   return {

--- a/commerce/sections/Seo/SeoPDPV2.tsx
+++ b/commerce/sections/Seo/SeoPDPV2.tsx
@@ -20,10 +20,15 @@ export interface Props {
    * @description In testing, you can use this to prevent search engines from indexing your site
    */
   noIndexing?: boolean;
+  /**
+   * @title Force JSON-LDs
+   * @description By default, JSON-LDs are only shown to crawlers. Use this to force JSON-LDs to be shown to all users
+   */
+  forceJsonLDs?: boolean;
 }
 
 /** @title Product details */
-export function loader(_props: Props, _req: Request, ctx: AppContext) {
+export function loader(_props: Props, req: Request, ctx: AppContext) {
   const props = _props as Partial<Props>;
   const {
     titleTemplate = "",
@@ -57,6 +62,11 @@ export function loader(_props: Props, _req: Request, ctx: AppContext) {
     jsonLD.product.isVariantOf.hasVariant = [];
   }
 
+  const url = new URL(req.url);
+  const shouldShowJsonLDs = url.searchParams.has("__d") || ctx.isBot ||
+    props.forceJsonLDs;
+  const jsonLDs = shouldShowJsonLDs && jsonLD ? [jsonLD] : [];
+
   return {
     ...seoSiteProps,
     title,
@@ -64,7 +74,7 @@ export function loader(_props: Props, _req: Request, ctx: AppContext) {
     image,
     canonical,
     noIndexing,
-    jsonLDs: [jsonLD],
+    jsonLDs,
   };
 }
 

--- a/commerce/sections/Seo/SeoPLPV2.tsx
+++ b/commerce/sections/Seo/SeoPLPV2.tsx
@@ -38,7 +38,7 @@ export interface Props {
 }
 
 /** @title Product listing */
-export function loader(_props: Props, req: Request, ctx: AppContext) {
+export function loader(_props: Props, _req: Request, ctx: AppContext) {
   const props = _props as Partial<Props>;
   const {
     titleTemplate = "",
@@ -82,9 +82,7 @@ export function loader(_props: Props, req: Request, ctx: AppContext) {
     });
   }
 
-  const url = new URL(req.url);
-  const shouldShowJsonLDs = url.searchParams.has("__d") || ctx.isBot ||
-    configJsonLD?.forceJsonLDs;
+  const shouldShowJsonLDs = ctx.isBot || configJsonLD?.forceJsonLDs;
   const jsonLDs = shouldShowJsonLDs && jsonLD ? [jsonLD] : [];
 
   return {

--- a/commerce/sections/Seo/SeoPLPV2.tsx
+++ b/commerce/sections/Seo/SeoPLPV2.tsx
@@ -13,6 +13,11 @@ export interface ConfigJsonLD {
    * @description Remove product videos from structured data
    */
   removeVideos?: boolean;
+  /**
+   * @title Force JSON-LDs
+   * @description By default, JSON-LDs are only shown to crawlers. Use this to force JSON-LDs to be shown to all users
+   */
+  forceJsonLDs?: boolean;
 }
 
 export interface Props {
@@ -33,14 +38,19 @@ export interface Props {
 }
 
 /** @title Product listing */
-export function loader(_props: Props, _req: Request, ctx: AppContext) {
+export function loader(_props: Props, req: Request, ctx: AppContext) {
   const props = _props as Partial<Props>;
   const {
     titleTemplate = "",
     descriptionTemplate = "",
     ...seoSiteProps
   } = ctx.seo ?? {};
-  const { title: titleProp, description: descriptionProp, jsonLD } = props;
+  const {
+    title: titleProp,
+    description: descriptionProp,
+    jsonLD,
+    configJsonLD,
+  } = props;
 
   const title = renderTemplateString(
     titleTemplate,
@@ -72,12 +82,17 @@ export function loader(_props: Props, _req: Request, ctx: AppContext) {
     });
   }
 
+  const url = new URL(req.url);
+  const shouldShowJsonLDs = url.searchParams.has("__d") || ctx.isBot ||
+    configJsonLD?.forceJsonLDs;
+  const jsonLDs = shouldShowJsonLDs && jsonLD ? [jsonLD] : [];
+
   return {
     ...seoSiteProps,
     title,
     description,
     canonical,
-    jsonLDs: [jsonLD],
+    jsonLDs,
     noIndexing,
   };
 }

--- a/vtex/loaders/intelligentSearch/productList.ts
+++ b/vtex/loaders/intelligentSearch/productList.ts
@@ -246,7 +246,7 @@ const getSearchParams = (
 ): Entry[] => {
   if (isFacetsList(props)) {
     return [
-      ["query", props.query ?? searchParams.get("q")],
+      ["query", props.query ?? searchParams.get("q") ?? ""],
       ["count", (props.count || searchParams.get("count") || 12).toString()],
       ["sort", props.sort || searchParams.get("sort") || ""],
       ["selectedFacets", props.facets],

--- a/website/loaders/secret.ts
+++ b/website/loaders/secret.ts
@@ -47,7 +47,9 @@ const getSecret = async (props: Props): Promise<string | null> => {
     await showWarningOnce();
     return Promise.resolve(null);
   }
-  return moduleCache[encrypted] ??= decryptFromHex(encrypted).then((d) => d.decrypted)
+  return moduleCache[encrypted] ??= decryptFromHex(encrypted).then((d) =>
+    d.decrypted
+  )
     .catch((err) => {
       const prettyName = name ? colors.brightRed(name) : "anonymous secret";
       console.error(


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

This PR refactors the SEO PLP and PDP sections to avoid sending the structured data for the customers as it's only useful for crawlers and bots.

This changes can decrease significantly the Document size on product listing pages with many products, specifications and variants

https://github.com/user-attachments/assets/22cf7a6c-c523-49f4-b2a9-681fe9d50f97