### PR TITLE
Fix(Website): Check if "src" is undefined before images optimization

### DIFF
--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -166,6 +166,11 @@ const Image = forwardRef<HTMLImageElement, Props>((props, ref) => {
     );
   }
 
+  if (!props.src) {
+    console.error("Missing src. This image will NOT be rendered");
+    return null;
+  }
+
   const srcSet = getSrcSet(props.src, props.width, props.height, props.fit);
   const linkProps = srcSet && {
     imagesrcset: srcSet,


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?
With this PR the Image component will no more break the entire section if src is not defined correctly.

I'm not happy yet on how we are handling it, now it only shows that are some Image somewhere in my codebase that will not be rendered and I have no clue on where it is. I've tried to use `console.trace` and `console.error(new Error(...))` but the stack trace that I get is not enough to locate where this log is coming from.

![tracing](https://github.com/user-attachments/assets/2804f17b-573b-41e0-83c0-5e59862f5e28)
