### PR TITLE
Improve srcSet flexibility in the Image component

### DIFF
--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -166,7 +166,8 @@ const Image = forwardRef<HTMLImageElement, Props>((props, ref) => {
     );
   }
 
-  const srcSet = getSrcSet(props.src, props.width, props.height, props.fit);
+  const srcSet = props.srcSet ?? getSrcSet(props.src, props.width, props.height, props.fit);
+
   const linkProps = srcSet && {
     imagesrcset: srcSet,
     imagesizes: props.sizes,


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

The `Image` component serves as a wrapper that optimizes image URLs for each e-commerce platform while leveraging the optimized Deco CDN. However, the current `srcSet` generation is limited because it only considers two factors, preventing the generation of intermediate image sizes.

Since modifying the existing `srcSet` logic could introduce breaking changes across all stores, a more flexible approach would be to allow an optional `srcSet` prop, enabling customization without altering the default behavior.

## **Proposed Solution:**
Introduce an optional `srcSet` prop to the `Image` component, allowing developers to define custom breakpoints while maintaining backward compatibility.