### PR TITLE
Remove window in SEO Preview

### DIFF
--- a/website/components/_seo/Preview.tsx
+++ b/website/components/_seo/Preview.tsx
@@ -106,7 +106,7 @@ function PreviewItem(
 }
 
 function Preview(props: SeoProps) {
-  const path = useMemo(() => globalThis.window.location?.host, []);
+  const path = useMemo(() => globalThis.location?.host, []);
 
   return (
     <>


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?
Window is discontinued in deno 2. Developers running the project in localhost has error while preview the SEO

### After:
![image](https://github.com/user-attachments/assets/3a705477-e849-4741-84ed-46f9d9d2199e)
![image](https://github.com/user-attachments/assets/bee7ebbb-dc33-4bb3-aeeb-9ffe10dedf9b)
### Before:
![image](https://github.com/user-attachments/assets/c53e4ade-4afe-4491-9cea-4c0fcd66917e)
![image](https://github.com/user-attachments/assets/f35f6c3c-2527-4ef1-813c-6f4bff866554)



## Issue Link

Please link to the relevant issue that this pull request addresses:

- Issue: [#ISSUE_NUMBER](link_to_issue)

## Loom Video

> Record a quick screencast describing your changes to help the team understand and review your contribution. This will greatly assist in the review process.

## Demonstration Link

> Provide a link to a branch or environment where this pull request can be tested and seen in action.
