### PR TITLE
[Wake] fix: extra paths proxy

### DIFF
--- a/wake/loaders/proxy.ts
+++ b/wake/loaders/proxy.ts
@@ -48,7 +48,9 @@ function loader(
     extraPathsToProxy = [],
   } = props as Props;
 
-  const checkout = [...PATHS_TO_PROXY, ...extraPathsToProxy].map((
+  const extraPathsToProxyAsArray = extraPathsToProxy.map((path) => [path]);
+
+  const checkout = [...PATHS_TO_PROXY, ...extraPathsToProxyAsArray].map((
     [pathTemplate, basePath],
   ) => ({
     pathTemplate,


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

This PR fix the extraPathsToProxyh format on wake integration

