### PR TITLE
fix: account verification for user request

### DIFF
--- a/vtex/mod.ts
+++ b/vtex/mod.ts
@@ -43,6 +43,11 @@ export interface Props {
    */
   account: string;
   /**
+   * @title Store Name
+   * @description VTEX Store name For more info, read here: https://help.vtex.com/en/tutorial/account-details-page--2vhUVOKfCaswqLguT2F9xq#stores
+   */
+  subAccount?: string;
+  /**
    * @title Public store URL
    * @description Domain that is registered on License Manager (e.g: secure.mystore.com.br) to enable account/checkout/api proxy. Important: dont use the same domain as the public store url, or it will create a loop and break the app.
    */
@@ -86,7 +91,7 @@ export const color = 0xf71963;
  * @logo https://raw.githubusercontent.com/deco-cx/apps/main/vtex/logo.png
  */
 export default function VTEX(
-  { appKey, appToken, account, publicUrl, salesChannel, ...props }: Props,
+  { appKey, appToken, account, publicUrl, salesChannel, subAccount, ...props }: Props,
 ) {
   const headers = new Headers();
   appKey &&
@@ -116,7 +121,7 @@ export default function VTEX(
   });
   const io = createGraphqlClient({
     endpoint:
-      `https://${account}.vtexcommercestable.com.br/api/io/_v/private/graphql/v1`,
+      `https://${subAccount || account}.vtexcommercestable.com.br/api/io/_v/private/graphql/v1`,
     processHeaders: removeDirtyCookies,
     fetcher: fetchSafe,
   });

--- a/vtex/utils/vtexId.ts
+++ b/vtex/utils/vtexId.ts
@@ -15,21 +15,30 @@ interface CookiePayload {
 
 export const parseCookie = (headers: Headers, account: string) => {
   const cookies = getCookies(headers);
-  const cookie = cookies[VTEX_ID_CLIENT_COOKIE] ||
-    cookies[`${VTEX_ID_CLIENT_COOKIE}_${account}`];
+
+  const authCookieName = Object.keys(cookies).toSorted((a, z) =>
+    a.length - z.length
+  ).find((cookieName) => cookieName.startsWith("VtexIdclientAutCookie"));
+
+  if (!authCookieName) {
+    return {
+      cookie: "",
+    }
+  }
+
+  const cookie = authCookieName ? cookies[authCookieName] : undefined
+
   const decoded = cookie ? decode(cookie) : null;
 
   const payload = decoded?.[1] as CookiePayload | undefined;
 
   return {
     cookie: stringify({
-      ...(cookies[VTEX_ID_CLIENT_COOKIE] &&
-        { [VTEX_ID_CLIENT_COOKIE]: cookies[VTEX_ID_CLIENT_COOKIE] }),
-      ...(cookies[`${VTEX_ID_CLIENT_COOKIE}_${account}`] &&
-        {
-          [`${VTEX_ID_CLIENT_COOKIE}_${account}`]:
-            cookies[`${VTEX_ID_CLIENT_COOKIE}_${account}`],
-        }),
+      ...(cookies[authCookieName] &&
+      {
+        [authCookieName]:
+          cookies[authCookieName],
+      }),
     }),
     payload,
   };


### PR DESCRIPTION
## What is this Contribution about?
Fixation in the search for the cookie "texIdclientAutCookie" to retrieve user data

Previously, in VTEX stores that use subAccounts, there was a problem in searching for the cookie, as it was generated based on the Account name, and not on the name of the main subAccount.

vtexid.ts
![image](https://github.com/user-attachments/assets/0b0e111a-63c8-468f-9fab-742526697fe8)

mod.ts
![image](https://github.com/user-attachments/assets/ea3d4e11-29bb-4678-97bc-c97862bce4fc)

![image](https://github.com/user-attachments/assets/bc531f81-e67a-4ee7-b7d6-9bc6aba3b72d)
