### PR TITLE
refactor: reorganize manifest and update video action parameters

### DIFF
--- a/vidu/actions/imageToVideo.ts
+++ b/vidu/actions/imageToVideo.ts
@@ -32,13 +32,16 @@ export interface Result {
  */
 const action = async (
   props: Props,
-  _req: Request,
+  req: Request,
   ctx: AppContext,
 ): Promise<ImageToVideoResponseBody | Result> => {
   const payload = {
     ...props,
     model: props.model ?? "vidu2.0",
   } as unknown as ImageToVideoRequestBody; // Type assertion to satisfy TypeScript
+
+  const url = new URL(req.url);
+  const installId = url.searchParams.get("installId");
 
   const response = await ctx.api["POST /ent/v2/img2video"]({}, {
     body: payload,
@@ -50,7 +53,7 @@ const action = async (
     return {
       status: "success",
       previewUrl:
-        `${PREVIEW_URL}&generationId=${result.task_id}&presignedUrl=${props.presignedUrl}&installId=${ctx.installId}`,
+        `${PREVIEW_URL}&generationId=${result.task_id}&presignedUrl=${props.presignedUrl}&installId=${installId}`,
       message:
         "Video generation started. The video will be available at the previewUrl.",
     };

--- a/vidu/actions/referenceToVideo.ts
+++ b/vidu/actions/referenceToVideo.ts
@@ -32,9 +32,12 @@ export interface Result {
  */
 const action = async (
   props: Props,
-  _req: Request,
+  req: Request,
   ctx: AppContext,
 ): Promise<ReferenceToVideoResponseBody | Result> => {
+  const url = new URL(req.url);
+  const installId = url.searchParams.get("installId");
+
   const payload = {
     ...props,
     model: props.model ?? "vidu2.0",
@@ -50,7 +53,7 @@ const action = async (
     return {
       status: "success",
       previewUrl:
-        `${PREVIEW_URL}&generationId=${result.task_id}&presignedUrl=${props.presignedUrl}&installId=${ctx.installId}`,
+        `${PREVIEW_URL}&generationId=${result.task_id}&presignedUrl=${props.presignedUrl}&installId=${installId}`,
       message:
         "Video generation started. The video will be available at the previewUrl.",
     };

--- a/vidu/actions/startEndToVideo.ts
+++ b/vidu/actions/startEndToVideo.ts
@@ -41,7 +41,7 @@ export interface Result {
  */
 const action = async (
   props: Props,
-  _req: Request,
+  req: Request,
   ctx: AppContext,
 ): Promise<StartEndToVideoResponseBody | Result> => {
   // Validate that exactly 2 images are provided
@@ -50,6 +50,9 @@ const action = async (
       "Start-End to Video requires exactly 2 images - the first is used as the start frame and the second as the end frame.",
     );
   }
+
+  const url = new URL(req.url);
+  const installId = url.searchParams.get("installId");
 
   const payload = {
     ...props,
@@ -66,7 +69,7 @@ const action = async (
     return {
       status: "success",
       previewUrl:
-        `${PREVIEW_URL}&generationId=${result.task_id}&presignedUrl=${props.presignedUrl}&installId=${ctx.installId}`,
+        `${PREVIEW_URL}&generationId=${result.task_id}&presignedUrl=${props.presignedUrl}&installId=${installId}`,
       message:
         "Video generation started. The video will transition smoothly from the start frame to the end frame and will be available at the previewUrl.",
     };

--- a/vidu/actions/textToVideo.ts
+++ b/vidu/actions/textToVideo.ts
@@ -32,13 +32,16 @@ export interface Result {
  */
 const action = async (
   props: Props,
-  _req: Request,
+  req: Request,
   ctx: AppContext,
 ): Promise<TextToVideoResponseBody | Result> => {
   const payload = {
     ...props,
     model: props.model ?? "vidu1.5" as TextToVideoModel,
   };
+
+  const url = new URL(req.url);
+  const installId = url.searchParams.get("installId");
 
   const response = await ctx.api["POST /ent/v2/text2video"]({}, {
     body: payload,
@@ -50,7 +53,7 @@ const action = async (
     return {
       status: "success",
       previewUrl:
-        `${PREVIEW_URL}&generationId=${result.task_id}&presignedUrl=${props.presignedUrl}&installId=${ctx.installId}`,
+        `${PREVIEW_URL}&generationId=${result.task_id}&presignedUrl=${props.presignedUrl}&installId=${installId}`,
       message:
         "Video generation started. The video will be available at the previewUrl.",
     };

--- a/vidu/manifest.gen.ts
+++ b/vidu/manifest.gen.ts
@@ -3,21 +3,22 @@
 // This file is automatically updated during development when running `dev.ts`.
 
 import * as $$$$$$$$$0 from "./actions/imageToVideo.ts";
-import * as $$$$$$$$$$0 from "./actions/textToVideo.ts";
-import * as $$$$$$$$$$1 from "./actions/referenceToVideo.ts";
-import * as $$$$$$$$$$2 from "./actions/startEndToVideo.ts";
+import * as $$$$$$$$$1 from "./actions/referenceToVideo.ts";
+import * as $$$$$$$$$2 from "./actions/startEndToVideo.ts";
+import * as $$$$$$$$$3 from "./actions/textToVideo.ts";
 import * as $$$0 from "./loaders/getGenerationResult.ts";
-import * as $$$$0 from "./loaders/resultPreview.ts";
+import * as $$$1 from "./loaders/resultPreview.ts";
+
 const manifest = {
-  "actions": {
-    "vidu/actions/imageToVideo.ts": $$$$$$$$$0,
-    "vidu/actions/textToVideo.ts": $$$$$$$$$$0,
-    "vidu/actions/referenceToVideo.ts": $$$$$$$$$$1,
-    "vidu/actions/startEndToVideo.ts": $$$$$$$$$$2,
-  },
   "loaders": {
     "vidu/loaders/getGenerationResult.ts": $$$0,
-    "vidu/loaders/resultPreview.ts": $$$$0,
+    "vidu/loaders/resultPreview.ts": $$$1,
+  },
+  "actions": {
+    "vidu/actions/imageToVideo.ts": $$$$$$$$$0,
+    "vidu/actions/referenceToVideo.ts": $$$$$$$$$1,
+    "vidu/actions/startEndToVideo.ts": $$$$$$$$$2,
+    "vidu/actions/textToVideo.ts": $$$$$$$$$3,
   },
   "name": "vidu",
   "baseUrl": import.meta.url,

--- a/vidu/mod.ts
+++ b/vidu/mod.ts
@@ -18,7 +18,6 @@ export interface Props {
 
 export interface State {
   api: ReturnType<typeof createHttpClient<ViduClient>>;
-  installId: string;
 }
 
 /**
@@ -29,7 +28,6 @@ export interface State {
  */
 export default function App(
   props: Props,
-  req: Request,
 ): App<Manifest, State> {
   const { apiKey } = props;
   const stringToken = typeof apiKey === "string"
@@ -45,14 +43,7 @@ export default function App(
     fetcher: fetchSafe,
   });
 
-  const url = new URL(req.url);
-  const installId = url.searchParams.get("installId");
-
-  if (!installId) {
-    throw new Error("Install ID is required");
-  }
-
-  const state = { api, installId };
+  const state = { api };
 
   return {
     state,


### PR DESCRIPTION
* Rearranged the order of actions in the manifest for consistency.
* Updated video action functions to accept `req` parameter instead of `_req` and retrieve `installId` from the request URL.
* Ensured `installId` is included in the preview URLs for better traceability in video generation responses.

<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Please provide a brief description of the changes or enhancements you are proposing in this pull request.

## Issue Link

Please link to the relevant issue that this pull request addresses:

- Issue: [#ISSUE_NUMBER](link_to_issue)

## Loom Video

> Record a quick screencast describing your changes to help the team understand and review your contribution. This will greatly assist in the review process.

## Demonstration Link

> Provide a link to a branch or environment where this pull request can be tested and seen in action.
