### PR TITLE
feat: add utility function to extract install ID from URL

### DIFF
--- a/vidu/actions/imageToVideo.ts
+++ b/vidu/actions/imageToVideo.ts
@@ -4,7 +4,7 @@ import type {
   ImageToVideoResponseBody,
 } from "../client.ts";
 import { PREVIEW_URL } from "../loaders/resultPreview.ts";
-
+import { getInstallId } from "../utils.ts";
 export type Props = ImageToVideoRequestBody;
 
 export interface Result {
@@ -41,7 +41,7 @@ const action = async (
   } as unknown as ImageToVideoRequestBody; // Type assertion to satisfy TypeScript
 
   const url = new URL(req.url);
-  const installId = url.searchParams.get("installId");
+  const installId = getInstallId(url);
 
   const response = await ctx.api["POST /ent/v2/img2video"]({}, {
     body: payload,

--- a/vidu/actions/referenceToVideo.ts
+++ b/vidu/actions/referenceToVideo.ts
@@ -4,7 +4,7 @@ import type {
   ReferenceToVideoResponseBody,
 } from "../client.ts";
 import { PREVIEW_URL } from "../loaders/resultPreview.ts";
-
+import { getInstallId } from "../utils.ts";
 export type Props = ReferenceToVideoRequestBody;
 
 export interface Result {
@@ -36,7 +36,7 @@ const action = async (
   ctx: AppContext,
 ): Promise<ReferenceToVideoResponseBody | Result> => {
   const url = new URL(req.url);
-  const installId = url.searchParams.get("installId");
+  const installId = getInstallId(url);
 
   const payload = {
     ...props,

--- a/vidu/actions/startEndToVideo.ts
+++ b/vidu/actions/startEndToVideo.ts
@@ -4,6 +4,8 @@ import type {
   StartEndToVideoResponseBody,
 } from "../client.ts";
 import { PREVIEW_URL } from "../loaders/resultPreview.ts";
+import { getInstallId } from "../utils.ts";
+
 export type Props = StartEndToVideoRequestBody;
 
 export interface Result {
@@ -52,7 +54,7 @@ const action = async (
   }
 
   const url = new URL(req.url);
-  const installId = url.searchParams.get("installId");
+  const installId = getInstallId(url);
 
   const payload = {
     ...props,

--- a/vidu/actions/textToVideo.ts
+++ b/vidu/actions/textToVideo.ts
@@ -5,6 +5,7 @@ import type {
   TextToVideoResponseBody,
 } from "../client.ts";
 import { PREVIEW_URL } from "../loaders/resultPreview.ts";
+import { getInstallId } from "../utils.ts";
 
 export type Props = TextToVideoRequestBody;
 
@@ -41,7 +42,8 @@ const action = async (
   };
 
   const url = new URL(req.url);
-  const installId = url.searchParams.get("installId");
+
+  const installId = getInstallId(url);
 
   const response = await ctx.api["POST /ent/v2/text2video"]({}, {
     body: payload,

--- a/vidu/utils.ts
+++ b/vidu/utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Extracts the install ID from a URL pathname with the format:
+ * /apps/Vidu/7afa4147-0903-4416-a52a-c1f7d3b35762/mcp/messages
+ *
+ * @param url URL object or string representation of the URL
+ * @returns The install ID from the pathname or null if not found
+ */
+export function getInstallId(url: URL | string): string | null {
+  const pathName = typeof url === "string" ? url : url.pathname;
+
+  // Match the UUID pattern in the pathname after /apps/Vidu/
+  const match = pathName.match(
+    /\/apps\/Vidu\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i,
+  );
+
+  return match ? match[1] : null;
+}


### PR DESCRIPTION
* Introduced `getInstallId` function in `utils.ts` to extract the install ID from a specific URL pathname format.
* Updated video action files to utilize the new utility function for retrieving install ID, improving code consistency and readability.

<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Please provide a brief description of the changes or enhancements you are proposing in this pull request.

## Issue Link

Please link to the relevant issue that this pull request addresses:

- Issue: [#ISSUE_NUMBER](link_to_issue)

## Loom Video

> Record a quick screencast describing your changes to help the team understand and review your contribution. This will greatly assist in the review process.

## Demonstration Link

> Provide a link to a branch or environment where this pull request can be tested and seen in action.
