### PR TITLE
fix: catch font error at googleFonts loader

### DIFF
--- a/website/loaders/fonts/googleFonts.ts
+++ b/website/loaders/fonts/googleFonts.ts
@@ -120,8 +120,21 @@ const loader = async (props: Props, _req: Request): Promise<Font> => {
   }
 
   const sheets = await Promise.all([
-    fetchSafe(url, { headers: OLD_BROWSER_KEY }).then((res) => res.text()),
-    fetchSafe(url, { headers: NEW_BROWSER_KEY }).then((res) => res.text()),
+    fetchSafe(url, { headers: OLD_BROWSER_KEY }).then((res) => res.text())
+      .catch((e) => {
+        console.error(
+          `Error fetching font: ${url} -  headers: ${OLD_BROWSER_KEY} - error: ${e}`,
+        );
+        return "";
+      }),
+    fetchSafe(url, { headers: NEW_BROWSER_KEY }).then((res) => res.text())
+      .catch((e) => {
+        console.error(
+          `Error fetching font: ${url} -  headers: ${NEW_BROWSER_KEY} - error: ${e}`,
+        );
+        return "";
+      })
+      .catch(() => ""),
   ]);
 
   const styleSheet = sheets.join("\n").replaceAll(


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?
When google fonts request throw an error, a page can't be resolved. The fix consists into catch the error and allow page render.