### PR TITLE
Whitelist domain for assets

### DIFF
--- a/website/loaders/asset.ts
+++ b/website/loaders/asset.ts
@@ -9,14 +9,21 @@ interface Props {
   src: string;
 }
 
-const loader = async (props: Props, request: Request, ctx: AppContext): Promise<Response> => {
+const loader = async (
+  props: Props,
+  request: Request,
+  ctx: AppContext,
+): Promise<Response> => {
   const url = new URL(props.src);
 
   if (ctx.disableProxy) {
     return new Response("Proxy disabled", { status: 403 });
   }
 
-  if (ctx.whitelistPatterns && !ctx.whitelistPatterns.some((pattern) => pattern.test(request.url))) {
+  if (
+    ctx.whitelistPatterns &&
+    !ctx.whitelistPatterns.some((pattern) => pattern.test(request.url))
+  ) {
     return new Response("Proxy disabled for this source", { status: 403 });
   }
 

--- a/website/loaders/asset.ts
+++ b/website/loaders/asset.ts
@@ -22,7 +22,7 @@ const loader = async (
 
   if (
     ctx.whitelistPatterns &&
-    !ctx.whitelistPatterns.some((pattern) => pattern.test(request.url))
+    !ctx.whitelistPatterns.some((pattern) => pattern.test(url))
   ) {
     return new Response("Proxy disabled for this source", { status: 403 });
   }

--- a/website/loaders/asset.ts
+++ b/website/loaders/asset.ts
@@ -1,5 +1,7 @@
 import { forbidden } from "@deco/deco";
 import { fetchSafe, STALE } from "../../utils/fetch.ts";
+import { AppContext } from "../mod.ts";
+
 interface Props {
   /**
    * @description Asset src like: https://fonts.gstatic.com/...
@@ -7,8 +9,16 @@ interface Props {
   src: string;
 }
 
-const loader = async (props: Props, request: Request): Promise<Response> => {
+const loader = async (props: Props, request: Request, ctx: AppContext): Promise<Response> => {
   const url = new URL(props.src);
+
+  if (ctx.disableProxy) {
+    return new Response("Proxy disabled", { status: 403 });
+  }
+
+  if (ctx.whitelistPatterns && !ctx.whitelistPatterns.some((pattern) => pattern.test(request.url))) {
+    return new Response("Proxy disabled for this source", { status: 403 });
+  }
 
   // Whitelist allowed protocols
   const allowedProtocols = ["https:", "http:"];

--- a/website/loaders/image.ts
+++ b/website/loaders/image.ts
@@ -58,15 +58,16 @@ const handler = async (
       return new Response("Proxy disabled", { status: 403 });
     }
 
+    const preferredMediaType = acceptMediaType(req);
+    const params = parseParams(props);
+
     if (
       ctx.whitelistPatterns &&
-      !ctx.whitelistPatterns.some((pattern) => pattern.test(req.url))
+      !ctx.whitelistPatterns.some((pattern) => pattern.test(params.src))
     ) {
       return new Response("Proxy disabled for this source", { status: 403 });
     }
 
-    const preferredMediaType = acceptMediaType(req);
-    const params = parseParams(props);
     const engine = ENGINES.find((e) => e.accepts(params.src)) ?? passThrough;
 
     const response = await engine.resolve(params, preferredMediaType, req);

--- a/website/loaders/image.ts
+++ b/website/loaders/image.ts
@@ -58,7 +58,10 @@ const handler = async (
       return new Response("Proxy disabled", { status: 403 });
     }
 
-    if (ctx.whitelistPatterns && !ctx.whitelistPatterns.some((pattern) => pattern.test(req.url))) {
+    if (
+      ctx.whitelistPatterns &&
+      !ctx.whitelistPatterns.some((pattern) => pattern.test(req.url))
+    ) {
       return new Response("Proxy disabled for this source", { status: 403 });
     }
 

--- a/website/loaders/image.ts
+++ b/website/loaders/image.ts
@@ -5,6 +5,7 @@ import { engine as cloudflare } from "../utils/image/engines/cloudflare/engine.t
 import { engine as deco } from "../utils/image/engines/deco/engine.ts";
 import { engine as passThrough } from "../utils/image/engines/passThrough/engine.ts";
 import { engine as wasm } from "../utils/image/engines/wasm/engine.ts";
+import { AppContext } from "../mod.ts";
 
 const ENGINES = [
   passThrough,
@@ -50,8 +51,17 @@ const acceptMediaType = (req: Request) => {
 const handler = async (
   props: Props,
   req: Request,
+  ctx: AppContext,
 ): Promise<Response> => {
   try {
+    if (ctx.disableProxy) {
+      return new Response("Proxy disabled", { status: 403 });
+    }
+
+    if (ctx.whitelistPatterns && !ctx.whitelistPatterns.some((pattern) => pattern.test(req.url))) {
+      return new Response("Proxy disabled for this source", { status: 403 });
+    }
+
     const preferredMediaType = acceptMediaType(req);
     const params = parseParams(props);
     const engine = ENGINES.find((e) => e.accepts(params.src)) ?? passThrough;
@@ -83,12 +93,12 @@ const handler = async (
 
 const cache = typeof caches !== "undefined" ? await caches.open(PATH) : null;
 
-const loader: typeof handler = async (props, req) => {
+const loader: typeof handler = async (props, req, ctx) => {
   const cached = await cache?.match(req).catch(() => null);
 
   if (cached) return cached;
 
-  const response = await handler(props, req);
+  const response = await handler(props, req, ctx);
 
   if (response.status === 200) {
     const cloned = response.clone();

--- a/website/loaders/whitelistAssets.ts
+++ b/website/loaders/whitelistAssets.ts
@@ -12,7 +12,10 @@ export default function WhitelistAssets(
   "disableProxy": boolean | undefined;
 } {
   // Avoid cache on /live/invoke only
-  if (new URL(_req.url).pathname === ("/live/invoke/website/loaders/whitelistAssets.ts")) {
+  if (
+    new URL(_req.url).pathname ===
+      ("/live/invoke/website/loaders/whitelistAssets.ts")
+  ) {
     ctx.response.headers.set("Cache-Control", "public, max-age=60");
   }
   return {

--- a/website/loaders/whitelistAssets.ts
+++ b/website/loaders/whitelistAssets.ts
@@ -1,9 +1,9 @@
 import { AppContext } from "../mod.ts";
 
 /**
- * @title Pages
+ * @title Whitelist Assets
  */
-export default function Pages(
+export default function WhitelistAssets(
   _props: unknown,
   _req: Request,
   ctx: AppContext,

--- a/website/loaders/whitelistAssets.ts
+++ b/website/loaders/whitelistAssets.ts
@@ -16,3 +16,11 @@ export default function WhitelistAssets(
     "disableProxy": ctx.disableProxy,
   };
 }
+
+export const cache = "stale-while-revalidate";
+
+export const cacheKey = (_props: unknown, req: Request, _ctx: AppContext) => {
+  const url = new URL(req.url);
+  url.pathname = "/live/invoke/website/loaders/whitelistAssets.ts";
+  return url.href;
+};

--- a/website/loaders/whitelistAssets.ts
+++ b/website/loaders/whitelistAssets.ts
@@ -11,6 +11,10 @@ export default function WhitelistAssets(
   "whitelistURLs": string[] | undefined;
   "disableProxy": boolean | undefined;
 } {
+  // Avoid cache on /live/invoke only
+  if (new URL(_req.url).pathname === ("/live/invoke/website/loaders/whitelistAssets.ts")) {
+    ctx.response.headers.set("Cache-Control", "public, max-age=60");
+  }
   return {
     "whitelistURLs": ctx.whilelistURLs,
     "disableProxy": ctx.disableProxy,

--- a/website/loaders/whitelistDomains.ts
+++ b/website/loaders/whitelistDomains.ts
@@ -7,6 +7,12 @@ export default function Pages(
   _props: unknown,
   _req: Request,
   ctx: AppContext,
-): string[] | undefined {
-  return ctx.whilelistDomains;
+): {
+  "whitelistURLs": string[] | undefined;
+  "disableProxy": boolean | undefined;
+} {
+  return {
+    "whitelistURLs": ctx.whilelistURLs,
+    "disableProxy": ctx.disableProxy,
+  };
 }

--- a/website/loaders/whitelistDomains.ts
+++ b/website/loaders/whitelistDomains.ts
@@ -1,0 +1,12 @@
+import { AppContext } from "../mod.ts";
+
+/**
+ * @title Pages
+ */
+export default function Pages(
+  _props: unknown,
+  _req: Request,
+  ctx: AppContext,
+): string[] | undefined {
+  return ctx.whilelistDomains;
+}

--- a/website/manifest.gen.ts
+++ b/website/manifest.gen.ts
@@ -30,6 +30,7 @@ import * as $$$9 from "./loaders/redirects.ts";
 import * as $$$10 from "./loaders/redirectsFromCsv.ts";
 import * as $$$11 from "./loaders/secret.ts";
 import * as $$$12 from "./loaders/secretString.ts";
+import * as $$$13 from "./loaders/whitelistAssets.ts";
 import * as $$$$$$$0 from "./matchers/always.ts";
 import * as $$$$$$$1 from "./matchers/cookie.ts";
 import * as $$$$$$$2 from "./matchers/cron.ts";
@@ -72,6 +73,7 @@ const manifest = {
     "website/loaders/redirectsFromCsv.ts": $$$10,
     "website/loaders/secret.ts": $$$11,
     "website/loaders/secretString.ts": $$$12,
+    "website/loaders/whitelistAssets.ts": $$$13,
   },
   "handlers": {
     "website/handlers/fresh.ts": $$$$0,

--- a/website/mod.ts
+++ b/website/mod.ts
@@ -143,7 +143,7 @@ export interface Props {
    */
   sendToClickHouse?: boolean;
 
-    /**
+  /**
    * @title Disable image/asset proxy for this site
    * @description Disable image/asset proxy for this site
    */
@@ -167,7 +167,9 @@ export default function App({ ...state }: Props): App<Manifest, Props> {
   return {
     state: {
       ...state,
-      whitelistPatterns: state.whilelistURLs?.map((pattern) => new URLPattern(pattern)),
+      whitelistPatterns: state.whilelistURLs?.map((pattern) =>
+        new URLPattern(pattern)
+      ),
     },
     manifest: {
       ...manifest,

--- a/website/mod.ts
+++ b/website/mod.ts
@@ -142,13 +142,33 @@ export interface Props {
    * @hide true
    */
   sendToClickHouse?: boolean;
+
+    /**
+   * @title Disable image/asset proxy for this site
+   * @description Disable image/asset proxy for this site
+   */
+  disableProxy?: boolean;
+
+  /**
+   * @title Whilelist URL Patterns
+   * @description Patterns that will be allowed to be proxied through images and assets (example: https://*.deco.cx/images/*). An empty array will allow all URLs.
+   */
+  whilelistURLs?: string[];
+
+  /**
+   * @hide
+   */
+  whitelistPatterns?: URLPattern[];
 }
 /**
  * @title Website
  */
 export default function App({ ...state }: Props): App<Manifest, Props> {
   return {
-    state,
+    state: {
+      ...state,
+      whitelistPatterns: state.whilelistURLs?.map((pattern) => new URLPattern(pattern)),
+    },
     manifest: {
       ...manifest,
       sections: {


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

- Enhanced control over resource proxying via `/image.ts` and `/assets.ts` routes.
  - Added `disableProxy` (boolean) to disable proxying entirely for a site.
  - Added `whitelistURLs` (array of URL/domain patterns) to limit which resources can be proxied.
    - If `whitelistURLs` is omitted and proxying is enabled, all sources will be allowed.
    - Changes to the whitelist may take up to 120 seconds to propagate.

These additions allow more flexible and fine-grained control over external image and font proxy behavior on a per-deployment basis (you may test locally or using an env var).