### PR TITLE
fix: add addressDistrict and tradeName fields

### DIFF
--- a/commerce/types.ts
+++ b/commerce/types.ts
@@ -592,6 +592,8 @@ export interface PostalAddress extends Omit<ContactPoint, "@type"> {
   addressLocality?: string;
   /** The region in which the locality is, and which is in the country. For example, California. */
   addressRegion?: string;
+  /** The district in which the locality is, and which is in the region. For example, San Francisco. */
+  addressDistrict?: string;
   /** The postal code. For example, 94043. */
   postalCode?: string;
   /** The street address. For example, 1600 Amphitheatre Pkwy. */

--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -1276,6 +1276,7 @@ export const toPostalAddress = (address: Address): PostalAddress => {
     addressCountry: address.country,
     addressLocality: address.city,
     addressRegion: address.state,
+    addressDistrict: address.neighborhood,
     postalCode: address.postalCode,
     streetAddress: address.street,
     name: address.addressName || undefined,

--- a/vtex/utils/types.ts
+++ b/vtex/utils/types.ts
@@ -1717,6 +1717,7 @@ export interface Profile {
   customFields?: Maybe<ProfileCustomField[]>;
   passwordLastUpdate?: Maybe<string>;
   pii?: Maybe<boolean>;
+  tradeName?: Maybe<string>;
 }
 
 export interface ProfileInput {


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

It corrects the Profile typing related to an info that exists in the data. And it adds the “neighborhood” value that comes from the vtex API, but isn't passed on in the transform


## Evidence

![image](https://github.com/user-attachments/assets/afb65755-672f-4907-b118-7db84cdf322b)
