### PR TITLE
fix: reverting vtex app prop that existed and was removed by mistake

### DIFF
--- a/vtex/mod.ts
+++ b/vtex/mod.ts
@@ -74,7 +74,6 @@ export interface Props {
    * @default false
    */
   setRefreshToken?: boolean;
-  /**
   defaultSegment?: SegmentCulture;
   usePortalSitemap?: boolean;
   /**


### PR DESCRIPTION
Props exist and are used, and were commented on by mistake in this [pr](https://github.com/deco-cx/apps/commit/3bf2b1d60fd1a21ae9c0694db9eb5fc1020b1d96)


<img width="429" height="572" alt="image" src="https://github.com/user-attachments/assets/1f1b0714-bc77-43c1-a87d-ce20d8e4c80f" />
<img width="429" height="572" alt="image" src="https://github.com/user-attachments/assets/b6bc2645-60e6-4476-b8ae-227d75e1f944" />
