### PR TITLE
remove productList call

### DIFF
--- a/airtable/utils/ui-templates/selection-page.template.html
+++ b/airtable/utils/ui-templates/selection-page.template.html
@@ -12,11 +12,7 @@
 
       body {
         font-family:
-          Inter,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          Roboto,
+          Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
           sans-serif;
         margin: 0;
         padding: 20px;
@@ -94,11 +90,7 @@
         text-align: left;
         margin: 0 16px;
         font-family:
-          Inter,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          Roboto,
+          Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
           sans-serif;
       }
 
@@ -156,11 +148,7 @@
         font-size: 14px;
         text-align: left;
         font-family:
-          Inter,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          Roboto,
+          Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
           sans-serif;
       }
 
@@ -195,11 +183,7 @@
         color: #f5f5f4;
         transition: border-color 0.2s;
         font-family:
-          Inter,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          Roboto,
+          Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
           sans-serif;
       }
 
@@ -352,11 +336,7 @@
         font-size: 14px;
         color: #f5f5f4;
         font-family:
-          Inter,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          Roboto,
+          Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
           sans-serif;
       }
 
@@ -491,11 +471,7 @@
         font-size: 14px;
         color: #f5f5f4;
         font-family:
-          Inter,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          Roboto,
+          Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
           sans-serif;
       }
 
@@ -510,11 +486,7 @@
         color: #737373;
         font-size: 14px;
         font-family:
-          Inter,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          Roboto,
+          Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
           sans-serif;
       }
 
@@ -547,11 +519,7 @@
         align-items: center;
         justify-content: center;
         font-family:
-          Inter,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          Roboto,
+          Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
           sans-serif;
       }
 

--- a/vtex/loaders/legacy/relatedProductsLoader.ts
+++ b/vtex/loaders/legacy/relatedProductsLoader.ts
@@ -99,15 +99,18 @@ async function loader(
     p.offers?.offers.find((o) =>
       o.availability === "https://schema.org/InStock"
     );
-  
-  if(ctx.advancedConfigs?.doNotFetchVariantsForRelatedProducts) {
-    const toProducts = products.slice(0, count).map((p) => 
+
+  if (ctx.advancedConfigs?.doNotFetchVariantsForRelatedProducts) {
+    const toProducts = products.slice(0, count).map((p) =>
       toProduct(p, p.items[0], 0, {
         baseUrl: req.url,
         priceCurrency: segment?.payload?.currencyCode ?? "BRL",
       })
     );
-    return toProducts.filter(inStock);
+    if (hideUnavailableItems) {
+      return toProducts.filter(inStock);
+    }
+    return toProducts;
   }
 
   // unique Ids
@@ -145,7 +148,6 @@ async function loader(
     });
 
   if (hideUnavailableItems && relatedProducts) {
-
     return relatedProducts.filter(inStock);
   }
 

--- a/vtex/mod.ts
+++ b/vtex/mod.ts
@@ -84,7 +84,7 @@ export interface Props {
 
   advancedConfigs?: {
     doNotFetchVariantsForRelatedProducts?: boolean;
-  }
+  };
 }
 export const color = 0xf71963;
 /**


### PR DESCRIPTION
Add option to skip VTEX calls on Product List route

It was identified that the main difference between the Product List and Direct Related Products routes is that Product List returns all variants of similar products, while Direct Related Products returns only one. In some cases, having all variants is unnecessary, making the VTEC call redundant.

This change adds an option to skip the VTEX call, improving performance when full variant data is not needed.