### PR TITLE
feat(search): add support for custom search application ID

### DIFF
--- a/google-sites/loaders/searchContent.ts
+++ b/google-sites/loaders/searchContent.ts
@@ -7,7 +7,7 @@ import { DOMParser } from "https://deno.land/x/deno_dom@v0.1.43/deno-dom-wasm.ts
 export interface Props {
   /**
    * @title URL pública do Google Sites
-   * @description URL completa do site (ex.: https://sites.google.com/view/<slug>/home)
+   * @description URL completa do site
    */
   siteUrl?: string;
   /**
@@ -26,6 +26,11 @@ export interface Props {
    * @default 10
    */
   pageSize?: number;
+  /**
+   * @title Search Application ID (opcional)
+   * @description Caso o ID do contexto esteja ausente/inválido, você pode informar aqui (ex.: searchapplications/1234567890). Se não informado, tentaremos o valor 'default'.
+   */
+  searchApplicationId?: string;
 }
 
 /**
@@ -156,10 +161,7 @@ function cleanHtmlAndGetText(html: string): string {
           const parent = (el as unknown as Element).parentNode;
           try {
             if (parent && (doc as unknown as Document).createTextNode) {
-              parent.insertBefore(
-                (doc as unknown as Document).createTextNode(" "),
-                el as unknown as Node,
-              );
+              parent.insertBefore((doc as unknown as Document).createTextNode(" "), el as unknown as Node);
             }
           } catch { /* ignore */ }
           ((el as unknown) as Element).remove?.();
@@ -237,7 +239,7 @@ async function fetchWithTimeout(
   const startedAt = Date.now();
   try {
     const res = await fetch(url, { ...opts, signal: controller.signal });
-
+ 
     return res;
   } catch (err) {
     const duration = Date.now() - startedAt;
@@ -596,7 +598,9 @@ async function searchWithCloudSearch(
   siteUrl?: string,
   start: number = 0,
   pageSize: number = 10,
-): Promise<{ results: SearchResult[]; total: number; unavailable?: boolean }> {
+  // Novo: permitir override vindo do prompt do loader
+  overrideSearchApplicationId?: string,
+): Promise<{ results: SearchResult[]; total: number; unavailable?: boolean; info?: string }> {
   try {
     const body: {
       query: string;
@@ -607,10 +611,38 @@ async function searchWithCloudSearch(
           name: string;
         };
       }>;
+      requestOptions?: {
+        searchApplicationId?: string;
+        timeZone?: string;
+      };
     } = {
       query,
       pageSize,
       start,
+    };
+
+    // Determinar o ID efetivo seguindo a prioridade: contexto -> prompt -> 'default'
+    const ctxSearchApplicationId =
+      (ctx as unknown as { searchApplicationId?: string })?.searchApplicationId;
+
+    let effectiveSearchApplicationId =
+      ctxSearchApplicationId && ctxSearchApplicationId.trim()
+        ? ctxSearchApplicationId.trim()
+        : undefined;
+
+    if (!effectiveSearchApplicationId) {
+      if (overrideSearchApplicationId && overrideSearchApplicationId.trim()) {
+        effectiveSearchApplicationId = overrideSearchApplicationId.trim();
+      } else {
+        // fallback final requerido
+        effectiveSearchApplicationId = "default";
+      }
+    }
+
+    // Define requestOptions com o ID efetivo e fuso horário
+    body.requestOptions = {
+      searchApplicationId: effectiveSearchApplicationId,
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     };
 
     // Se temos URL do site, adicionar restrição de domínio
@@ -633,14 +665,40 @@ async function searchWithCloudSearch(
         message?: string;
         status?: string;
       };
+
+      // Mensagem padrão de orientação
+      const infoMsg =
+        "Não foi possível usar o Google Cloud Search porque o Search Application ID está ausente ou inválido. " +
+        "Peça ao time de TI/Admin do Google Workspace para enviar esse ID (Admin Console > Cloud Search > Search applications). " +
+        "Você pode informar este valor no prompt deste loader usando o campo searchApplicationId: 'searchapplications/1234567890' " +
+        "ou configurar no app. Observação: tentamos automaticamente o valor 'default' quando o ID não é informado.";
+
       // Cloud Search não disponível para contas pessoais (Google Workspace required)
       if (
         err.code === 403 &&
         (err.message?.includes("only available to G Suite users") ||
           err.status === "PERMISSION_DENIED")
       ) {
-        return { results: [], total: 0, unavailable: true };
+        return { results: [], total: 0, unavailable: true, info: infoMsg };
       }
+
+      // Tratar erros de ID faltando/ inválido / não encontrado
+      const msg = (err.message || "").toLowerCase();
+      const isMissingId =
+        err.code === 400 &&
+        (msg.includes("search application id is required") ||
+          msg.includes("required for the request"));
+      const isInvalidOrNotFound =
+        (err.code === 400 || err.code === 404) &&
+        (msg.includes("invalid") ||
+          msg.includes("not found") ||
+          msg.includes("search application"));
+
+      if (isMissingId || isInvalidOrNotFound) {
+        console.warn("[CloudSearch] ID inválido/ausente:", err.message);
+        return { results: [], total: 0, unavailable: true, info: infoMsg };
+      }
+
       throw new Error(`Cloud Search API Error: ${err.message}`);
     }
 
@@ -655,7 +713,7 @@ async function searchWithCloudSearch(
     return { results, total };
   } catch (error) {
     console.error("Cloud Search Error:", error);
-    return { results: [], total: 0 };
+    return { results: [], total: 0, unavailable: true };
   }
 }
 
@@ -674,9 +732,11 @@ const loader = async (
   pageSize: number;
   info?: string;
 }> => {
-  const { siteUrl, query, page = 1, pageSize = 10 } = props;
+  const { siteUrl, query, page = 1, pageSize = 10, searchApplicationId } = props;
 
   const siteUrlNorm = normalize(siteUrl);
+
+  console.log("siteUrlNorm", siteUrlNorm);
 
   // Exigir pelo menos um identificador ou termo de busca
   if (!query.trim()) {
@@ -690,6 +750,7 @@ const loader = async (
   }
 
   const start = (page - 1) * pageSize;
+  
   let searchResults: {
     results: SearchResult[];
     total: number;
@@ -697,23 +758,33 @@ const loader = async (
   };
   let info: string | undefined;
 
-  // Tentar primeiro com Custom Search API
-  searchResults = await searchWithCustomSearch(
-    query,
-    siteUrlNorm || "",
-    start + 1,
-    pageSize,
-  );
-
-  if ("invalidSite" in searchResults && searchResults.invalidSite) {
-    return {
+  if (siteUrlNorm=== ""){
+    searchResults = {
       results: [],
       total: 0,
-      page,
-      pageSize,
-      info: "Site inválido. Verifique se a URL está correta.",
+      isPrivate: true
     };
+  }else{
+      // Tentar primeiro com Custom Search API
+    searchResults = await searchWithCustomSearch(
+      query,
+      siteUrlNorm || "",
+      start + 1,
+      pageSize,
+    );
+
+    if ("invalidSite" in searchResults && searchResults.invalidSite) {
+      return {
+        results: [],
+        total: 0,
+        page,
+        pageSize,
+        info: "Site inválido. Verifique se a URL está correta.",
+      };
+    }
   }
+
+  
 
   // Se Custom Search indicar site privado ou não retornar resultados, tentar Cloud Search
   if (
@@ -726,6 +797,7 @@ const loader = async (
       siteUrlNorm,
       start, // Cloud Search usa 0-based indexing
       pageSize,
+      searchApplicationId, // Novo: override vindo do prompt do loader
     );
 
     searchResults = {
@@ -735,6 +807,7 @@ const loader = async (
 
     if (cloudSearchResults.unavailable) {
       info =
+        cloudSearchResults.info ??
         "Cloud Search API não está disponível para contas pessoais. É necessário usar uma conta Google Workspace com o serviço Cloud Search habilitado e permissões de consulta.";
     } else if (cloudSearchResults.results.length > 0) {
       info = "Resultados obtidos via Cloud Search API (site privado)";

--- a/google-sites/mod.ts
+++ b/google-sites/mod.ts
@@ -40,6 +40,11 @@ export interface Props {
   tokens?: OAuthTokens;
   clientSecret?: string;
   clientId?: string;
+  /**
+   * @title Search Application ID (opcional)
+   * @description ID do aplicativo de pesquisa do Google Cloud Search da sua organização. Caso não seja informado, será exibida uma mensagem explicando como obtê-lo com o TI.
+   */
+  searchApplicationId?: string;
 }
 
 export interface State extends Props {


### PR DESCRIPTION
Add optional searchApplicationId parameter to allow overriding the default Google Cloud Search application ID. Improve error handling and user guidance when ID is missing or invalid. The ID can now be provided either through the context or directly in the loader prompt.

Also includes:
- Better error messages for missing/invalid search application IDs
- Fallback to 'default' ID when none is provided
- Timezone support in search requests
- Improved handling of private sites