### PR TITLE
fix: cache-wake-filters

### DIFF
--- a/wake/loaders/productListingPage.ts
+++ b/wake/loaders/productListingPage.ts
@@ -373,7 +373,7 @@ export const cacheKey = (props: Props, req: Request, _ctx: AppContext) => {
   // Add any filter parameters
   url.searchParams.forEach((value, key) => {
     if (
-      key.startsWith("filter.") || key === "q" || key === "sort" ||
+      key === "filtro" || key === "q" || key === "sort" ||
       key === "page"
     ) {
       params.append(key, value);


### PR DESCRIPTION
The cache code is not picking up the wake filter pattern but the vtex filter pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Performance
  - Improved caching behavior on product listing pages by narrowing which URL parameters affect cache generation (now limited to search, sorting, pagination, and a specific filter). Users may see faster, more consistent page loads and fewer unnecessary cache refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->