### PR TITLE
feat(seo): add og:url metatag

### DIFF
--- a/website/components/Seo.tsx
+++ b/website/components/Seo.tsx
@@ -81,6 +81,7 @@ function Component({
       <meta property="og:description" content={description} />
       <meta property="og:type" content={type} />
       <meta property="og:image" content={image} />
+      {canonical && <meta property="og:url" content={canonical} />}
 
       {/* Link tags */}
       {canonical && <link rel="canonical" href={canonical} />}


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?

This contribution adds the og:url meta tag to all relevant pages (product, category, and institutional). The tag is aligned with the canonical URL of each page and always points to the www domain.

## Why is this important?
- Ensures that shared links on social platforms (WhatsApp, LinkedIn, Twitter/X, etc.) always resolve to the canonical www URL, avoiding issues with parameters, staging, or proxied domains like secure..
- Consolidates engagement and traffic metrics into a single URL, which improves attribution and SEO consistency.
- Provides a more reliable and professional preview experience when customers share links, reinforcing brand trust and click-through rates.
