### PR TITLE
fix: OneDollarStats script type module

### DIFF
--- a/website/components/OneDollarStats.tsx
+++ b/website/components/OneDollarStats.tsx
@@ -70,7 +70,6 @@ const oneDollarSnippet = () => {
     }
     const values = { ...props };
     for (const key in params) {
-      // @ts-expect-error somehow typescript bugs
       const value = params[key];
       if (value !== null && value !== undefined) {
         values[key] = truncate(
@@ -101,6 +100,7 @@ function Component({ collectorAddress, staticScriptUrl }: Props) {
         data-autocollect="false"
         data-hash-routing="true"
         data-url={collector}
+        type="module"
         src={`/live/invoke/website/loaders/analyticsScript.ts?url=${staticScript}`}
       />
       <script defer src={useScriptAsDataURI(oneDollarSnippet)} />


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?
Fixes analyticsScript script to not be render blocking request at pagespeed insight reports.

before: https://pagespeed.web.dev/analysis/https-storefront-deco-site/iin3vqwbni?form_factor=mobile
<img width="971" height="279" alt="image" src="https://github.com/user-attachments/assets/bdcfd9f1-328a-4a07-bcab-2a4362f54b66" />

after: https://pagespeed.web.dev/analysis/https-sites-storefront--m5kd1f-decocdn-com/lhres7nu3v?form_factor=mobile
<img width="968" height="307" alt="image" src="https://github.com/user-attachments/assets/a58f4aec-2aba-4c6e-aa5a-880bbf5965a0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated analytics script to use modern module loading, improving reliability and potential page performance.
- Chores
  - Strengthened type enforcement in parameter handling by removing a suppression, enabling broader compile-time checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->