### PR TITLE
Hubspot: Retrieve thread history

### DIFF
--- a/hubspot/loaders/conversations/getTheadHistory.ts
+++ b/hubspot/loaders/conversations/getTheadHistory.ts
@@ -1,0 +1,140 @@
+import type { AppContext } from "../../mod.ts";
+import { HubSpotClient } from "../../utils/client.ts";
+
+export interface Props {
+  /**
+   * @title Thread ID
+   * @description The ID of the conversation thread to retrieve message history for
+   */
+  threadId: string;
+
+  /**
+   * @title Limit
+   * @description Maximum number of messages to return (default: 20, max: 100)
+   */
+  limit?: number;
+
+  /**
+   * @title After
+   * @description Cursor for pagination - use the 'after' value from the previous response
+   */
+  after?: string;
+}
+
+export interface DeliveryIdentifier {
+  type: string;
+  value: string;
+}
+
+export interface Sender {
+  actorId: string;
+  name?: string;
+  senderField?: string;
+  deliveryIdentifier?: DeliveryIdentifier;
+}
+
+export interface Recipient {
+  actorId?: string;
+  name?: string;
+  recipientField?: string;
+  deliveryIdentifier?: DeliveryIdentifier;
+}
+
+export interface Client {
+  clientType: string;
+  integrationAppId?: number;
+}
+
+export interface Attachment {
+  fileUsageType?: string;
+  name: string;
+  type: string;
+  url: string;
+  fileId?: string;
+}
+
+export interface MessageStatus {
+  statusType: string;
+  failureDetails?: {
+    errorMessageTokens?: Record<string, unknown>;
+    errorMessage?: string;
+  };
+}
+
+export interface Message {
+  id: string;
+  conversationsThreadId: string;
+  createdAt: string;
+  updatedAt?: string;
+  createdBy: string;
+  client: Client;
+  senders: Sender[];
+  recipients: Recipient[];
+  archived: boolean;
+  text?: string;
+  richText?: string;
+  attachments: Attachment[];
+  subject?: string;
+  truncationStatus: string;
+  inReplyToId?: string;
+  status?: MessageStatus;
+  direction?: string;
+  channelId?: string;
+  channelAccountId?: string;
+  type: string;
+  newStatus?: string;
+}
+
+export interface ThreadHistoryResponse {
+  paging: {
+    next?: {
+      link: string;
+      after: string;
+    };
+  };
+  results: Message[];
+}
+
+/**
+ * @title Get Thread Message History
+ * @description Retrieve the message history for a specific conversation thread from HubSpot Conversations API
+ */
+export default async function getThreadHistory(
+  props: Props,
+  _req: Request,
+  ctx: AppContext,
+): Promise<ThreadHistoryResponse> {
+  const { threadId, limit = 20, after } = props;
+
+  try {
+    const client = new HubSpotClient(ctx);
+
+    const searchParams: Record<
+      string,
+      string | number | boolean | undefined
+    > = {};
+
+    if (limit) {
+      searchParams.limit = Math.min(limit, 100);
+    }
+    if (after) {
+      searchParams.after = after;
+    }
+
+    const response = await client.get<ThreadHistoryResponse>(
+      `/conversations/v3/conversations/threads/${threadId}/messages`,
+      searchParams,
+    );
+
+    return {
+      paging: response.paging || { next: undefined },
+      results: response.results || [],
+    };
+  } catch (error) {
+    console.error("Error fetching thread message history:", error);
+    return {
+      paging: { next: undefined },
+      results: [],
+    };
+  }
+}

--- a/hubspot/manifest.gen.ts
+++ b/hubspot/manifest.gen.ts
@@ -95,6 +95,7 @@ import * as $$$53 from "./loaders/settings/getAccount.ts";
 import * as $$$54 from "./loaders/settings/getBusinessUnits.ts";
 import * as $$$55 from "./loaders/settings/getUsers.ts";
 import * as $$$56 from "./loaders/webhooks/getWebhooks.ts";
+import * as $$$57 from "./loaders/conversations/getTheadHistory.ts";
 
 const manifest = {
   "loaders": {
@@ -155,6 +156,7 @@ const manifest = {
     "hubspot/loaders/settings/getBusinessUnits.ts": $$$54,
     "hubspot/loaders/settings/getUsers.ts": $$$55,
     "hubspot/loaders/webhooks/getWebhooks.ts": $$$56,
+    "hubspot/loaders/conversations/getTheadHistory.ts": $$$57,
   },
   "actions": {
     "hubspot/actions/automation/enrollInWorkflow.ts": $$$$$$$$$0,


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Please provide a brief description of the changes or enhancements you are proposing in this pull request.

## Issue Link

Please link to the relevant issue that this pull request addresses:

- Issue: [#ISSUE_NUMBER](link_to_issue)

## Loom Video

> Record a quick screencast describing your changes to help the team understand and review your contribution. This will greatly assist in the review process.

## Demonstration Link

> Provide a link to a branch or environment where this pull request can be tested and seen in action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - View message history for conversation threads in HubSpot-connected conversations with pagination and configurable page size (up to 100).
  - Message details include senders/recipients, text/rich text, attachments, statuses, and timestamps for richer context.
  - Graceful behavior on errors: returns empty results when data is unavailable, ensuring a stable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->