### PR TITLE
fix(website): Image/Source early hints params

### DIFF
--- a/website/components/Picture.tsx
+++ b/website/components/Picture.tsx
@@ -4,6 +4,7 @@ import { ComponentChildren, createContext, JSX } from "preact";
 import { Head, IS_BROWSER } from "$fresh/runtime.ts";
 
 import {
+  FACTORS,
   getEarlyHintFromSrcProps,
   getSrcSet,
   type SetEarlyHint,
@@ -36,7 +37,14 @@ export const Source = forwardRef<HTMLSourceElement, SourceProps>(
   (props, ref) => {
     const { preload } = useContext(Context);
 
-    const srcSet = getSrcSet(props.src, props.width, props.height);
+    const shouldSetEarlyHint = !!props.setEarlyHint && preload;
+    const srcSet = getSrcSet(
+      props.src,
+      props.width,
+      props.height,
+      undefined,
+      shouldSetEarlyHint ? FACTORS.slice(-1) : FACTORS,
+    );
     const linkProps = {
       imagesrcset: srcSet,
       imagesizes: props.sizes,
@@ -49,9 +57,14 @@ export const Source = forwardRef<HTMLSourceElement, SourceProps>(
       media: string | undefined;
     };
 
-    if (!IS_BROWSER && preload && linkProps && props.setEarlyHint) {
-      props.setEarlyHint(
-        getEarlyHintFromSrcProps({ ...linkProps, src: props.src }),
+    if (!IS_BROWSER && shouldSetEarlyHint) {
+      props.setEarlyHint!(
+        getEarlyHintFromSrcProps({
+          width: props.width,
+          height: props.height,
+          fetchpriority: props.fetchPriority,
+          src: props.src,
+        }),
       );
     }
 


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Fixed early hint to set only one image srcset and remove invalid params.
Example: https://github.com/deco-sites/storefront/pull/223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Conditional early-hint support for image preloading in non-browser environments.
  * Optimized responsive image generation for better loading behavior.

* Improvements
  * Faster perceived load times through simplified, more accurate preload hint construction.

* Refactor
  * Standardized image link property names (imageSrcSet, imageSizes, fetchPriority) for consistency.
  * Streamlined internal logic to compute optimized image URLs and responsive sets based on context.

* Tests
  * None.

* Documentation
  * None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->