### PR TITLE
fix(pinecone-assistant): update PINECONE_API_VERSION

### DIFF
--- a/pinecone-assistant/mod.ts
+++ b/pinecone-assistant/mod.ts
@@ -28,6 +28,8 @@ export interface State extends Props {
 
 export type AppContext = FnContext<State & McpContext<Props>, Manifest>;
 
+const PINECONE_API_VERSION = "2025-10";
+
 /**
  * @title Pinecone Assistant
  * @appName pinecone-assistant
@@ -48,7 +50,7 @@ export default function App(
     base: props.host,
     headers: new Headers({
       "Api-Key": apiKey ?? "",
-      "X-Pinecone-API-Version": "2025-01-01",
+      "X-Pinecone-API-Version": PINECONE_API_VERSION,
     }),
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Pinecone integration to use the 2025-10 API version for all requests.
  * Standardized the API version value via a single module constant to ensure consistency across requests.
  * No changes to public APIs or types; behavior remains the same for end users.
  * Transparent update—no action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->