### PR TITLE
 Fix(RESEND): Handle apiKey object processing in Resend app

### DIFF
--- a/resend/mod.ts
+++ b/resend/mod.ts
@@ -2,7 +2,9 @@ import { Markdown } from "../decohub/components/Markdown.tsx";
 import { fetchSafe } from "../utils/fetch.ts";
 import { createHttpClient } from "../utils/http.ts";
 import { PreviewContainer } from "../utils/preview.tsx";
-import type { Secret } from "../website/loaders/secret.ts";
+import Secret, {
+  type Props as SecretProps,
+} from "../website/loaders/secret.ts";
 import manifest, { Manifest } from "./manifest.gen.ts";
 import { ResendApi } from "./utils/client.ts";
 import { type App, type AppContext as AC } from "@deco/deco";
@@ -12,7 +14,7 @@ export interface EmailFrom {
 }
 export interface Props {
   /**@title API KEY Resend  */
-  apiKey?: Secret;
+  apiKey?: SecretProps;
   /**
    * @title Sender Options | Default
    */
@@ -36,7 +38,7 @@ export interface State extends Props {
  * @description Send transactional or marketing emails with a reliable delivery API.
  * @logo https://assets.decocache.com/mcp/932e4c3a-6045-40af-9fd1-42894bdd138e/Resend.svg
  */
-export default function App({
+export default async function App({
   apiKey,
   emailFrom = {
     name: "Contact",
@@ -44,10 +46,9 @@ export default function App({
   },
   emailTo,
   subject = "Contato via app resend",
-}: State): App<Manifest, State> {
-  const apiKeyToken = typeof apiKey === "string"
-    ? apiKey
-    : apiKey?.get?.() ?? "";
+}: State): Promise<App<Manifest, State>> {
+  const processedApiKey = apiKey ? await Secret(apiKey) : null;
+  const apiKeyToken = processedApiKey?.get() ?? "";
   const apiWrite = createHttpClient<ResendApi>({
     base: "https://api.resend.com",
     fetcher: fetchSafe,
@@ -69,7 +70,7 @@ export default function App({
   };
   return app;
 }
-export type AppContext = AC<ReturnType<typeof App>>;
+export type AppContext = AC<App<Manifest, State>>;
 export const preview = async () => {
   const markdownContent = await Markdown(
     new URL("./README.md", import.meta.url).href,


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

The apiKey in Resend was being received as an object with encrypted and name properties, but without the required get() method to extract the token. This caused:

- apiKey?.get returned undefined
- apiKeyToken remained empty (length: 0)
- Authentication failure with Resend API

## Issue Link

Don't have, but reporting in ![Discord](https://discord.com/channels/985687648595243068/1425926352271577170)



## Test
<img width="951" height="162" alt="Captura de tela 2025-10-09 181447" src="https://github.com/user-attachments/assets/04b5a03a-a83c-445d-95d5-2bc2c536f8d1" />

Testing with my local app brought this result



## Solution
Implemented safe apiKey processing:

```js
const processedApiKey = apiKey ? await Secret(apiKey) : null;
const apiKeyToken = processedApiKey?.get() ?? "";

```

## Changes

- Added check if apiKey exists before processing
- Used Secret() loader to convert object to processable format
- Optional chaining (?.get()) for safe method access
- Fallback to empty string with nullish coalescing (?? "")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * App startup is now asynchronous to support secure, runtime resolution of API keys.
  * Improved integration with secret managers for enhanced security and reliability.
  * Updated internal context to align with the new initialization model.

* **Impact**
  * No UI changes. Users should experience more reliable authentication and startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->