### PR TITLE
[fix: Slack] do not lock streams

### DIFF
--- a/slack/actions/deco-chat/channels/invoke.ts
+++ b/slack/actions/deco-chat/channels/invoke.ts
@@ -86,10 +86,6 @@ export default async function invoke(
       let lastMessage;
       console.log("starting to iterate over stream");
 
-      // Try to get the async iterator explicitly
-      const iterator = stream[Symbol.asyncIterator]();
-      console.log("got iterator:", iterator);
-
       try {
         for await (const uiMessage of stream) {
           console.log("slack uiMessage", uiMessage);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing feature changes in this release.
- Refactor
  - Streamed chat responses now use native async iteration, simplifying handling and improving reliability. This helps prevent intermittent iterator-related issues and makes chat stream processing more consistent across environments.
- Chores
  - Removed unnecessary debug logging during streaming to reduce noise, making it easier to monitor live chats without extraneous entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->