### PR TITLE
Google Drive: search documents fix

### DIFF
--- a/google-drive/utils/query.ts
+++ b/google-drive/utils/query.ts
@@ -1,0 +1,66 @@
+import { QueryCondition } from "./types.ts";
+
+/**
+ * Builds a Google Drive API query string from an array of query conditions.
+ * 
+ * @param queries Array of query conditions
+ * @returns Formatted query string for Google Drive API
+ * 
+ * @example
+ * ```typescript
+ * const queries = [
+ *   { term: "trashed", operator: "=", value: "false", combinator: "and" },
+ *   { term: "mimeType", operator: "contains", value: "image/" }
+ * ];
+ * buildQueryString(queries); // Returns: "trashed = false and mimeType contains 'image/'"
+ * ```
+ */
+export function buildQueryString(queries: QueryCondition[]): string {
+  if (!queries || queries.length === 0) {
+    throw new Error("At least one query condition is required");
+  }
+
+  return queries.map((condition, index) => {
+    const { term, operator, value, combinator, negate } = condition;
+
+    // Build the basic condition
+    let conditionStr = "";
+
+    // Special handling for 'in' operator - value goes in quotes for certain terms
+    if (operator === "in") {
+      // For 'in' operator with collections like owners, writers, readers
+      // Format: 'value' in term
+      conditionStr = `'${value}' ${operator} ${term}`;
+    } else if (operator === "has") {
+      // For 'has' operator with properties/appProperties
+      // Value should already be formatted like: { key='dept' and value='sales' }
+      conditionStr = `${term} ${operator} ${value}`;
+    } else {
+      // Standard format: term operator 'value'
+      // Check if value needs quotes (strings, dates) or not (booleans, numbers in some cases)
+      const needsQuotes = !["true", "false"].includes(value.toLowerCase()) &&
+        isNaN(Number(value));
+
+      const formattedValue = needsQuotes ? `'${value}'` : value;
+      conditionStr = `${term} ${operator} ${formattedValue}`;
+    }
+
+    // Apply negation if specified
+    if (negate) {
+      conditionStr = `not ${conditionStr}`;
+    }
+
+    // Add combinator if not the last condition
+    if (index < queries.length - 1) {
+      if (!combinator) {
+        throw new Error(
+          `Combinator is required for condition at index ${index} (not the last condition)`,
+        );
+      }
+      conditionStr += ` ${combinator}`;
+    }
+
+    return conditionStr;
+  }).join(" ");
+}
+

--- a/google-drive/utils/types.ts
+++ b/google-drive/utils/types.ts
@@ -79,9 +79,170 @@ export interface CopyFileParams {
   parents?: string[];
 }
 
+/**
+ * Query term (field) to filter by
+ */
+export type QueryTerm =
+  | "name" // File name
+  | "fullText" // Full text search in content
+  | "mimeType" // MIME type of the file
+  | "modifiedTime" // Last modified date
+  | "createdTime" // Creation date
+  | "viewedByMeTime" // Last viewed date
+  | "sharedWithMeTime" // Date shared with me
+  | "trashed" // Whether in trash
+  | "starred" // Whether starred
+  | "parents" // Parent folder IDs
+  | "owners" // File owners
+  | "writers" // Users with write access
+  | "readers" // Users with read access
+  | "sharedWithMe" // Files shared with me
+  | "properties" // Custom properties
+  | "appProperties" // App-specific properties
+  | "visibility" // File visibility
+  | "orgUnitId"; // Organization unit
+
+/**
+ * Query operator for comparisons
+ */
+export type QueryOperator =
+  | "=" // Exact match
+  | "!=" // Not equal
+  | "<" // Less than (dates, numbers)
+  | "<=" // Less than or equal
+  | ">" // Greater than (dates, numbers)
+  | ">=" // Greater than or equal
+  | "contains" // String contains
+  | "in" // Value in collection
+  | "has"; // Has property (for properties/appProperties)
+
+/**
+ * Logical combinator for joining conditions
+ */
+export type QueryCombinator = "and" | "or";
+
+/**
+ * A single query condition
+ */
+export interface QueryCondition {
+  /**
+   * The field to filter by (e.g., 'name', 'mimeType', 'trashed')
+   */
+  term: QueryTerm;
+  
+  /**
+   * The comparison operator (e.g., '=', 'contains', '>', 'in')
+   */
+  operator: QueryOperator;
+  
+  /**
+   * The value to compare against.
+   * - For strings: use quotes in the value if needed (e.g., 'hello')
+   * - For dates: ISO 8601 format (e.g., '2024-01-01T12:00:00')
+   * - For booleans: 'true' or 'false'
+   * - For 'in' operator: the collection item (e.g., 'me', 'user@example.com')
+   * - For 'has' operator (properties): object like "{ key='dept' and value='sales' }"
+   */
+  value: string;
+  
+  /**
+   * How to combine with the next condition.
+   * - 'and': Both conditions must be true
+   * - 'or': Either condition must be true
+   * 
+   * Omit for the last condition in the array.
+   */
+  combinator?: QueryCombinator;
+  
+  /**
+   * If true, negates this condition with 'not'.
+   * @default false
+   */
+  negate?: boolean;
+}
+
 export interface SearchFilesParams {
-  query: string;
+  /**
+   * Array of query conditions to filter files.
+   * Each condition specifies a term, operator, value, and optional combinator.
+   * 
+   * Examples:
+   * ```typescript
+   * // Search for non-trashed image files
+   * queries: [
+   *   { term: "trashed", operator: "=", value: "false", combinator: "and" },
+   *   { term: "mimeType", operator: "contains", value: "image/" }
+   * ]
+   * 
+   * // Search for files named "hello" or "goodbye"
+   * queries: [
+   *   { term: "name", operator: "=", value: "hello", combinator: "or" },
+   *   { term: "name", operator: "=", value: "goodbye" }
+   * ]
+   * 
+   * // Search for Google Docs I own
+   * queries: [
+   *   { term: "mimeType", operator: "=", value: "application/vnd.google-apps.document", combinator: "and" },
+   *   { term: "owners", operator: "in", value: "me" }
+   * ]
+   * 
+   * // Search in specific folder
+   * queries: [
+   *   { term: "parents", operator: "in", value: "FOLDER_ID_HERE" }
+   * ]
+   * 
+   * // Files modified after date
+   * queries: [
+   *   { term: "modifiedTime", operator: ">", value: "2024-01-01T12:00:00" }
+   * ]
+   * ```
+   * 
+   * @see https://developers.google.com/drive/api/guides/search-files
+   */
+  queries: QueryCondition[];
+  
+  /**
+   * Maximum number of files to return per page (1-1000).
+   * @default 100
+   */
   pageSize?: number;
+  
+  /**
+   * Token for retrieving the next page of results.
+   */
   pageToken?: string;
+  
+  /**
+   * Selector specifying which fields to include in the response.
+   * @default "nextPageToken, files(id, name, mimeType, modifiedTime, size, webViewLink)"
+   */
   fields?: string;
+  
+  /**
+   * Comma-separated list of spaces to query within.
+   * Supported values: 'drive', 'appDataFolder', 'photos'
+   * @default "drive"
+   */
+  spaces?: string;
+  
+  /**
+   * Bodies of items (files/documents) to which the query applies.
+   * Supported values: 'user', 'domain', 'drive', 'allDrives'
+   * @default "user"
+   */
+  corpora?: string;
+  
+  /**
+   * Sort order for the returned files.
+   * Examples: 'createdTime', 'folder', 'modifiedByMeTime', 'modifiedTime', 
+   * 'name', 'quotaBytesUsed', 'recency', 'sharedWithMeTime', 'starred', 'viewedByMeTime'
+   * Add 'desc' suffix for descending order: 'modifiedTime desc'
+   */
+  orderBy?: string;
+  
+  /**
+   * Whether to include items from all drives (Team Drives) in results.
+   * @default false
+   */
+  includeItemsFromAllDrives?: boolean;
 }


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Please provide a brief description of the changes or enhancements you are proposing in this pull request.

## Issue Link

Please link to the relevant issue that this pull request addresses:

- Issue: [#ISSUE_NUMBER](link_to_issue)

## Loom Video

> Record a quick screencast describing your changes to help the team understand and review your contribution. This will greatly assist in the review process.

## Demonstration Link

> Provide a link to a branch or environment where this pull request can be tested and seen in action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces structured, multi-condition search for Drive files and folders with AND/OR and negation support.
  - Adds new request options: page size, page token, fields selection, spaces, corpora, sorting, and inclusion of items from shared drives.
- Bug Fixes
  - Validates that at least one search condition is provided, preventing empty searches.
- Documentation
  - Updated usage examples and guidance for building advanced Drive search queries, referencing the official search documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->