### PR TITLE
Hubspot singlethread info loader added

### DIFF
--- a/hubspot/loaders/conversations/getThread.ts
+++ b/hubspot/loaders/conversations/getThread.ts
@@ -1,0 +1,130 @@
+import type { AppContext } from "../../mod.ts";
+import { HubSpotClient } from "../../utils/client.ts";
+
+export interface Props {
+  /**
+   * @title Thread ID
+   * @description The ID of the conversation thread to retrieve
+   */
+  threadId: string;
+}
+
+export interface ThreadAssociations {
+  /**
+   * @title Associated Ticket ID
+   * @description The ID of the associated ticket in the CRM
+   */
+  associatedTicketId?: string;
+}
+
+export interface Thread {
+  /**
+   * @title Associated Contact ID
+   * @description The ID of the associated Contact in the CRM. If the Contact for the thread has not yet been added or created, the associatedContactId returned will be a visitorID and cannot be used to search for the Contact in the CRM.
+   */
+  associatedContactId?: string;
+
+  /**
+   * @title Thread Associations
+   * @description Associations related to the thread (e.g., tickets)
+   */
+  threadAssociations?: ThreadAssociations;
+
+  /**
+   * @title Assigned To
+   * @description The ID of the user the thread is assigned to
+   */
+  assignedTo?: string;
+
+  /**
+   * @title Created At
+   * @description When the thread was created
+   */
+  createdAt: string;
+
+  /**
+   * @title Archived
+   * @description Whether this thread is archived
+   */
+  archived?: boolean;
+
+  /**
+   * @title Original Channel ID
+   * @description The ID of the original channel
+   */
+  originalChannelId: string;
+
+  /**
+   * @title Latest Message Timestamp
+   * @description The time that the latest message was sent or received on the thread
+   */
+  latestMessageTimestamp?: string;
+
+  /**
+   * @title Latest Message Sent Timestamp
+   * @description The time that the latest message was sent on the thread
+   */
+  latestMessageSentTimestamp?: string;
+
+  /**
+   * @title Original Channel Account ID
+   * @description The ID of the original channel account
+   */
+  originalChannelAccountId: string;
+
+  /**
+   * @title Thread ID
+   * @description The unique ID of the thread
+   */
+  id: string;
+
+  /**
+   * @title Closed At
+   * @description When the thread was closed. Only set if the thread is closed.
+   */
+  closedAt?: string;
+
+  /**
+   * @title Spam
+   * @description Whether the thread is marked as spam
+   */
+  spam: boolean;
+
+  /**
+   * @title Inbox ID
+   * @description The ID of the conversations inbox containing the thread
+   */
+  inboxId: string;
+
+  /**
+   * @title Status
+   * @description The thread's status: OPEN or CLOSED
+   */
+  status: "OPEN" | "CLOSED";
+
+  /**
+   * @title Latest Message Received Timestamp
+   * @description The time that the latest message was received on the thread
+   */
+  latestMessageReceivedTimestamp?: string;
+}
+
+/**
+ * @title Get Thread
+ * @description Retrieve a single conversation thread by its ID from HubSpot Conversations API
+ */
+export default async function getThread(
+  props: Props,
+  _req: Request,
+  ctx: AppContext,
+): Promise<Thread> {
+  const { threadId } = props;
+
+  const client = new HubSpotClient(ctx);
+
+  const response = await client.get<Thread>(
+    `/conversations/v3/conversations/threads/${threadId}`,
+  );
+
+  return response;
+}

--- a/hubspot/manifest.gen.ts
+++ b/hubspot/manifest.gen.ts
@@ -45,59 +45,60 @@ import * as $$$1 from "./loaders/cms/getPages.ts";
 import * as $$$2 from "./loaders/conversations/getChannelAccounts.ts";
 import * as $$$3 from "./loaders/conversations/getConversations.ts";
 import * as $$$4 from "./loaders/conversations/getTheadHistory.ts";
-import * as $$$5 from "./loaders/conversations/getThreads.ts";
-import * as $$$6 from "./loaders/crm/getAssociations.ts";
-import * as $$$7 from "./loaders/crm/getCall.ts";
-import * as $$$8 from "./loaders/crm/getCarts.ts";
-import * as $$$9 from "./loaders/crm/getCommunication.ts";
-import * as $$$10 from "./loaders/crm/getCommunications.ts";
-import * as $$$11 from "./loaders/crm/getCompanies.ts";
-import * as $$$12 from "./loaders/crm/getCompany.ts";
-import * as $$$13 from "./loaders/crm/getContact.ts";
-import * as $$$14 from "./loaders/crm/getContacts.ts";
-import * as $$$15 from "./loaders/crm/getCustomObject.ts";
-import * as $$$16 from "./loaders/crm/getCustomObjects.ts";
-import * as $$$17 from "./loaders/crm/getDeal.ts";
-import * as $$$18 from "./loaders/crm/getDeals.ts";
-import * as $$$19 from "./loaders/crm/getInvoice.ts";
-import * as $$$20 from "./loaders/crm/getInvoices.ts";
-import * as $$$21 from "./loaders/crm/getLead.ts";
-import * as $$$22 from "./loaders/crm/getLeads.ts";
-import * as $$$23 from "./loaders/crm/getLineItems.ts";
-import * as $$$24 from "./loaders/crm/getLists.ts";
-import * as $$$25 from "./loaders/crm/getMeeting.ts";
-import * as $$$26 from "./loaders/crm/getNote.ts";
-import * as $$$27 from "./loaders/crm/getOrder.ts";
-import * as $$$28 from "./loaders/crm/getOrders.ts";
-import * as $$$29 from "./loaders/crm/getOwner.ts";
-import * as $$$30 from "./loaders/crm/getOwners.ts";
-import * as $$$31 from "./loaders/crm/getPayments.ts";
-import * as $$$32 from "./loaders/crm/getPipelines.ts";
-import * as $$$33 from "./loaders/crm/getProduct.ts";
-import * as $$$34 from "./loaders/crm/getProperties.ts";
-import * as $$$35 from "./loaders/crm/getPropertyDetails.ts";
-import * as $$$36 from "./loaders/crm/getQuote.ts";
-import * as $$$37 from "./loaders/crm/getSchema.ts";
-import * as $$$38 from "./loaders/crm/getSchemaProperties.ts";
-import * as $$$39 from "./loaders/crm/getSchemas.ts";
-import * as $$$40 from "./loaders/crm/getTask.ts";
-import * as $$$41 from "./loaders/crm/getTicket.ts";
-import * as $$$42 from "./loaders/crm/getTickets.ts";
-import * as $$$43 from "./loaders/crm/searchContacts.ts";
-import * as $$$44 from "./loaders/crm/searchDeals.ts";
-import * as $$$45 from "./loaders/events/getEventDefinitions.ts";
-import * as $$$46 from "./loaders/files/getFile.ts";
-import * as $$$47 from "./loaders/files/getFiles.ts";
-import * as $$$48 from "./loaders/marketing/getCampaigns.ts";
-import * as $$$49 from "./loaders/marketing/getCommunicationPreferences.ts";
-import * as $$$50 from "./loaders/marketing/getForm.ts";
-import * as $$$51 from "./loaders/marketing/getForms.ts";
-import * as $$$52 from "./loaders/marketing/getMarketingEmails.ts";
-import * as $$$53 from "./loaders/oauth/getTokenInfo.ts";
-import * as $$$54 from "./loaders/settings/getAccount.ts";
-import * as $$$55 from "./loaders/settings/getBusinessUnits.ts";
-import * as $$$56 from "./loaders/settings/getUsers.ts";
-import * as $$$57 from "./loaders/webhooks/getWebhooks.ts";
+import * as $$$5 from "./loaders/conversations/getThread.ts";
+import * as $$$6 from "./loaders/conversations/getThreads.ts";
+import * as $$$7 from "./loaders/crm/getAssociations.ts";
+import * as $$$8 from "./loaders/crm/getCall.ts";
+import * as $$$9 from "./loaders/crm/getCarts.ts";
+import * as $$$10 from "./loaders/crm/getCommunication.ts";
+import * as $$$11 from "./loaders/crm/getCommunications.ts";
+import * as $$$12 from "./loaders/crm/getCompanies.ts";
+import * as $$$13 from "./loaders/crm/getCompany.ts";
+import * as $$$14 from "./loaders/crm/getContact.ts";
+import * as $$$15 from "./loaders/crm/getContacts.ts";
+import * as $$$16 from "./loaders/crm/getCustomObject.ts";
+import * as $$$17 from "./loaders/crm/getCustomObjects.ts";
+import * as $$$18 from "./loaders/crm/getDeal.ts";
+import * as $$$19 from "./loaders/crm/getDeals.ts";
+import * as $$$20 from "./loaders/crm/getInvoice.ts";
+import * as $$$21 from "./loaders/crm/getInvoices.ts";
+import * as $$$22 from "./loaders/crm/getLead.ts";
+import * as $$$23 from "./loaders/crm/getLeads.ts";
+import * as $$$24 from "./loaders/crm/getLineItems.ts";
+import * as $$$25 from "./loaders/crm/getLists.ts";
+import * as $$$26 from "./loaders/crm/getMeeting.ts";
+import * as $$$27 from "./loaders/crm/getNote.ts";
+import * as $$$28 from "./loaders/crm/getOrder.ts";
+import * as $$$29 from "./loaders/crm/getOrders.ts";
+import * as $$$30 from "./loaders/crm/getOwner.ts";
+import * as $$$31 from "./loaders/crm/getOwners.ts";
+import * as $$$32 from "./loaders/crm/getPayments.ts";
+import * as $$$33 from "./loaders/crm/getPipelines.ts";
+import * as $$$34 from "./loaders/crm/getProduct.ts";
+import * as $$$35 from "./loaders/crm/getProperties.ts";
+import * as $$$36 from "./loaders/crm/getPropertyDetails.ts";
+import * as $$$37 from "./loaders/crm/getQuote.ts";
+import * as $$$38 from "./loaders/crm/getSchema.ts";
+import * as $$$39 from "./loaders/crm/getSchemaProperties.ts";
+import * as $$$40 from "./loaders/crm/getSchemas.ts";
+import * as $$$41 from "./loaders/crm/getTask.ts";
+import * as $$$42 from "./loaders/crm/getTicket.ts";
+import * as $$$43 from "./loaders/crm/getTickets.ts";
+import * as $$$44 from "./loaders/crm/searchContacts.ts";
+import * as $$$45 from "./loaders/crm/searchDeals.ts";
+import * as $$$46 from "./loaders/events/getEventDefinitions.ts";
+import * as $$$47 from "./loaders/files/getFile.ts";
+import * as $$$48 from "./loaders/files/getFiles.ts";
+import * as $$$49 from "./loaders/marketing/getCampaigns.ts";
+import * as $$$50 from "./loaders/marketing/getCommunicationPreferences.ts";
+import * as $$$51 from "./loaders/marketing/getForm.ts";
+import * as $$$52 from "./loaders/marketing/getForms.ts";
+import * as $$$53 from "./loaders/marketing/getMarketingEmails.ts";
+import * as $$$54 from "./loaders/oauth/getTokenInfo.ts";
+import * as $$$55 from "./loaders/settings/getAccount.ts";
+import * as $$$56 from "./loaders/settings/getBusinessUnits.ts";
+import * as $$$57 from "./loaders/settings/getUsers.ts";
+import * as $$$58 from "./loaders/webhooks/getWebhooks.ts";
 
 const manifest = {
   "loaders": {
@@ -106,59 +107,60 @@ const manifest = {
     "hubspot/loaders/conversations/getChannelAccounts.ts": $$$2,
     "hubspot/loaders/conversations/getConversations.ts": $$$3,
     "hubspot/loaders/conversations/getTheadHistory.ts": $$$4,
-    "hubspot/loaders/conversations/getThreads.ts": $$$5,
-    "hubspot/loaders/crm/getAssociations.ts": $$$6,
-    "hubspot/loaders/crm/getCall.ts": $$$7,
-    "hubspot/loaders/crm/getCarts.ts": $$$8,
-    "hubspot/loaders/crm/getCommunication.ts": $$$9,
-    "hubspot/loaders/crm/getCommunications.ts": $$$10,
-    "hubspot/loaders/crm/getCompanies.ts": $$$11,
-    "hubspot/loaders/crm/getCompany.ts": $$$12,
-    "hubspot/loaders/crm/getContact.ts": $$$13,
-    "hubspot/loaders/crm/getContacts.ts": $$$14,
-    "hubspot/loaders/crm/getCustomObject.ts": $$$15,
-    "hubspot/loaders/crm/getCustomObjects.ts": $$$16,
-    "hubspot/loaders/crm/getDeal.ts": $$$17,
-    "hubspot/loaders/crm/getDeals.ts": $$$18,
-    "hubspot/loaders/crm/getInvoice.ts": $$$19,
-    "hubspot/loaders/crm/getInvoices.ts": $$$20,
-    "hubspot/loaders/crm/getLead.ts": $$$21,
-    "hubspot/loaders/crm/getLeads.ts": $$$22,
-    "hubspot/loaders/crm/getLineItems.ts": $$$23,
-    "hubspot/loaders/crm/getLists.ts": $$$24,
-    "hubspot/loaders/crm/getMeeting.ts": $$$25,
-    "hubspot/loaders/crm/getNote.ts": $$$26,
-    "hubspot/loaders/crm/getOrder.ts": $$$27,
-    "hubspot/loaders/crm/getOrders.ts": $$$28,
-    "hubspot/loaders/crm/getOwner.ts": $$$29,
-    "hubspot/loaders/crm/getOwners.ts": $$$30,
-    "hubspot/loaders/crm/getPayments.ts": $$$31,
-    "hubspot/loaders/crm/getPipelines.ts": $$$32,
-    "hubspot/loaders/crm/getProduct.ts": $$$33,
-    "hubspot/loaders/crm/getProperties.ts": $$$34,
-    "hubspot/loaders/crm/getPropertyDetails.ts": $$$35,
-    "hubspot/loaders/crm/getQuote.ts": $$$36,
-    "hubspot/loaders/crm/getSchema.ts": $$$37,
-    "hubspot/loaders/crm/getSchemaProperties.ts": $$$38,
-    "hubspot/loaders/crm/getSchemas.ts": $$$39,
-    "hubspot/loaders/crm/getTask.ts": $$$40,
-    "hubspot/loaders/crm/getTicket.ts": $$$41,
-    "hubspot/loaders/crm/getTickets.ts": $$$42,
-    "hubspot/loaders/crm/searchContacts.ts": $$$43,
-    "hubspot/loaders/crm/searchDeals.ts": $$$44,
-    "hubspot/loaders/events/getEventDefinitions.ts": $$$45,
-    "hubspot/loaders/files/getFile.ts": $$$46,
-    "hubspot/loaders/files/getFiles.ts": $$$47,
-    "hubspot/loaders/marketing/getCampaigns.ts": $$$48,
-    "hubspot/loaders/marketing/getCommunicationPreferences.ts": $$$49,
-    "hubspot/loaders/marketing/getForm.ts": $$$50,
-    "hubspot/loaders/marketing/getForms.ts": $$$51,
-    "hubspot/loaders/marketing/getMarketingEmails.ts": $$$52,
-    "hubspot/loaders/oauth/getTokenInfo.ts": $$$53,
-    "hubspot/loaders/settings/getAccount.ts": $$$54,
-    "hubspot/loaders/settings/getBusinessUnits.ts": $$$55,
-    "hubspot/loaders/settings/getUsers.ts": $$$56,
-    "hubspot/loaders/webhooks/getWebhooks.ts": $$$57,
+    "hubspot/loaders/conversations/getThread.ts": $$$5,
+    "hubspot/loaders/conversations/getThreads.ts": $$$6,
+    "hubspot/loaders/crm/getAssociations.ts": $$$7,
+    "hubspot/loaders/crm/getCall.ts": $$$8,
+    "hubspot/loaders/crm/getCarts.ts": $$$9,
+    "hubspot/loaders/crm/getCommunication.ts": $$$10,
+    "hubspot/loaders/crm/getCommunications.ts": $$$11,
+    "hubspot/loaders/crm/getCompanies.ts": $$$12,
+    "hubspot/loaders/crm/getCompany.ts": $$$13,
+    "hubspot/loaders/crm/getContact.ts": $$$14,
+    "hubspot/loaders/crm/getContacts.ts": $$$15,
+    "hubspot/loaders/crm/getCustomObject.ts": $$$16,
+    "hubspot/loaders/crm/getCustomObjects.ts": $$$17,
+    "hubspot/loaders/crm/getDeal.ts": $$$18,
+    "hubspot/loaders/crm/getDeals.ts": $$$19,
+    "hubspot/loaders/crm/getInvoice.ts": $$$20,
+    "hubspot/loaders/crm/getInvoices.ts": $$$21,
+    "hubspot/loaders/crm/getLead.ts": $$$22,
+    "hubspot/loaders/crm/getLeads.ts": $$$23,
+    "hubspot/loaders/crm/getLineItems.ts": $$$24,
+    "hubspot/loaders/crm/getLists.ts": $$$25,
+    "hubspot/loaders/crm/getMeeting.ts": $$$26,
+    "hubspot/loaders/crm/getNote.ts": $$$27,
+    "hubspot/loaders/crm/getOrder.ts": $$$28,
+    "hubspot/loaders/crm/getOrders.ts": $$$29,
+    "hubspot/loaders/crm/getOwner.ts": $$$30,
+    "hubspot/loaders/crm/getOwners.ts": $$$31,
+    "hubspot/loaders/crm/getPayments.ts": $$$32,
+    "hubspot/loaders/crm/getPipelines.ts": $$$33,
+    "hubspot/loaders/crm/getProduct.ts": $$$34,
+    "hubspot/loaders/crm/getProperties.ts": $$$35,
+    "hubspot/loaders/crm/getPropertyDetails.ts": $$$36,
+    "hubspot/loaders/crm/getQuote.ts": $$$37,
+    "hubspot/loaders/crm/getSchema.ts": $$$38,
+    "hubspot/loaders/crm/getSchemaProperties.ts": $$$39,
+    "hubspot/loaders/crm/getSchemas.ts": $$$40,
+    "hubspot/loaders/crm/getTask.ts": $$$41,
+    "hubspot/loaders/crm/getTicket.ts": $$$42,
+    "hubspot/loaders/crm/getTickets.ts": $$$43,
+    "hubspot/loaders/crm/searchContacts.ts": $$$44,
+    "hubspot/loaders/crm/searchDeals.ts": $$$45,
+    "hubspot/loaders/events/getEventDefinitions.ts": $$$46,
+    "hubspot/loaders/files/getFile.ts": $$$47,
+    "hubspot/loaders/files/getFiles.ts": $$$48,
+    "hubspot/loaders/marketing/getCampaigns.ts": $$$49,
+    "hubspot/loaders/marketing/getCommunicationPreferences.ts": $$$50,
+    "hubspot/loaders/marketing/getForm.ts": $$$51,
+    "hubspot/loaders/marketing/getForms.ts": $$$52,
+    "hubspot/loaders/marketing/getMarketingEmails.ts": $$$53,
+    "hubspot/loaders/oauth/getTokenInfo.ts": $$$54,
+    "hubspot/loaders/settings/getAccount.ts": $$$55,
+    "hubspot/loaders/settings/getBusinessUnits.ts": $$$56,
+    "hubspot/loaders/settings/getUsers.ts": $$$57,
+    "hubspot/loaders/webhooks/getWebhooks.ts": $$$58,
   },
   "actions": {
     "hubspot/actions/automation/enrollInWorkflow.ts": $$$$$$$$$0,


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Please provide a brief description of the changes or enhancements you are proposing in this pull request.

## Issue Link

Please link to the relevant issue that this pull request addresses:

- Issue: [#ISSUE_NUMBER](link_to_issue)

## Loom Video

> Record a quick screencast describing your changes to help the team understand and review your contribution. This will greatly assist in the review process.

## Demonstration Link

> Provide a link to a branch or environment where this pull request can be tested and seen in action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to fetch individual HubSpot conversation threads, providing access to thread details including contact associations, assignments, timestamps, and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->