### PR TITLE
fix(discord-bot): returning obj instead of raw arrays

### DIFF
--- a/discord-bot/loaders/getChannelMessages.ts
+++ b/discord-bot/loaders/getChannelMessages.ts
@@ -33,6 +33,14 @@ export interface Props {
   around?: string;
 }
 
+export interface ChannelMessagesResponse {
+  /**
+   * @title Messages
+   * @description Lista de mensagens do canal
+   */
+  messages: DiscordMessage[];
+}
+
 /**
  * @title Get Channel Messages
  * @description Get messages from a Discord channel using Bot Token
@@ -41,7 +49,7 @@ export default async function getChannelMessages(
   props: Props,
   _req: Request,
   ctx: AppContext,
-): Promise<DiscordMessage[]> {
+): Promise<ChannelMessagesResponse> {
   const { channelId, limit = 50, before, after, around } = props;
   const { client } = ctx;
 
@@ -66,5 +74,5 @@ export default async function getChannelMessages(
   }
 
   const messages = await response.json();
-  return messages;
+  return { messages };
 }

--- a/discord-bot/loaders/getGuildChannels.ts
+++ b/discord-bot/loaders/getGuildChannels.ts
@@ -9,6 +9,14 @@ export interface Props {
   guildId: string;
 }
 
+export interface GuildChannelsResponse {
+  /**
+   * @title Channels
+   * @description Lista de canais do servidor
+   */
+  channels: DiscordChannel[];
+}
+
 /**
  * @title List Guild Channels
  * @description List all channels from a specific Discord guild using Bot Token
@@ -17,7 +25,7 @@ export default async function getGuildChannels(
   props: Props,
   _req: Request,
   ctx: AppContext,
-): Promise<DiscordChannel[]> {
+): Promise<GuildChannelsResponse> {
   const { guildId } = props;
   const { client } = ctx;
 
@@ -35,5 +43,5 @@ export default async function getGuildChannels(
   }
 
   const channels = await response.json();
-  return channels;
+  return { channels };
 }

--- a/discord-bot/loaders/getGuildMembers.ts
+++ b/discord-bot/loaders/getGuildMembers.ts
@@ -21,6 +21,14 @@ export interface Props {
   after?: string;
 }
 
+export interface GuildMembersResponse {
+  /**
+   * @title Members
+   * @description Lista de membros do servidor
+   */
+  members: DiscordGuildMember[];
+}
+
 /**
  * @title Get Guild Members
  * @description List members of a Discord guild using Bot Token
@@ -29,7 +37,7 @@ export default async function getGuildMembers(
   props: Props,
   _req: Request,
   ctx: AppContext,
-): Promise<DiscordGuildMember[]> {
+): Promise<GuildMembersResponse> {
   const { guildId, limit = 1, after } = props;
   const { client } = ctx;
 
@@ -52,5 +60,5 @@ export default async function getGuildMembers(
   }
 
   const members = await response.json();
-  return members;
+  return { members };
 }

--- a/discord-bot/loaders/getGuildRoles.ts
+++ b/discord-bot/loaders/getGuildRoles.ts
@@ -9,6 +9,14 @@ export interface Props {
   guildId: string;
 }
 
+export interface GuildRolesResponse {
+  /**
+   * @title Roles
+   * @description Lista de roles do servidor
+   */
+  roles: DiscordRole[];
+}
+
 /**
  * @title Get Guild Roles
  * @description Get all roles from a Discord server using Bot Token
@@ -17,7 +25,7 @@ export default async function getGuildRoles(
   props: Props,
   _req: Request,
   ctx: AppContext,
-): Promise<DiscordRole[]> {
+): Promise<GuildRolesResponse> {
   const { guildId } = props;
   const { client } = ctx;
 
@@ -35,5 +43,5 @@ export default async function getGuildRoles(
   }
 
   const roles = await response.json();
-  return roles;
+  return { roles };
 }

--- a/discord-bot/loaders/getMessageReactions.ts
+++ b/discord-bot/loaders/getMessageReactions.ts
@@ -34,6 +34,14 @@ export interface Props {
   limit?: number;
 }
 
+export interface MessageReactionsResponse {
+  /**
+   * @title Users
+   * @description Usuários que reagiram à mensagem
+   */
+  users: DiscordUser[];
+}
+
 /**
  * @title Get Message Reactions
  * @description Get users who reacted to a message with a specific emoji using Bot Token
@@ -42,7 +50,7 @@ export default async function getMessageReactions(
   props: Props,
   _req: Request,
   ctx: AppContext,
-): Promise<DiscordUser[]> {
+): Promise<MessageReactionsResponse> {
   const { channelId, messageId, emoji, after, limit = 25 } = props;
   const { client } = ctx;
 
@@ -80,5 +88,5 @@ export default async function getMessageReactions(
   }
 
   const users = await response.json();
-  return users;
+  return { users };
 }

--- a/discord-bot/loaders/getPinnedMessages.ts
+++ b/discord-bot/loaders/getPinnedMessages.ts
@@ -9,6 +9,14 @@ export interface Props {
   channelId: string;
 }
 
+export interface PinnedMessagesResponse {
+  /**
+   * @title Messages
+   * @description Mensagens fixadas do canal
+   */
+  messages: DiscordMessage[];
+}
+
 /**
  * @title Get Pinned Messages
  * @description Get all pinned messages from a Discord channel using Bot Token
@@ -17,7 +25,7 @@ export default async function getPinnedMessages(
   props: Props,
   _req: Request,
   ctx: AppContext,
-): Promise<DiscordMessage[]> {
+): Promise<PinnedMessagesResponse> {
   const { channelId } = props;
   const { client } = ctx;
 
@@ -35,5 +43,5 @@ export default async function getPinnedMessages(
   }
 
   const messages = await response.json();
-  return messages;
+  return { messages };
 }

--- a/discord-bot/loaders/listBotGuilds.ts
+++ b/discord-bot/loaders/listBotGuilds.ts
@@ -28,6 +28,14 @@ export interface Props {
   withCounts?: boolean;
 }
 
+export interface BotGuildsResponse {
+  /**
+   * @title Guilds
+   * @description Lista de servidores onde o bot está presente
+   */
+  guilds: DiscordGuild[];
+}
+
 /**
  * @title List Bot Guilds
  * @description List all guilds where the bot is present using Bot Token
@@ -36,7 +44,7 @@ export default async function listBotGuilds(
   props: Props,
   _req: Request,
   ctx: AppContext,
-): Promise<DiscordGuild[]> {
+): Promise<BotGuildsResponse> {
   const { limit = 100, before, after, withCounts = false } = props;
   const { botToken } = ctx;
 
@@ -72,5 +80,5 @@ export default async function listBotGuilds(
   }
 
   const guilds = await response.json();
-  return guilds;
+  return { guilds };
 }

--- a/discord-bot/loaders/listWebhooks.ts
+++ b/discord-bot/loaders/listWebhooks.ts
@@ -64,6 +64,14 @@ export interface WebhookInfo {
   url?: string;
 }
 
+export interface WebhooksResponse {
+  /**
+   * @title Webhooks
+   * @description Lista de webhooks
+   */
+  webhooks: WebhookInfo[];
+}
+
 /**
  * @title List Webhooks
  * @description List webhooks from a Discord channel or guild using Bot Token
@@ -72,7 +80,7 @@ export default async function listWebhooks(
   props: Props,
   _req: Request,
   ctx: AppContext,
-): Promise<WebhookInfo[]> {
+): Promise<WebhooksResponse> {
   const { channelId, guildId } = props;
   const { client } = ctx;
 
@@ -101,5 +109,5 @@ export default async function listWebhooks(
   }
 
   const webhooks = await response.json();
-  return webhooks;
+  return { webhooks };
 }

--- a/wake/loaders/productListingPage.ts
+++ b/wake/loaders/productListingPage.ts
@@ -354,7 +354,10 @@ export const cacheKey = (props: Props, req: Request, _ctx: AppContext) => {
   const url = new URL(props.pageHref || req.url);
 
   // Don't cache search queries to ensure freshness
-  if (url.searchParams.get("q") || url.searchParams.get("query") || url.searchParams.get("busca")) {
+  if (
+    url.searchParams.get("q") || url.searchParams.get("query") ||
+    url.searchParams.get("busca")
+  ) {
     return null;
   }
 


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Please provide a brief description of the changes or enhancements you are proposing in this pull request.

## Issue Link

Please link to the relevant issue that this pull request addresses:

- Issue: [#ISSUE_NUMBER](link_to_issue)

## Loom Video

> Record a quick screencast describing your changes to help the team understand and review your contribution. This will greatly assist in the review process.

## Demonstration Link

> Provide a link to a branch or environment where this pull request can be tested and seen in action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated Discord API response formats to return structured objects instead of arrays for improved consistency and type safety across loader endpoints.

* **Bug Fixes**
  * Added input validation for channel identifiers and request limits with automatic constraint enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->