### PR TITLE
feat(airtable): add create records action with batch support

### DIFF
--- a/airtable/actions/createRecords.ts
+++ b/airtable/actions/createRecords.ts
@@ -1,0 +1,155 @@
+import type { AppContext } from "../mod.ts";
+import type {
+  AirtableRecord,
+  CreateRecordsBody,
+  FieldSet,
+} from "../utils/types.ts";
+
+interface RecordToCreate {
+  fields: FieldSet;
+  typecast?: boolean;
+}
+
+interface Props {
+  /**
+   * @title Base ID
+   * @description The ID of the Airtable base
+   */
+  baseId: string;
+
+  /**
+   * @title Table ID
+   * @description The ID of the table within the base
+   */
+  tableId: string;
+
+  /**
+   * @title Records to Create
+   * @description An array of records to create. Each record must have a fields object.
+   */
+  records: RecordToCreate[];
+
+  /**
+   * @title Typecast
+   * @description Optional. If true, Airtable will attempt to convert cell values to the appropriate type.
+   */
+  typecast?: boolean;
+}
+
+interface ErrorObject {
+  message: string;
+  code?: string;
+}
+
+interface ResponsePayload {
+  data: AirtableRecord[];
+  error?: ErrorObject | null;
+}
+
+/**
+ * @title Create Airtable Records
+ * @description Creates one or more records in a specified table using OAuth.
+ */
+const action = async (
+  props: Props,
+  _req: Request,
+  ctx: AppContext,
+): Promise<ResponsePayload> => {
+  try {
+    if (!ctx.client) {
+      return {
+        data: [],
+        error: { message: "OAuth authentication is required" },
+      };
+    }
+
+    const validationResult = await ctx.invoke["airtable"].loaders.permissioning
+      .validatePermissions({
+        mode: "check",
+        baseId: props.baseId,
+        tableIdOrName: props.tableId,
+      });
+
+    if (
+      "hasPermission" in validationResult && !validationResult.hasPermission
+    ) {
+      return {
+        data: [],
+        error: {
+          message: validationResult.message || "Access denied",
+        },
+      };
+    }
+
+    const { baseId, tableId, records, typecast } = props;
+
+    if (!records || records.length === 0) {
+      return {
+        data: [],
+        error: { message: "At least one record is required" },
+      };
+    }
+
+    if (records.length > 10) {
+      return {
+        data: [],
+        error: { message: "Maximum 10 records can be created at once" },
+      };
+    }
+
+    const invalidRecords = records.filter((record) => !record.fields);
+    if (invalidRecords.length > 0) {
+      return {
+        data: [],
+        error: { message: "All records must have a 'fields' property" },
+      };
+    }
+
+    // Transform records to the format expected by Airtable API
+    const requestBody: CreateRecordsBody = {
+      records: records.map((record) => ({
+        fields: record.fields,
+        ...(record.typecast !== undefined && { typecast: record.typecast }),
+      })),
+    };
+
+    // Apply global typecast if provided
+    if (
+      typecast !== undefined && !records.some((r) => r.typecast !== undefined)
+    ) {
+      requestBody.typecast = typecast;
+    }
+
+    // deno-lint-ignore no-explicit-any
+    const response = await (ctx.client as any)["POST /v0/:baseId/:tableId"](
+      { baseId, tableId },
+      { body: requestBody },
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return {
+        data: [],
+        error: { message: `Error creating records: ${errorText}` },
+      };
+    }
+
+    const result = await response.json();
+    const createdRecords = result.records || [];
+
+    return {
+      data: createdRecords,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error
+      ? error.message
+      : "Unknown error occurred";
+
+    return {
+      data: [],
+      error: { message: errorMessage },
+    };
+  }
+};
+
+export default action;

--- a/airtable/manifest.gen.ts
+++ b/airtable/manifest.gen.ts
@@ -3,13 +3,14 @@
 // This file is automatically updated during development when running `dev.ts`.
 
 import * as $$$$$$$$$0 from "./actions/createField.ts";
-import * as $$$$$$$$$1 from "./actions/createTable.ts";
-import * as $$$$$$$$$2 from "./actions/deleteRecords.ts";
-import * as $$$$$$$$$3 from "./actions/oauth/callback.ts";
-import * as $$$$$$$$$4 from "./actions/permissioning/addNewPermitions.ts";
-import * as $$$$$$$$$5 from "./actions/updateField.ts";
-import * as $$$$$$$$$6 from "./actions/updateRecords.ts";
-import * as $$$$$$$$$7 from "./actions/updateTable.ts";
+import * as $$$$$$$$$1 from "./actions/createRecords.ts";
+import * as $$$$$$$$$2 from "./actions/createTable.ts";
+import * as $$$$$$$$$3 from "./actions/deleteRecords.ts";
+import * as $$$$$$$$$4 from "./actions/oauth/callback.ts";
+import * as $$$$$$$$$5 from "./actions/permissioning/addNewPermitions.ts";
+import * as $$$$$$$$$6 from "./actions/updateField.ts";
+import * as $$$$$$$$$7 from "./actions/updateRecords.ts";
+import * as $$$$$$$$$8 from "./actions/updateTable.ts";
 import * as $$$0 from "./loaders/getBaseSchema.ts";
 import * as $$$1 from "./loaders/getRecord.ts";
 import * as $$$2 from "./loaders/listBases.ts";
@@ -34,13 +35,14 @@ const manifest = {
   },
   "actions": {
     "airtable/actions/createField.ts": $$$$$$$$$0,
-    "airtable/actions/createTable.ts": $$$$$$$$$1,
-    "airtable/actions/deleteRecords.ts": $$$$$$$$$2,
-    "airtable/actions/oauth/callback.ts": $$$$$$$$$3,
-    "airtable/actions/permissioning/addNewPermitions.ts": $$$$$$$$$4,
-    "airtable/actions/updateField.ts": $$$$$$$$$5,
-    "airtable/actions/updateRecords.ts": $$$$$$$$$6,
-    "airtable/actions/updateTable.ts": $$$$$$$$$7,
+    "airtable/actions/createRecords.ts": $$$$$$$$$1,
+    "airtable/actions/createTable.ts": $$$$$$$$$2,
+    "airtable/actions/deleteRecords.ts": $$$$$$$$$3,
+    "airtable/actions/oauth/callback.ts": $$$$$$$$$4,
+    "airtable/actions/permissioning/addNewPermitions.ts": $$$$$$$$$5,
+    "airtable/actions/updateField.ts": $$$$$$$$$6,
+    "airtable/actions/updateRecords.ts": $$$$$$$$$7,
+    "airtable/actions/updateTable.ts": $$$$$$$$$8,
   },
   "name": "airtable",
   "baseUrl": import.meta.url,

--- a/airtable/utils/client.ts
+++ b/airtable/utils/client.ts
@@ -3,6 +3,7 @@ import type {
   BaseSchemaResponse,
   CreateFieldBody,
   CreateRecordBody,
+  CreateRecordsBody,
   CreateTableBody,
   Field,
   ListBasesResponse,
@@ -14,6 +15,10 @@ import type {
   UpdateTableBody,
   WhoamiResponse,
 } from "./types.ts";
+
+// Type helper to allow both single and batch record creation
+type CreateRecordPayload = CreateRecordBody | CreateRecordsBody;
+type CreateRecordResponse = AirtableRecord | { records: AirtableRecord[] };
 
 export interface AirtableClient {
   /**
@@ -61,14 +66,12 @@ export interface AirtableClient {
 
   /**
    * Create records
-   * NOTE: Airtable API allows creating multiple records (up to 10). This client method is for a single record for simplicity to match service layer.
-   * For batch creation, the service method `createRecord` would call this and wrap it in an array if needed, or a separate client method for batch could be made.
-   * Let's define it for creating a single record as per the IAirtableService.createRecord
+   * NOTE: Airtable API allows creating multiple records (up to 10). This can accept both single and batch creation.
    * @see https://airtable.com/developers/web/api/create-records
    */
   "POST /v0/:baseId/:tableId": {
-    body: CreateRecordBody; // { fields: FieldSet, typecast?: boolean }
-    response: AirtableRecord;
+    body: CreateRecordPayload; // Single or multiple records
+    response: CreateRecordResponse;
   };
 
   /**

--- a/airtable/utils/types.ts
+++ b/airtable/utils/types.ts
@@ -75,6 +75,11 @@ export interface CreateRecordBody {
   typecast?: boolean;
 }
 
+export interface CreateRecordsBody {
+  records: Array<{ fields: FieldSet; typecast?: boolean }>;
+  typecast?: boolean;
+}
+
 export interface UpdateRecordsBody {
   records: Array<{ id: string; fields: FieldSet }>;
   typecast?: boolean;


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Please provide a brief description of the changes or enhancements you are proposing in this pull request.

## Issue Link

Please link to the relevant issue that this pull request addresses:

- Issue: [#ISSUE_NUMBER](link_to_issue)

## Loom Video

> Record a quick screencast describing your changes to help the team understand and review your contribution. This will greatly assist in the review process.

## Demonstration Link

> Provide a link to a branch or environment where this pull request can be tested and seen in action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for creating multiple Airtable records in a single operation. Supports up to 10 records per request with optional data type casting for individual records or the entire batch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->