### PR TITLE
feat(seo): create twitter and opengraph configs

### DIFF
--- a/website/components/Seo.tsx
+++ b/website/components/Seo.tsx
@@ -40,6 +40,21 @@ export interface Props {
    */
   noIndexing?: boolean;
 
+  /** @title Open Graph Config */
+  openGraphConfig?: {
+    title?: string;
+    description?: string;
+    image?: ImageWidget;
+    url?: string;
+  };
+
+  /** @title Twitter Config */
+  twitterConfig?: {
+    title?: string;
+    description?: string;
+    image?: ImageWidget;
+  };
+
   jsonLDs?: unknown[];
 }
 
@@ -54,11 +69,30 @@ function Component({
   themeColor,
   canonical,
   noIndexing,
+  openGraphConfig,
+  twitterConfig,
   jsonLDs = [],
 }: Props) {
   const twitterCard = type === "website" ? "summary" : "summary_large_image";
-  const description = stripHTML(desc || "");
+
   const title = stripHTML(t);
+  const description = stripHTML(desc || "");
+
+  const twitterImage = twitterConfig?.image ?? image;
+  const twitterTitle = twitterConfig?.title
+    ? stripHTML(twitterConfig.title)
+    : title;
+  const twitterDescription = twitterConfig?.description
+    ? stripHTML(twitterConfig.description)
+    : description;
+
+  const openGraphImage = openGraphConfig?.image ?? image;
+  const openGraphTitle = openGraphConfig?.title
+    ? stripHTML(openGraphConfig.title)
+    : title;
+  const openGraphDescription = openGraphConfig?.description
+    ? stripHTML(openGraphConfig.description)
+    : description;
 
   return (
     <Head>
@@ -71,17 +105,25 @@ function Component({
       <link rel="icon" href={favicon} />
 
       {/* Twitter tags */}
-      <meta property="twitter:title" content={title} />
-      <meta property="twitter:description" content={description} />
-      <meta property="twitter:image" content={image} />
+      <meta property="twitter:title" content={twitterTitle} />
+      <meta
+        property="twitter:description"
+        content={twitterDescription}
+      />
+      <meta property="twitter:image" content={twitterImage} />
       <meta property="twitter:card" content={twitterCard} />
 
       {/* OpenGraph tags */}
-      <meta property="og:title" content={title} />
-      <meta property="og:description" content={description} />
+      <meta property="og:title" content={openGraphTitle} />
+      <meta
+        property="og:description"
+        content={openGraphDescription}
+      />
       <meta property="og:type" content={type} />
-      <meta property="og:image" content={image} />
-      {canonical && <meta property="og:url" content={canonical} />}
+      <meta property="og:image" content={openGraphImage} />
+      {Boolean(openGraphConfig?.url || canonical) && (
+        <meta property="og:url" content={openGraphConfig?.url ?? canonical} />
+      )}
 
       {/* Link tags */}
       {canonical && <link rel="canonical" href={canonical} />}


### PR DESCRIPTION
## Motivation

Previously, all OpenGraph (`og:*`) and Twitter meta tags implicitly inherited the global SEO values (`title`, `description`, `image`, `canonical`).  
This caused two practical issues:

1. **No way to override OG/Twitter metadata per page**, which is required for custom PLPs, hybrid routes, and cases where canonical and social URLs differ.

2. **`og:url` always reused the canonical URL**, meaning pagination parameters like `?page` leaked into OG metadata.  
   Social platforms treat `og:url` as a cache key, which led to:
   - duplicated social previews  
   - inconsistent sharing behavior  
   - divergence from VTEX’s default behavior and SEO best practices  

This PR introduces explicit override support for OG and Twitter configurations, restoring full control while remaining fully backward compatible.

---

## ✅ What’s Included

### Added `openGraphConfig` and `twitterConfig` overrides  
The following OG fields now support page-level overrides:
- `title`
- `description`
- `image`
- `url`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Open Graph configuration to customize title, description, image and optional URL (falls back to canonical when URL not provided).
  * Added Twitter configuration to customize title, description and image.
  * Social metadata now prefers explicit config values but falls back to existing metadata for predictable previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->