### PR TITLE
fix(image): added optional disable optimization

### DIFF
--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -27,7 +27,7 @@ export type Props =
     /** @description Object-fit */
     fit?: FitOptions;
     /** @description Disable image optimization */
-    disableImageOptimization?: boolean;
+    disableims?: boolean;
     setEarlyHint?: SetEarlyHint;
   };
 
@@ -56,7 +56,7 @@ interface OptimizationOptions {
   height?: number;
   factor: number;
   fit: FitOptions;
-  disableImageOptimization?: boolean;
+  disableims?: boolean;
 }
 
 const optmizeVNDA = (opts: OptimizationOptions) => {
@@ -105,7 +105,7 @@ const optimizeVTEX = (opts: OptimizationOptions) => {
 };
 
 export const getOptimizedMediaUrl = (opts: OptimizationOptions) => {
-  const { originalSrc, width, height, fit, disableImageOptimization } = opts;
+  const { originalSrc, width, height, fit, disableims } = opts;
 
   if (originalSrc.startsWith("data:")) {
     return originalSrc;
@@ -145,7 +145,7 @@ export const getOptimizedMediaUrl = (opts: OptimizationOptions) => {
   params.set("fit", fit);
   params.set("width", `${width}`);
   height && params.set("height", `${height}`);
-  disableImageOptimization && params.set("disableims", "true");
+  disableims && params.set("disableims", "true");
 
   if (isAzionAssetsEnabled()) {
     const imageSource = originalSrc
@@ -170,7 +170,7 @@ export const getSrcSet = (
   height?: number,
   fit?: FitOptions,
   factors: number[] = FACTORS,
-  disableImageOptimization?: boolean,
+  disableims?: boolean,
 ) => {
   const srcSet = [];
 
@@ -185,7 +185,7 @@ export const getSrcSet = (
       height: h,
       factor,
       fit: fit || "cover",
-      disableImageOptimization,
+      disableims,
     });
 
     if (src) {
@@ -202,7 +202,7 @@ export const getEarlyHintFromSrcProps = (srcProps: {
   fit?: FitOptions;
   width: number;
   height?: number;
-  disableImageOptimization?: boolean;
+  disableims?: boolean;
 }) => {
   const factor = FACTORS.at(-1)!;
   const src = getOptimizedMediaUrl({
@@ -211,7 +211,7 @@ export const getEarlyHintFromSrcProps = (srcProps: {
     height: srcProps.height && Math.trunc(srcProps.height * factor),
     fit: srcProps.fit || "cover",
     factor,
-    disableImageOptimization: srcProps.disableImageOptimization,
+    disableims: srcProps.disableims,
   });
   const earlyHintParts = [
     `<${src}>`,
@@ -243,7 +243,7 @@ const Image = forwardRef<HTMLImageElement, Props>((props, ref) => {
       props.height,
       props.fit,
       shouldSetEarlyHint ? FACTORS.slice(-1) : FACTORS,
-      props.disableImageOptimization,
+      props.disableims,
     );
 
   const linkProps = srcSet &&
@@ -269,7 +269,7 @@ const Image = forwardRef<HTMLImageElement, Props>((props, ref) => {
         height: props.height,
         fetchpriority: props.fetchPriority,
         src: props.src,
-        disableImageOptimization: props.disableImageOptimization,
+        disableims: props.disableims,
       }),
     );
   }

--- a/website/components/Picture.tsx
+++ b/website/components/Picture.tsx
@@ -12,12 +12,13 @@ import {
 
 interface Context {
   preload?: boolean;
-  disableImageOptimization?: boolean;
+  /** @description Disable image optimization */
+  disableims?: boolean;
 }
 
 const Context = createContext<Context>({
   preload: false,
-  disableImageOptimization: false,
+  disableims: false,
 });
 
 type SourceProps =
@@ -38,7 +39,7 @@ type SourceProps =
 
 export const Source = forwardRef<HTMLSourceElement, SourceProps>(
   (props, ref) => {
-    const { preload, disableImageOptimization } = useContext(Context);
+    const { preload, disableims } = useContext(Context);
 
     const shouldSetEarlyHint = !!props.setEarlyHint && preload;
     const srcSet = getSrcSet(
@@ -47,7 +48,7 @@ export const Source = forwardRef<HTMLSourceElement, SourceProps>(
       props.height,
       undefined,
       shouldSetEarlyHint ? FACTORS.slice(-1) : FACTORS,
-      disableImageOptimization,
+      disableims,
     );
     const linkProps = {
       imagesrcset: srcSet,
@@ -68,7 +69,7 @@ export const Source = forwardRef<HTMLSourceElement, SourceProps>(
           height: props.height,
           fetchpriority: props.fetchPriority,
           src: props.src,
-          disableImageOptimization,
+          disableims,
         }),
       );
     }
@@ -101,14 +102,14 @@ export const Source = forwardRef<HTMLSourceElement, SourceProps>(
 type Props = Omit<JSX.IntrinsicElements["picture"], "preload"> & {
   children: ComponentChildren;
   preload?: boolean;
-  disableImageOptimization?: boolean;
+  disableims?: boolean;
 };
 
 export const Picture = forwardRef<HTMLPictureElement, Props>(
-  ({ children, preload, disableImageOptimization, ...props }, ref) => {
-    const value = useMemo(() => ({ preload, disableImageOptimization }), [
+  ({ children, preload, disableims, ...props }, ref) => {
+    const value = useMemo(() => ({ preload, disableims }), [
       preload,
-      disableImageOptimization,
+      disableims,
     ]);
 
     return (

--- a/website/loaders/image.ts
+++ b/website/loaders/image.ts
@@ -21,7 +21,7 @@ function assert(expr: unknown, msg = ""): asserts expr {
 }
 
 const parseParams = (
-  { src, width, height, fit, quality }: Partial<Props>,
+  { src, width, height, fit, quality, disableims }: Partial<Props>,
 ): Props => {
   assert(src, "src is required");
   assert(width, "width is required");
@@ -33,6 +33,7 @@ const parseParams = (
     height: Number(height),
     quality: Number(quality) || undefined,
     fit: fit === "contain" ? "contain" : "cover",
+    disableims: disableims ? true : false,
   };
 };
 

--- a/website/utils/image/engine.ts
+++ b/website/utils/image/engine.ts
@@ -4,6 +4,7 @@ export interface Params {
   height: number;
   fit?: "cover" | "contain";
   quality?: number; // 0 - 100
+  disableims?: boolean;
 }
 
 export type Engine = {


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Please provide a brief description of the changes or enhancements you are proposing in this pull request.

## Issue Link

Please link to the relevant issue that this pull request addresses:

- Issue: [#ISSUE_NUMBER](link_to_issue)

## Loom Video

> Record a quick screencast describing your changes to help the team understand and review your contribution. This will greatly assist in the review process.

## Demonstration Link

> Provide a link to a branch or environment where this pull request can be tested and seen in action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-instance toggle to disable automatic image optimization: Image and Picture components now accept a disableims flag so you can opt out of optimization for individual images.
  * Preload/link hints, source set generation, and server-side image parameter handling now respect this flag for accurate loading and hinting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->