### PR TITLE
feat: VNDA productListingPage default sorting param

### DIFF
--- a/vnda/loaders/productListingPage.ts
+++ b/vnda/loaders/productListingPage.ts
@@ -296,7 +296,7 @@ export const cacheKey = (props: Props, req: Request, _ctx: AppContext) => {
 
   const params = new URLSearchParams([
     ["count", (props.count || url.searchParams.get("count") || 12).toString()],
-    ["sort", props.sort ?? url.searchParams.get("sort") ?? ""],
+    ["sort", url.searchParams.get("sort") ?? props.sort ?? ""],
     ["type_tags", typeTags],
     ["tags", props?.tags?.join("\\") ?? ""],
     [


### PR DESCRIPTION
Adds a Sort property to VNDA productListingPage Loader, allowing commerces to set default order option on their pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can set an optional default sort preference for product listings.

* **Refactor**
  * Sort selection now resolves more predictably (explicit preference → URL → default) and caching updated to respect the chosen preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->