### PR TITLE
Added validation to vtex skuid

### DIFF
--- a/vtex/loaders/legacy/productList.ts
+++ b/vtex/loaders/legacy/productList.ts
@@ -133,9 +133,10 @@ const fromProps = ({ props }: Props) => {
   };
 
   if (isSKUIDProps(props)) {
-    const skuIds = props.ids || [];
+    const skuIds = (props.ids || [])
+      .filter((skuId) => skuId && /^\d+$/.test(skuId.trim()));
 
-    skuIds.forEach((skuId) => params.fq.push(`skuId:${skuId}`));
+    skuIds.forEach((skuId) => params.fq.push(`skuId:${skuId.trim()}`));
     params._from = 0;
     params._to = Math.max(skuIds.length - 1, 0);
 
@@ -143,9 +144,10 @@ const fromProps = ({ props }: Props) => {
   }
 
   if (isProductIDProps(props)) {
-    const productIds = props.productIds || [];
+    const productIds = (props.productIds || [])
+      .filter((productId) => productId && /^\d+$/.test(productId.trim()));
 
-    productIds.forEach((productId) => params.fq.push(`productId:${productId}`));
+    productIds.forEach((productId) => params.fq.push(`productId:${productId.trim()}`));
     params._from = 0;
     params._to = Math.max(productIds.length - 1, 0);
 

--- a/vtex/loaders/legacy/productList.ts
+++ b/vtex/loaders/legacy/productList.ts
@@ -151,9 +151,7 @@ const fromProps = ({ props }: Props) => {
   if (isProductIDProps(props)) {
     const productIds = sanitizeNumericIds(props.productIds);
 
-    productIds.forEach((productId) =>
-      params.fq.push(`productId:${productId}`)
-    );
+    productIds.forEach((productId) => params.fq.push(`productId:${productId}`));
     params._from = 0;
     params._to = Math.max(productIds.length - 1, 0);
 


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Some stores are receiving many VTEX timeout errors (HttpError 400: "Can't create search criteria! Error: Invalid Parameter, skuId should be Int64.)
Possibly invalid skuids were being passed to the VTEX API.
<img width="986" height="505" alt="image" src="https://github.com/user-attachments/assets/e6cdf537-e9ed-485f-b719-5f3614be5bc0" />

Added validation to filter out invalid IDs before sending to the VTEX API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Product list selection now filters out invalid (non-numeric) IDs and trims whitespace when selecting by SKU or Product IDs, ensuring only valid IDs are used in queries.
  * Cache keys now use the sanitized, consistently ordered ID lists, preventing mismatches and improving cache reliability.
  * Preserves existing single-entry mapping behavior and formatting; only ID handling was tightened.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->