### PR TITLE
remove console.warn from Image Component

### DIFF
--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -222,12 +222,6 @@ export const getEarlyHintFromSrcProps = (srcProps: {
 const Image = forwardRef<HTMLImageElement, Props>((props, ref) => {
   const { preload, loading = "lazy" } = props;
 
-  if (!props.height) {
-    console.warn(
-      `Missing height. This image will NOT be optimized: ${props.src}`,
-    );
-  }
-
   const shouldSetEarlyHint = !!props.setEarlyHint && preload;
   const srcSet = props.srcSet ??
     getSrcSet(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary runtime warning that appeared when images lacked height specification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->