### PR TITLE
fix(commerce): stop sending structured data to bots when explicitly disabled

### DIFF
--- a/commerce/utils/structuredData.ts
+++ b/commerce/utils/structuredData.ts
@@ -1,0 +1,16 @@
+// commerce/utils/structuredData.ts
+export type StructuredDataControl =
+  | "disable for users"
+  | "disable for all"
+  | "always include";
+
+export function shouldIncludeStructuredData(
+  jsonLD: unknown,
+  control: StructuredDataControl = "always include",
+  isBot: boolean,
+): boolean {
+  if (!jsonLD) return false;
+
+  return control !== "disable for all" &&
+    (control !== "disable for users" || isBot);
+}


### PR DESCRIPTION
## What is this Contribution About?

Fixes a bug where `ignoreStructuredData=true` was still sending JSON-LD to search engine bots, causing duplicate structured data on sites with custom LD+JSON implementations.

**Changes:**
- Replaces boolean `ignoreStructuredData` with explicit `structuredDataControl` prop offering three modes: `"always include"` (default), `"disable for users"` (bots only), `"disable for all"` (completely disabled)
- Extracts shared logic into reusable `shouldIncludeStructuredData` utility
- Maintains backward compatibility by deprecating old prop with fallback logic
- Applies fix to both PDP and PLP SEO sections

**Before:** Bots received duplicate `@type":"ProductDetailsPage"` when custom structured data existed
**After:** Sites can properly exclude section's structured data while maintaining custom implementations

## Issue Link
N/A - Bug identified during bot testing with curl

## Demonstration Link
Tested with Googlebot user-agent simulation - structured data now correctly excluded when configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds three granular structured-data control modes to fine-tune when JSON-LD is emitted, improving SEO behavior.
  * Smarter bot-aware delivery: structured data can be targeted differently for crawlers vs. regular users.

* **Deprecations**
  * Legacy boolean structured-data flag deprecated; migrate to the new control mechanism for greater flexibility and clearer defaults.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->