### PR TITLE
fix: blog author and category field

### DIFF
--- a/blog/core/handlePosts.ts
+++ b/blog/core/handlePosts.ts
@@ -103,7 +103,7 @@ export const sortPosts = async (
  */
 export const filterPostsByCategory = (posts: BlogPost[], slug?: string) =>
   slug
-    ? posts.filter(({ categories }) => categories.find((c) => c.slug === slug))
+    ? posts.filter(({ categories }) => categories?.find((c) => c.slug === slug))
     : posts;
 
 /**
@@ -139,7 +139,7 @@ export const filterRelatedPosts = (
   slug: string[],
 ) =>
   posts.filter(
-    ({ categories }) => categories.find((c) => slug.includes(c.slug)),
+    ({ categories }) => categories?.find((c) => slug.includes(c.slug)),
   );
 
 /**

--- a/blog/loaders/BlogpostListing.ts
+++ b/blog/loaders/BlogpostListing.ts
@@ -92,7 +92,7 @@ export default async function BlogPostList(
       return null;
     }
 
-    const category = slicedPosts[0].categories.find((c) => c.slug === slug);
+    const category = slicedPosts[0].categories?.find((c) => c.slug === slug);
     return {
       posts: slicedPosts,
       pageInfo: toPageInfo(handledPosts, postsPerPage, pageNumber, params),

--- a/blog/types.ts
+++ b/blog/types.ts
@@ -34,12 +34,12 @@ export interface BlogPost {
    * @widget blog
    * @collection authors
    */
-  authors: Author[];
+  authors?: Author[];
   /**
    * @widget blog
    * @collection categories
    */
-  categories: Category[];
+  categories?: Category[];
   /**
    * @format date
    */


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Please provide a brief description of the changes or enhancements you are proposing in this pull request.

## Issue Link

Please link to the relevant issue that this pull request addresses:

- Issue: [#ISSUE_NUMBER](link_to_issue)

## Loom Video

> Record a quick screencast describing your changes to help the team understand and review your contribution. This will greatly assist in the review process.

## Demonstration Link

> Provide a link to a branch or environment where this pull request can be tested and seen in action.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes in blog listing and category filters when posts lack authors or categories. Makes these fields optional and safely handles missing categories during lookups.

- **Bug Fixes**
  - Made `authors` and `categories` optional in `BlogPost` type.
  - Added optional chaining to category filters in `handlePosts` and `BlogpostListing` to prevent runtime errors when fields are missing.

<sup>Written for commit 4dc65a49c6d6b21c838e826da5888e92b8c4f604. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced blog system stability by safely handling blog posts without assigned categories or authors, preventing crashes during post filtering and listing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->