### PR TITLE
feat(blog): resolve pageSlug pattern in Template section

### DIFF
--- a/blog/sections/Template.tsx
+++ b/blog/sections/Template.tsx
@@ -1,12 +1,15 @@
 import { BlogPost } from "../types.ts";
 import { CSS } from "../static/css.ts";
 import { renderSection } from "../../website/pages/Page.tsx";
+import { AppContext } from "../mod.ts";
 
 export interface Props {
   post: BlogPost | null;
 }
 
-export default function Template({ post }: Props) {
+export default function Template(
+  { post, pageSlug }: ReturnType<typeof loader>,
+) {
   if (!post) return null;
 
   const {
@@ -18,6 +21,21 @@ export default function Template({ post }: Props) {
     alt,
     sections,
   } = post;
+
+  if (pageSlug) {
+    const { slug, categories } = post;
+    const categorySlug = categories?.[0]?.slug ?? "";
+    const resolvedUrl = pageSlug
+      .replace(":category", categorySlug)
+      .replace(":slug", slug);
+
+    return (
+      <iframe
+        src={resolvedUrl}
+        style="width:100%;height:100%;border:none;height:100vh;"
+      />
+    );
+  }
 
   return (
     <>
@@ -50,3 +68,10 @@ export default function Template({ post }: Props) {
     </>
   );
 }
+
+export const loader = (props: Props, _req: Request, ctx: AppContext) => {
+  return {
+    ...props,
+    pageSlug: ctx.pageSlug,
+  };
+};

--- a/vtex/loaders/legacy/productListingPage.ts
+++ b/vtex/loaders/legacy/productListingPage.ts
@@ -451,7 +451,10 @@ export const cacheKey = (props: Props, req: Request, ctx: AppContext) => {
   const searchTerm = url.searchParams.get("ft") || url.searchParams.get("q");
   const hasMap = url.search.includes("map=");
   const cachedSearchTerms = ctx.cachedSearchTerms ?? [];
-  if (hasMap || (searchTerm && !cachedSearchTerms.includes(searchTerm.toLowerCase()))) {
+  if (
+    hasMap ||
+    (searchTerm && !cachedSearchTerms.includes(searchTerm.toLowerCase()))
+  ) {
     return null;
   }
   const fq = [

--- a/vtex/loaders/legacy/productListingPage.ts
+++ b/vtex/loaders/legacy/productListingPage.ts
@@ -449,8 +449,9 @@ export const cacheKey = (props: Props, req: Request, ctx: AppContext) => {
   const url = new URL(props.pageHref || req.url);
 
   const searchTerm = url.searchParams.get("ft") || url.searchParams.get("q");
+  const hasMap = url.search.includes("map=");
   const cachedSearchTerms = ctx.cachedSearchTerms ?? [];
-  if (searchTerm && !cachedSearchTerms.includes(searchTerm.toLowerCase())) {
+  if (hasMap || (searchTerm && !cachedSearchTerms.includes(searchTerm.toLowerCase()))) {
     return null;
   }
   const fq = [


### PR DESCRIPTION
## Summary

- When `pageSlug` is configured in the Blog app state, the `Template` section now resolves `:slug` and `:category` tokens using the post own slug and first category slug
- Renders an iframe pointing to the resolved URL instead of the default post layout

Supported patterns:
- `/:slug`
- `/:category/:slug`
- `/post/:slug`
- `/post/:category/:slug`

## Test plan

- [ ] Set `pageSlug` to `/:slug` in the Blog app config and confirm the iframe src matches the post slug
- [ ] Set `pageSlug` to `/:category/:slug` and confirm the first category slug is substituted correctly
- [ ] Confirm posts without `pageSlug` still render normally


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `pageSlug` pattern resolution to the blog Template and renders an iframe to the resolved URL. Also skips caching product listing pages when `map=` is present to avoid stale results.

- **New Features**
  - Resolve `:slug` and `:category` in `pageSlug` and render an iframe to the URL. Supports `/:slug`, `/:category/:slug`, `/post/:slug`, `/post/:category/:slug`.
  - Add a `loader` to read `pageSlug` from `AppContext`.

- **Bug Fixes**
  - In `productListingPage` cache key, bypass cache when the URL contains `map=` to prevent incorrect cached results.

<sup>Written for commit f1cb32a946250f8f79ca53a78dd4aeb8c176960c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-aware rendering for blog posts with iframe support based on page context

* **Performance**
  * Optimized caching logic for product listing pages to improve handling of certain query parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->