### PR TITLE
feat(blog): add typed State with pageSlug to replace any

### DIFF
--- a/blog/mod.ts
+++ b/blog/mod.ts
@@ -1,8 +1,13 @@
 import manifest, { Manifest } from "./manifest.gen.ts";
 import { PreviewContainer } from "../utils/preview.tsx";
 import { type App, type FnContext } from "@deco/deco";
-// deno-lint-ignore no-explicit-any
-export type State = any;
+export type State = {
+  /**
+   * @title Page Slug
+   * @description The slug of the BlogPostPage to embed. Use :category and :slug.
+   */
+  pageSlug?: string;
+};
 export type AppContext = FnContext<State, Manifest>;
 /**
  * @title Deco Blog


### PR DESCRIPTION
## Summary

- Replaces `State = any` in `blog/mod.ts` with a proper typed interface
- Adds `pageSlug?: string` field with JSDoc annotations (`@title` and `@description`) for Deco admin UI integration

## Test plan

- [ ] Verify the `pageSlug` field appears correctly in the Deco admin UI for the Blog app
- [ ] Check that existing blog functionality is unaffected


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the `State` type in `blog/mod.ts` with a typed object and added an optional `pageSlug` field. This improves type safety and surfaces a Page Slug field in the Deco admin UI for embedding a BlogPostPage (supports :category and :slug); no behavior changes.

<sup>Written for commit bf9184c5500895e84e8c6b20d93a68cdc8ce6e20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

