### PR TITLE
Migrate asset URLs to decoims.com (clean cutover, drop ENABLE_AZION_ASSETS)

### DIFF
--- a/1001fx/mod.ts
+++ b/1001fx/mod.ts
@@ -19,7 +19,7 @@ export interface Props {
  * @appName 1001fx
  * @description Process and transform audio and video using AI-powered tools.
  * @category Media
- * @logo https://assets.decocache.com/mcp/b9109fab-421a-4275-911d-cec5651737d2/1001fx.svg
+ * @logo https://decoims.com/mcp/b9109fab-421a-4275-911d-cec5651737d2/1001fx.svg
  */
 export default function FX1001App(props: Props): App<Manifest, State> {
   const { apiKey } = props;

--- a/airtable/mod.ts
+++ b/airtable/mod.ts
@@ -64,7 +64,7 @@ export type AppContext = FnContext<State & McpContext<Props>, Manifest>;
  * @appName airtable
  * @description Access and manage data from Airtable bases, tables, and records.
  * @category Productivity
- * @logo https://assets.decocache.com/mcp/e724f447-3b98-46c4-9194-6b79841305a2/Airtable.svg
+ * @logo https://decoims.com/mcp/e724f447-3b98-46c4-9194-6b79841305a2/Airtable.svg
  */
 export default function App(
   props: Props,

--- a/apify/mod.ts
+++ b/apify/mod.ts
@@ -31,7 +31,7 @@ export type AppContext = FnContext<State, Manifest>;
  * @appName apify
  * @description Automate scraping and browser workflows with prebuilt actors.
  * @category Automation
- * @logo https://assets.decocache.com/mcp/4eda8c60-503f-4001-9edb-89de961ab7f0/Apify.svg
+ * @logo https://decoims.com/mcp/4eda8c60-503f-4001-9edb-89de961ab7f0/Apify.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const { token } = props;

--- a/aws/mod.ts
+++ b/aws/mod.ts
@@ -65,7 +65,7 @@ export interface State extends Props {
  * @appName aws
  * @description Track cloud costs, budgets, and billing insights using AWS tools.
  * @category Analytics
- * @logo https://assets.decocache.com/mcp/ece686cd-c380-41e8-97c8-34616a3bf5ba/AWS.svg
+ * @logo https://decoims.com/mcp/ece686cd-c380-41e8-97c8-34616a3bf5ba/AWS.svg
  */
 export default function App(state: Props): App<Manifest, State> {
   // Validate required credentials

--- a/barte/mod.ts
+++ b/barte/mod.ts
@@ -30,7 +30,7 @@ export interface State extends Omit<Props, "token"> {
  * @appName barte
  * @description Centralize and structure your product data with Barte’s catalog tools.
  * @category Payment Platform
- * @logo https://assets.decocache.com/mcp/2b4f178a-73be-44c9-a342-4d4c0e9bcad4/Barte.svg
+ * @logo https://decoims.com/mcp/2b4f178a-73be-44c9-a342-4d4c0e9bcad4/Barte.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const { token } = props;

--- a/brasilapi/mod.ts
+++ b/brasilapi/mod.ts
@@ -25,7 +25,7 @@ export interface State {
  * @appName brasilapi
  * @description Retrieve Brazilian data like CEPs, CNPJs, holidays, and more.
  * @category APIs Públicas
- * @logo https://assets.decocache.com/mcp/bd684c47-0525-4659-a298-97fa60ba24f1/BrasilAPI.svg
+ * @logo https://decoims.com/mcp/bd684c47-0525-4659-a298-97fa60ba24f1/BrasilAPI.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const { cacheDuration } = props;

--- a/browser-use/mod.ts
+++ b/browser-use/mod.ts
@@ -25,7 +25,7 @@ export interface State {
  * @appName browser-use
  * @description Let agents control browsers to automate UI-based tasks.
  * @category AI Tools
- * @logo https://assets.decocache.com/mcp/1a7a2573-023c-43ed-82a2-95d77adca3db/Browser-Use.svg
+ * @logo https://decoims.com/mcp/1a7a2573-023c-43ed-82a2-95d77adca3db/Browser-Use.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const { token } = props;

--- a/clearsale/mod.ts
+++ b/clearsale/mod.ts
@@ -36,7 +36,7 @@ export interface State {
  * @appName clearsale
  * @description Evaluate risk and prevent fraud in online transactions.
  * @category Payment
- * @logo https://assets.decocache.com/mcp/ac358fdd-be54-4656-b1e8-28e37198fb86/Clearsale.svg
+ * @logo https://decoims.com/mcp/ac358fdd-be54-4656-b1e8-28e37198fb86/Clearsale.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const { username, password, homolog } = props;

--- a/deno-deploy/mod.ts
+++ b/deno-deploy/mod.ts
@@ -33,7 +33,7 @@ export interface State {
  * @appName deno-deploy
  * @description Deploy edge functions globally with Deno’s cloud platform.
  * @category Cloud Services
- * @logo https://assets.decocache.com/mcp/f8ee96b7-9d64-4680-a2a8-008bf5f0a6e9/Deno-Deploy.svg
+ * @logo https://decoims.com/mcp/f8ee96b7-9d64-4680-a2a8-008bf5f0a6e9/Deno-Deploy.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const { token, apiVersion = "v1" } = props;

--- a/discohook/mod.ts
+++ b/discohook/mod.ts
@@ -15,7 +15,7 @@ export interface State {
  * @appName discohook
  * @description Send rich, formatted messages to Discord channels.
  * @category Communication
- * @logo https://assets.decocache.com/mcp/a626d828-e641-4931-8557-850276e91702/DiscordWebhook.svg
+ * @logo https://decoims.com/mcp/a626d828-e641-4931-8557-850276e91702/DiscordWebhook.svg
  */
 export default function App(): App<Manifest, State> {
   const api = createHttpClient<DiscordWebhookClient>({

--- a/elevenlabs/mod.ts
+++ b/elevenlabs/mod.ts
@@ -32,7 +32,7 @@ interface Props {
  * @appName elevenlabs
  * @description Turn text into realistic speech with ElevenLabs voice models.
  * @category Tool
- * @logo https://assets.decocache.com/mcp/d5b8b14e-7611-4cdd-8453-cad6a4c23703/ElevenLabs.svg
+ * @logo https://decoims.com/mcp/d5b8b14e-7611-4cdd-8453-cad6a4c23703/ElevenLabs.svg
  */
 export default function ElevenLabs(props: Props): App<Manifest, State> {
   const { apiKey, baseURL, headers } = props;

--- a/exa/mod.ts
+++ b/exa/mod.ts
@@ -33,7 +33,7 @@ export interface State {
  * @appName exa
  * @description Run semantic web searches powered by Exa’s intelligent retrieval.
  * @category AI Tools
- * @logo https://assets.decocache.com/mcp/e71a6d5a-81e1-486d-91f9-8f950c8b9f91/ExaAI.svg
+ * @logo https://decoims.com/mcp/e71a6d5a-81e1-486d-91f9-8f950c8b9f91/ExaAI.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const { apiKey } = props;

--- a/figma/mod.ts
+++ b/figma/mod.ts
@@ -20,7 +20,7 @@ export type AppContext = FnContext<State, Manifest>;
  * @appName figma
  * @title Figma
  * @description Fetch structured design data directly from your Figma files.
- * @logo https://assets.decocache.com/mcp/eb714f8a-404b-4b8e-bfc4-f3ce5bde6f51/Figma.svg
+ * @logo https://decoims.com/mcp/eb714f8a-404b-4b8e-bfc4-f3ce5bde6f51/Figma.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const figma = props.accessToken

--- a/github/mod.ts
+++ b/github/mod.ts
@@ -22,7 +22,7 @@ export type AppContext = FnContext<State & McpContext<Props>, Manifest>;
  * @appName github
  * @title GitHub
  * @description Create and manage issues, repositories, and pull requests.
- * @logo https://assets.decocache.com/mcp/02e06fe6-a820-4c42-b960-bce022362702/GitHub.svg
+ * @logo https://decoims.com/mcp/02e06fe6-a820-4c42-b960-bce022362702/GitHub.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const { access_token } = props;

--- a/google-calendar/mod.ts
+++ b/google-calendar/mod.ts
@@ -43,7 +43,7 @@ export type AppContext = FnContext<State & McpContext<Props>, Manifest>;
  * @appName google-calendar
  * @description Create and retrieve events from your calendar.
  * @category Produtividade
- * @logo https://assets.decocache.com/mcp/b5fffe71-647a-461c-aa39-3da07b86cc96/Google-Meets.svg
+ * @logo https://decoims.com/mcp/b5fffe71-647a-461c-aa39-3da07b86cc96/Google-Meets.svg
  */
 export default function App(
   props: Props,

--- a/google-docs/mod.ts
+++ b/google-docs/mod.ts
@@ -54,7 +54,7 @@ export type AppContext = FnContext<State & McpContext<Props>, Manifest>;
  * @appName google-docs
  * @description Read, write, and edit content in Google Docs.
  * @category Produtividade
- * @logo https://assets.decocache.com/mcp/e0a00fae-ba76-487a-9f62-7b21bbb08d50/Google-Docs.svg
+ * @logo https://decoims.com/mcp/e0a00fae-ba76-487a-9f62-7b21bbb08d50/Google-Docs.svg
  */
 export default function App(
   props: Props,

--- a/google-drive/mod.ts
+++ b/google-drive/mod.ts
@@ -65,7 +65,7 @@ export type AppContext = FnContext<State & McpContext<Props>, Manifest>;
  * @appName google-drive
  * @description Access, organize, and manage files in Google Drive.
  * @category Productivity
- * @logo https://assets.decocache.com/mcp/bc609f7d-e7c7-433d-b432-93639c5c84bf/Google-Drive.svg
+ * @logo https://decoims.com/mcp/bc609f7d-e7c7-433d-b432-93639c5c84bf/Google-Drive.svg
  */
 export default function App(
   props: Props,

--- a/google-gmail/mod.ts
+++ b/google-gmail/mod.ts
@@ -56,7 +56,7 @@ export type AppContext = FnContext<State & McpContext<Props>, Manifest>;
  * @appName google-gmail
  * @description Send and retrieve messages from your Gmail inbox.
  * @category Produtividade
- * @logo https://assets.decocache.com/mcp/b4dbd04f-2d03-4e29-a881-f924f5946c4e/Gmail.svg
+ * @logo https://decoims.com/mcp/b4dbd04f-2d03-4e29-a881-f924f5946c4e/Gmail.svg
  */
 export default function App(
   props: Props,

--- a/google-sheets/mod.ts
+++ b/google-sheets/mod.ts
@@ -55,7 +55,7 @@ export type AppContext = FnContext<State & McpContext<Props>, Manifest>;
  * @appName google-sheets
  * @description Create, read, and update spreadsheets with structured data.
  * @category Productivity
- * @logo https://assets.decocache.com/mcp/0b05c082-ce9d-4879-9258-1acbecf9bf68/Google-Sheets.svg
+ * @logo https://decoims.com/mcp/0b05c082-ce9d-4879-9258-1acbecf9bf68/Google-Sheets.svg
  */
 export default function App(
   props: Props,

--- a/google-youtube/mod.ts
+++ b/google-youtube/mod.ts
@@ -55,7 +55,7 @@ export type AppContext = FnContext<State & McpContext<Props>, Manifest>;
  * @appName google-youtube
  * @description Search and retrieve videos, playlists, and channels.
  * @category Social
- * @logo https://assets.decocache.com/mcp/cac50532-150e-437d-a996-91fd9a0c115e/YouTube.svg
+ * @logo https://decoims.com/mcp/cac50532-150e-437d-a996-91fd9a0c115e/YouTube.svg
  */
 export default function App(
   props: Props,

--- a/grain/mod.ts
+++ b/grain/mod.ts
@@ -22,7 +22,7 @@ export type AppContext = FnContext<State, Manifest>;
  * @appName grain
  * @title Grain
  * @description Capture and summarize meetings with AI-powered transcriptions.
- * @logo https://assets.decocache.com/mcp/1bfc7176-e7be-487c-83e6-4b9e970a8e10/Grain.svg
+ * @logo https://decoims.com/mcp/1bfc7176-e7be-487c-83e6-4b9e970a8e10/Grain.svg
  * @version 1.0.0
  */
 export default function App(props: Props): App<Manifest, State> {

--- a/jira/mod.ts
+++ b/jira/mod.ts
@@ -28,7 +28,7 @@ export type AppContext = FnContext<State, Manifest>;
  * @appName jira
  * @title Jira
  * @description Create and update issues and comments in your Jira projects.
- * @logo https://assets.decocache.com/mcp/7bae17a9-cfdb-4969-99ca-436b7a4dcf40/Jira.svg
+ * @logo https://decoims.com/mcp/7bae17a9-cfdb-4969-99ca-436b7a4dcf40/Jira.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const jira = new JiraClient({

--- a/openai-mcp/mod.ts
+++ b/openai-mcp/mod.ts
@@ -19,7 +19,7 @@ export interface Props {
  * @name OpenAI Imagen
  * @description Generate detailed images from natural language prompts.
  * @category AI
- * @logo https://assets.decocache.com/mcp/1449ff20-a110-4753-81a1-4c116ba39336/OpenAI-Imagen.svg
+ * @logo https://decoims.com/mcp/1449ff20-a110-4753-81a1-4c116ba39336/OpenAI-Imagen.svg
  */
 export default function OpenAIApp(props: Props): App<Manifest, State> {
   const { apiKey } = props;

--- a/perplexity/mod.ts
+++ b/perplexity/mod.ts
@@ -32,7 +32,7 @@ export interface State {
  * @appName perplexity
  * @description Ask natural language questions and get grounded, web-backed answers.
  * @category AI and Machine Learning
- * @logo https://assets.decocache.com/mcp/1b3b7880-e7a5-413b-8db2-601e84b22bcd/Perplexity.svg
+ * @logo https://decoims.com/mcp/1b3b7880-e7a5-413b-8db2-601e84b22bcd/Perplexity.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const { apiKey, defaultModel = "sonar" } = props;

--- a/pinecone-assistant/mod.ts
+++ b/pinecone-assistant/mod.ts
@@ -35,7 +35,7 @@ const PINECONE_API_VERSION = "2025-10";
  * @appName pinecone-assistant
  * @description Build conversational agents using vector search from Pinecone.
  * @category IA
- * @logo https://assets.decocache.com/mcp/57d30250-ed40-4f13-8b50-3a5ddff95ca0/Pinecone.svg
+ * @logo https://decoims.com/mcp/57d30250-ed40-4f13-8b50-3a5ddff95ca0/Pinecone.svg
  */
 export default function App(
   props: Props,

--- a/pncp/mod.ts
+++ b/pncp/mod.ts
@@ -11,7 +11,7 @@ export type AppContext = FnContext<State, Manifest>;
  * @appName pncp
  * @description Explore Brazil's public procurement data via PNCP.
  * @category Government
- * @logo https://assets.decocache.com/mcp/41461083-ef8c-496c-a336-ba6101b0b0f4/PNCP-gov-br.svg
+ * @logo https://decoims.com/mcp/41461083-ef8c-496c-a336-ba6101b0b0f4/PNCP-gov-br.svg
  */
 export default function App(): App<Manifest, State> {
   const api = createHttpClient<PNCPClient>({

--- a/querido-diario/mod.ts
+++ b/querido-diario/mod.ts
@@ -15,7 +15,7 @@ export interface State {
  * @appName querido-diario
  * @description Search and explore Brazilian government gazettes.
  * @category Government
- * @logo https://assets.decocache.com/mcp/0bb451a6-db7c-4f9a-9720-8f87b8898da5/QueridoDirio.svg
+ * @logo https://decoims.com/mcp/0bb451a6-db7c-4f9a-9720-8f87b8898da5/QueridoDirio.svg
  */
 export default function App(): App<Manifest, State> {
   const api = createHttpClient<QueridoDiarioClient>({

--- a/rd-station-marketing/mod.ts
+++ b/rd-station-marketing/mod.ts
@@ -25,7 +25,7 @@ export interface State {
  * @appName rd-station-marketing
  * @description Manage contacts, segments, and campaigns in RD Station.
  * @category Marketing
- * @logo https://assets.decocache.com/mcp/ed2e7962-6774-4ed9-9275-e22f7f1f267a/RD-Station.svg
+ * @logo https://decoims.com/mcp/ed2e7962-6774-4ed9-9275-e22f7f1f267a/RD-Station.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const { token } = props;

--- a/readwise/mod.ts
+++ b/readwise/mod.ts
@@ -26,7 +26,7 @@ export interface State {
  * @appName readwise
  * @description Access highlights and notes synced from your favorite reading sources.
  * @category Productivity
- * @logo https://assets.decocache.com/mcp/609eb29f-fa70-4170-ae1c-4108f3a42ea0/Readwise.svg
+ * @logo https://decoims.com/mcp/609eb29f-fa70-4170-ae1c-4108f3a42ea0/Readwise.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const { token } = props;

--- a/reflect/mod.ts
+++ b/reflect/mod.ts
@@ -22,7 +22,7 @@ export type AppContext = FnContext<State, Manifest>;
  * @appName reflect
  * @title Reflect
  * @description Capture and organize your thoughts in a connected notes app.
- * @logo https://assets.decocache.com/mcp/dede3890-36bb-4cd4-a574-2c10fed1fb85/Reflect.svg
+ * @logo https://decoims.com/mcp/dede3890-36bb-4cd4-a574-2c10fed1fb85/Reflect.svg
  * @version 1.0.0
  */
 export default function App(props: Props): App<Manifest, State> {

--- a/resend/mod.ts
+++ b/resend/mod.ts
@@ -34,7 +34,7 @@ export interface State extends Props {
  * @appName resend
  * @title Resend
  * @description Send transactional or marketing emails with a reliable delivery API.
- * @logo https://assets.decocache.com/mcp/932e4c3a-6045-40af-9fd1-42894bdd138e/Resend.svg
+ * @logo https://decoims.com/mcp/932e4c3a-6045-40af-9fd1-42894bdd138e/Resend.svg
  */
 export default function App({
   apiKey,

--- a/serper/mod.ts
+++ b/serper/mod.ts
@@ -26,7 +26,7 @@ export interface State {
  * @appName serper
  * @description Perform intelligent Google searches with structured results.
  * @category SEO
- * @logo https://assets.decocache.com/mcp/ffd61ea7-851d-4a8b-8a02-dedb0d5156ed/Serper.svg
+ * @logo https://decoims.com/mcp/ffd61ea7-851d-4a8b-8a02-dedb0d5156ed/Serper.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const { apiKey } = props;

--- a/shopify-mcp/mod.ts
+++ b/shopify-mcp/mod.ts
@@ -14,7 +14,7 @@ export const color = 0x96BF48;
  * @appName shopify-mcp
  * @description Manage products, carts, and checkout flows across channels.
  * @category Ecommmerce
- * @logo https://assets.decocache.com/mcp/37122d09-6ceb-4d25-a641-11ce4af8a19b/Shopify.svg
+ * @logo https://decoims.com/mcp/37122d09-6ceb-4d25-a641-11ce4af8a19b/Shopify.svg
  */
 export default function App(
   props: AppProps,

--- a/shopify/mod.ts
+++ b/shopify/mod.ts
@@ -59,7 +59,7 @@ export const color = 0x96BF48;
  * @title Shopify
  * @description Manage products, carts, and checkout flows across channels.
  * @category Ecommmerce
- * @logo https://assets.decocache.com/mcp/37122d09-6ceb-4d25-a641-11ce4af8a19b/Shopify.svg
+ * @logo https://decoims.com/mcp/37122d09-6ceb-4d25-a641-11ce4af8a19b/Shopify.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const { storeName, storefrontAccessToken, adminAccessToken } = props;

--- a/slack/mod.ts
+++ b/slack/mod.ts
@@ -123,7 +123,7 @@ export type AppContext = FnContext<State & McpContext<Props>, Manifest>;
  * @appName slack
  * @title Slack
  * @description Send messages and automate actions in Slack channels.
- * @logo https://assets.decocache.com/mcp/f7e005a9-1c53-48f7-989b-955baa422be1/Slack.svg
+ * @logo https://decoims.com/mcp/f7e005a9-1c53-48f7-989b-955baa422be1/Slack.svg
  */
 export default function App(
   appProps: Props,

--- a/spotify/mod.ts
+++ b/spotify/mod.ts
@@ -58,7 +58,7 @@ export type AppContext = FnContext<State & McpContext<Props>, Manifest>;
  * @appName spotify
  * @description Search and retrieve music, albums, artists, and playlists.
  * @category Music
- * @logo https://assets.decocache.com/mcp/18f88493-1165-40a8-b165-31d15a367f16/Spotify.svg
+ * @logo https://decoims.com/mcp/18f88493-1165-40a8-b165-31d15a367f16/Spotify.svg
  */
 export default function App(
   props: Props,

--- a/stability/mod.ts
+++ b/stability/mod.ts
@@ -24,7 +24,7 @@ interface Props {
  * @appName stability
  * @description Create images from text using Stability AI’s diffusion models.
  * @category Tool
- * @logo https://assets.decocache.com/mcp/438d786a-4266-4196-876d-eccde1310e24/Stability.svg
+ * @logo https://decoims.com/mcp/438d786a-4266-4196-876d-eccde1310e24/Stability.svg
  */
 export default function Stability(props: Props): App<Manifest, State> {
   const { apiKey, previewUrl } = props;

--- a/superfrete/mod.ts
+++ b/superfrete/mod.ts
@@ -40,7 +40,7 @@ export interface State extends Omit<Props, "token"> {
  * @appName superfrete
  * @description Calculate shipping prices and manage freight logistics.
  * @category Logistics
- * @logo https://assets.decocache.com/mcp/2fdb628e-c10c-4fac-8985-b55e383a64b2/SuperFrete.svg
+ * @logo https://decoims.com/mcp/2fdb628e-c10c-4fac-8985-b55e383a64b2/SuperFrete.svg
  */
 export default function SuperFreteApp(props: Props): App<Manifest, State> {
   const { token, environment = "sandbox", timeout = 30000 } = props;

--- a/tiny/mod.ts
+++ b/tiny/mod.ts
@@ -38,7 +38,7 @@ export interface State {
  * @appName tiny
  * @description Sync products, contacts, invoices, and financial data.
  * @category ERP
- * @logo https://assets.decocache.com/mcp/c073765e-e869-4244-9504-1edf6af02073/TinyERP.svg
+ * @logo https://decoims.com/mcp/c073765e-e869-4244-9504-1edf6af02073/TinyERP.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const { token, baseUrl = "https://api.tiny.com.br/public-api/v3" } = props;

--- a/tiptap-cloud/mod.ts
+++ b/tiptap-cloud/mod.ts
@@ -24,7 +24,7 @@ interface Props {
  * @appName tiptap-cloud
  * @description Enable rich text editing with real-time collaboration.
  * @category Content
- * @logo https://assets.decocache.com/mcp/d22f78d5-354f-4dd0-a8f3-226ef05c7a9e/TiptapCloud.svg
+ * @logo https://decoims.com/mcp/d22f78d5-354f-4dd0-a8f3-226ef05c7a9e/TiptapCloud.svg
  */
 export default function TiptapCloud(props: Props): App<Manifest, State> {
   const { appId, apiSecret } = props;

--- a/turso-db/mod.ts
+++ b/turso-db/mod.ts
@@ -32,7 +32,7 @@ export interface State {
  * @appName turso-db
  * @description Run fast SQL queries on distributed SQLite databases.
  * @category Databases
- * @logo https://assets.decocache.com/mcp/3ebbc3e0-59d3-41b3-8cbc-3649b7ba8052/Turso-DB.svg
+ * @logo https://decoims.com/mcp/3ebbc3e0-59d3-41b3-8cbc-3649b7ba8052/Turso-DB.svg
  */
 export default function App(props: Props): App<Manifest, State> {
   const { token, databaseUrl } = props;

--- a/vertex/mod.ts
+++ b/vertex/mod.ts
@@ -30,7 +30,7 @@ interface Props {
  * @appName vertex
  * @description Use Google’s Vertex AI for language, vision, and generative tasks.
  * @category Tool
- * @logo https://assets.decocache.com/mcp/156feb88-2648-43e0-b7d9-40c1bc2e1d1d/Vertex.svg
+ * @logo https://decoims.com/mcp/156feb88-2648-43e0-b7d9-40c1bc2e1d1d/Vertex.svg
  */
 export default function Vertex(props: Props): App<Manifest, State> {
   const { googleCredentials, location, project } = props;

--- a/vidu/mod.ts
+++ b/vidu/mod.ts
@@ -25,7 +25,7 @@ export interface State {
  * @appName vidu
  * @description Transform text or images into video using Vidu's AI tools.
  * @category AI & Generative
- * @logo https://assets.decocache.com/mcp/551c6502-caaf-498a-82b5-d6c586244fbd/Vidu.svg
+ * @logo https://decoims.com/mcp/551c6502-caaf-498a-82b5-d6c586244fbd/Vidu.svg
  */
 export default function App(
   props: Props,

--- a/vnda/mod.ts
+++ b/vnda/mod.ts
@@ -52,7 +52,7 @@ export const color = 0x0C29D0;
  * @appName vnda
  * @description Manage your e-commerce catalog and sales using VNDA by Olist.
  * @category Ecommmerce
- * @logo https://assets.decocache.com/mcp/d15a3dfb-145f-4d13-8bdf-a9568b5a33a1/VNDA.svg
+ * @logo https://decoims.com/mcp/d15a3dfb-145f-4d13-8bdf-a9568b5a33a1/VNDA.svg
  */
 export default function VNDA(props: Props): App<Manifest, State> {
   const { authToken, publicUrl, sandbox } = props;

--- a/vtex/mod.ts
+++ b/vtex/mod.ts
@@ -117,7 +117,7 @@ export const color = 0xf71963;
  * @title VTEX
  * @description Power your store with product, inventory, and checkout tools from VTEX.
  * @category Ecommmerce
- * @logo https://assets.decocache.com/mcp/0d6e795b-cefd-4853-9a51-93b346c52c3f/VTEX.svg
+ * @logo https://decoims.com/mcp/0d6e795b-cefd-4853-9a51-93b346c52c3f/VTEX.svg
  */
 export default function VTEX(
   { appKey, appToken, account, publicUrl: _publicUrl, salesChannel, ...props }:

--- a/website/components/Events.tsx
+++ b/website/components/Events.tsx
@@ -12,7 +12,6 @@ interface EventsAPI {
 }
 interface FeatureFlags {
   bypassPlatformImageOptimization: boolean;
-  azionAssets: boolean;
   bypassDecoImageOptimization: boolean;
 }
 declare global {
@@ -33,7 +32,6 @@ declare global {
 }
 const BYPASS_PLATFORM_IMAGE_OPTIMIZATION =
   Deno.env.get("BYPASS_PLATFORM_IMAGE_OPTIMIZATION") === "true";
-const ENABLE_AZION_ASSETS = Deno.env.get("ENABLE_AZION_ASSETS") !== "false";
 const BYPASS_DECO_IMAGE_OPTIMIZATION =
   Deno.env.get("BYPASS_DECO_IMAGE_OPTIMIZATION") === "true";
 /**
@@ -102,7 +100,6 @@ function Events({ deco }: {
           segmentCookie: DECO_SEGMENT,
           featureFlags: {
             bypassPlatformImageOptimization: BYPASS_PLATFORM_IMAGE_OPTIMIZATION,
-            azionAssets: ENABLE_AZION_ASSETS,
             bypassDecoImageOptimization: BYPASS_DECO_IMAGE_OPTIMIZATION,
           },
         })}

--- a/website/components/Events.tsx
+++ b/website/components/Events.tsx
@@ -13,6 +13,7 @@ interface EventsAPI {
 interface FeatureFlags {
   bypassPlatformImageOptimization: boolean;
   bypassDecoImageOptimization: boolean;
+  cdnHost: string;
 }
 declare global {
   interface Window {
@@ -34,6 +35,7 @@ const BYPASS_PLATFORM_IMAGE_OPTIMIZATION =
   Deno.env.get("BYPASS_PLATFORM_IMAGE_OPTIMIZATION") === "true";
 const BYPASS_DECO_IMAGE_OPTIMIZATION =
   Deno.env.get("BYPASS_DECO_IMAGE_OPTIMIZATION") === "true";
+const DECO_CDN_HOST = Deno.env.get("DECO_CDN_HOST") ?? "https://decoims.com";
 /**
  * This function handles all ecommerce analytics events.
  * Add another ecommerce analytics modules here.
@@ -101,6 +103,7 @@ function Events({ deco }: {
           featureFlags: {
             bypassPlatformImageOptimization: BYPASS_PLATFORM_IMAGE_OPTIMIZATION,
             bypassDecoImageOptimization: BYPASS_DECO_IMAGE_OPTIMIZATION,
+            cdnHost: DECO_CDN_HOST,
           },
         })}
       />

--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -2,10 +2,25 @@ import { Head, IS_BROWSER } from "$fresh/runtime.ts";
 import type { JSX } from "preact";
 import { forwardRef } from "preact/compat";
 
-// Strip these prefixes before passing the remainder to decoims `?src=` so the
-// worker hits GCS directly instead of doing an absolute-URL hop.
-const ASSET_URL_PREFIX_TO_STRIP = [
-  "https://decoims.com/",
+const DEFAULT_CDN_HOST = "https://decoims.com";
+
+// CDN host can be overridden via DECO_CDN_HOST env var (server) or
+// window.DECO.featureFlags.cdnHost (browser, injected by Events.tsx).
+const getCdnHost = (): string => {
+  if (IS_BROWSER) {
+    // deno-lint-ignore no-explicit-any
+    return (globalThis as any).DECO?.featureFlags?.cdnHost ?? DEFAULT_CDN_HOST;
+  }
+  return Deno.env.get("DECO_CDN_HOST") ?? DEFAULT_CDN_HOST;
+};
+
+// Strip these prefixes before passing the remainder to the CDN's `?src=` so
+// the worker hits GCS directly instead of doing an absolute-URL hop. The
+// configured CDN host is included so a non-default DECO_CDN_HOST still
+// strips correctly; the GCS deco-assets bucket is kept unconditionally as a
+// well-known origin.
+const getAssetUrlPrefixesToStrip = (): readonly string[] => [
+  `${getCdnHost()}/`,
   "https://storage.googleapis.com/deco-assets/",
 ];
 
@@ -211,13 +226,13 @@ export const getOptimizedMediaUrl = (opts: OptimizationOptions) => {
   // signed URLs, cache busters, etc.) is preserved verbatim through
   // URLSearchParams encoding and recovered on the worker via
   // searchParams.get("src").
-  const src = ASSET_URL_PREFIX_TO_STRIP.reduce(
+  const src = getAssetUrlPrefixesToStrip().reduce(
     (acc, url) => acc.replace(url, ""),
     opts.originalSrc,
   );
   params.set("src", src);
 
-  return `https://decoims.com/image?${params}`;
+  return `${getCdnHost()}/image?${params}`;
 };
 
 export const getSrcSet = (

--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -206,13 +206,18 @@ export const getOptimizedMediaUrl = (opts: OptimizationOptions) => {
   height && params.set("height", `${height}`);
   quality && params.set("quality", quality);
 
-  const stripped = ASSET_URL_PREFIX_TO_STRIP.reduce(
+  // Strip known CDN prefixes so the worker can hit GCS directly instead of
+  // doing an absolute-URL hop. Anything left (path + any query string —
+  // signed URLs, cache busters, etc.) is preserved verbatim through
+  // URLSearchParams encoding and recovered on the worker via
+  // searchParams.get("src").
+  const src = ASSET_URL_PREFIX_TO_STRIP.reduce(
     (acc, url) => acc.replace(url, ""),
     opts.originalSrc,
   );
-  const imageSource = stripped.split("?")[0];
-  // src is passed separately to avoid URL encoding issues
-  return `https://decoims.com/image?${params}&src=${imageSource}`;
+  params.set("src", src);
+
+  return `https://decoims.com/image?${params}`;
 };
 
 export const getSrcSet = (

--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -1,14 +1,12 @@
 import { Head, IS_BROWSER } from "$fresh/runtime.ts";
 import type { JSX } from "preact";
 import { forwardRef } from "preact/compat";
-import { Manifest } from "../manifest.gen.ts";
 
-export const PATH: `/live/invoke/${keyof Manifest["loaders"]}` =
-  "/live/invoke/website/loaders/image.ts";
-const ASSET_URLS_TO_REPLACE = [
-  "https://assets.decocache.com/",
-  "https://deco-sites-assets.s3.sa-east-1.amazonaws.com/",
-  "https://data.decoassets.com/",
+// Strip these prefixes before passing the remainder to decoims `?src=` so the
+// worker hits GCS directly instead of doing an absolute-URL hop.
+const ASSET_URL_PREFIX_TO_STRIP = [
+  "https://decoims.com/",
+  "https://storage.googleapis.com/deco-assets/",
 ];
 
 export type SetEarlyHint = (hint: string) => void;
@@ -48,13 +46,6 @@ const bypassPlatformImageOptimization = () =>
     // deno-lint-ignore no-explicit-any
     ? (globalThis as any).DECO?.featureFlags?.bypassPlatformImageOptimization
     : Deno.env.get("BYPASS_PLATFORM_IMAGE_OPTIMIZATION") === "true";
-
-// Default is true
-const isAzionAssetsEnabled = () =>
-  IS_BROWSER
-    // deno-lint-ignore no-explicit-any
-    ? (globalThis as any).DECO?.featureFlags?.azionAssets
-    : Deno.env.get("ENABLE_AZION_ASSETS") !== "false";
 
 // Default is false
 const bypassDecoImageOptimization = () =>
@@ -213,23 +204,15 @@ export const getOptimizedMediaUrl = (opts: OptimizationOptions) => {
   params.set("fit", fit);
   params.set("width", `${width}`);
   height && params.set("height", `${height}`);
+  quality && params.set("quality", quality);
 
-  if (isAzionAssetsEnabled()) {
-    // only accepted for Azion for now
-    quality && params.set("quality", quality);
-
-    const originalSrc = ASSET_URLS_TO_REPLACE.reduce(
-      (acc, url) => acc.replace(url, ""),
-      opts.originalSrc,
-    );
-    const imageSource = originalSrc.split("?")[0];
-    // src is being passed separately to avoid URL encoding issues
-    return `https://deco-assets.edgedeco.com/image?${params}&src=${imageSource}`;
-  }
-
-  params.set("src", originalSrc);
-
-  return `${PATH}?${params}`;
+  const stripped = ASSET_URL_PREFIX_TO_STRIP.reduce(
+    (acc, url) => acc.replace(url, ""),
+    opts.originalSrc,
+  );
+  const imageSource = stripped.split("?")[0];
+  // src is passed separately to avoid URL encoding issues
+  return `https://decoims.com/image?${params}&src=${imageSource}`;
 };
 
 export const getSrcSet = (

--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -22,6 +22,9 @@ const getCdnHost = (): string => {
 const getAssetUrlPrefixesToStrip = (): readonly string[] => [
   `${getCdnHost()}/`,
   "https://storage.googleapis.com/deco-assets/",
+  "https://assets.decocache.com/",
+  "https://deco-sites-assets.s3.sa-east-1.amazonaws.com/",
+  "https://data.decoassets.com/",
 ];
 
 export type SetEarlyHint = (hint: string) => void;

--- a/website/loaders/image.ts
+++ b/website/loaders/image.ts
@@ -1,11 +1,13 @@
 import { HttpError } from "../../utils/http.ts";
-import { PATH } from "../components/Image.tsx";
 import { Params as Props } from "../utils/image/engine.ts";
 import { engine as cloudflare } from "../utils/image/engines/cloudflare/engine.ts";
 import { engine as deco } from "../utils/image/engines/deco/engine.ts";
 import { engine as passThrough } from "../utils/image/engines/passThrough/engine.ts";
 import { engine as wasm } from "../utils/image/engines/wasm/engine.ts";
 import { AppContext } from "../mod.ts";
+
+// Cache namespace key for this loader. Matches the route this file is served at.
+const PATH = "/live/invoke/website/loaders/image.ts";
 
 const ENGINES = [
   passThrough,


### PR DESCRIPTION
## Summary

- **`website/components/Image.tsx`** — Always builds `https://decoims.com/image?...&src=<key>` URLs. Drops the Azion code branch, the `isAzionAssetsEnabled()` helper, and the `ENABLE_AZION_ASSETS` env flag entirely. Strip-prefix list shrunk to `decoims.com/` and `storage.googleapis.com/deco-assets/` so the worker hits GCS directly instead of doing an absolute-URL hop.
- **`website/components/Events.tsx`** — Removes `azionAssets` from `FeatureFlags` and stops publishing it on `window.DECO.featureFlags`. Removes the `ENABLE_AZION_ASSETS` env read.
- **`website/loaders/image.ts`** — Inlines the `PATH` constant it used to import from `Image.tsx` (it was the only consumer).
- **45 app `mod.ts` files** — Mechanical `@logo` URL swap from `assets.decocache.com` to `decoims.com`. Logos are SVGs and decoims routes those through `handleAsset` (plain GCS proxy, no transform), so this is a hostname-only change.

## Why

Per the migration plan, all asset URLs in deco move to `decoims.com`. This is the **clean cutover** for the storefront: no fallbacks to `assets.decocache.com` or `deco-assets.edgedeco.com`, no feature flag toggle. The URL contract on `decoims.com` is documented in [decocms/decoims#1](https://github.com/decocms/decoims/pull/1).

## Behavior change to be aware of

`decoims.com/image?...` defaults to `quality=low` (60) when no `quality` param is set. Azion previously defaulted to `80`. This is intentional per product direction — explicit quality requests are still honored, and the admin asset-copy picker (separate PR in `deco-sites/admin`) lets users pin a higher quality on a per-asset basis when needed.

## Compatibility

- Existing CMS content with `assets.decocache.com` URLs continues to resolve — `decoims.com/image?src=https://assets.decocache.com/...` still works (one extra hop) until a separate codemod rewrites stored URLs to bare keys.
- The companion admin PR strips legacy domains from runtime whitelists; storefronts on the new `Image.tsx` will no longer emit those domains.

## Test plan

- [ ] Local: storefront homepage renders all hero/product images via `decoims.com/image?...`.
- [ ] Inspect a rendered `<img srcset>` and confirm there is no `deco-assets.edgedeco.com` URL.
- [ ] Confirm `window.DECO.featureFlags` no longer has `azionAssets`.
- [ ] Spot-check 3-4 logos in the deco admin marketplace render correctly.
- [ ] Check that an explicit `?quality=high` request returns a higher-quality variant than the default.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut over all storefront and app asset URLs to `decoims.com`, removed Azion and the `ENABLE_AZION_ASSETS` flag, and made the CDN host configurable. Image URLs now preserve query strings and strip more legacy domains to avoid extra hops.

- **Refactors**
  - `website/components/Image.tsx`: always build `${cdnHost}/image?...&src=<src>` using `DECO_CDN_HOST` (server) or `window.DECO.featureFlags.cdnHost` (client); forward `quality`; preserve the original `src` query string via `URLSearchParams.set`; strip prefixes for the configured CDN host, GCS `deco-assets`, and additional legacy domains to hit GCS directly.
  - `website/components/Events.tsx`: remove `azionAssets` and the `ENABLE_AZION_ASSETS` read; add `cdnHost` to feature flags from `DECO_CDN_HOST` (default `https://decoims.com`).
  - `website/loaders/image.ts`: inline the loader path constant.
  - 45 app `mod.ts`: switch `@logo` URLs from `assets.decocache.com` to `decoims.com` (hostname-only).

- **Migration**
  - No feature flag. Storefront no longer emits `assets.decocache.com` or `deco-assets.edgedeco.com` URLs.
  - Default image quality is 60 when `quality` is unset; set `quality` explicitly if higher is needed.
  - Optionally set `DECO_CDN_HOST`; the client picks it up via `featureFlags.cdnHost`.
  - Legacy content with old domains continues to resolve via the configured CDN host using `.../image?src=...` until content is rewritten.

<sup>Written for commit 8a367ea2286bb469d7c109e9f57de4c47023ca04. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/apps/pull/1577?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Updated asset URLs across multiple app integrations

* **Infrastructure**
  - Consolidated image optimization to use unified service endpoints
  - Streamlined platform configuration by removing legacy feature flags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->