### PR TITLE
fix: handle optional integrationToken in App component

### DIFF
--- a/linx/mod.ts
+++ b/linx/mod.ts
@@ -37,7 +37,7 @@ export const color = 0xFF6A3B;
  * @logo https://raw.githubusercontent.com/deco-cx/apps/main/linx/logo.png
  */
 export default function App({ account, cdn, integrationToken }: State) {
-  const token = integrationToken.get();
+  const token = integrationToken?.get();
   const headers = new Headers({
     "Accept": "application/json",
     "User-Agent":


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Please provide a brief description of the changes or enhancements you are proposing in this pull request.

## Issue Link

Please link to the relevant issue that this pull request addresses:

- Issue: [#ISSUE_NUMBER](link_to_issue)

## Loom Video

> Record a quick screencast describing your changes to help the team understand and review your contribution. This will greatly assist in the review process.

## Demonstration Link

> Provide a link to a branch or environment where this pull request can be tested and seen in action.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented a runtime error when `integrationToken` is missing by making the token access optional in the `App` component. The app now runs without a token and behaves the same when one is provided.

- **Bug Fixes**
  - Use `integrationToken?.get()` in `linx/mod.ts` to avoid crashes when the token is not configured.

<sup>Written for commit 9fb63066419f8afa63f4529a2920267219698cdd. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/apps/pull/1579?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token retrieval to safely handle cases where the integration token is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->