### PR TITLE
fix: validate postMessage origin in LiveControls to prevent XSS

### DIFF
--- a/website/components/_Controls.tsx
+++ b/website/components/_Controls.tsx
@@ -59,8 +59,32 @@ const snippet = (live: Live) => {
       globalThis.window.location.href = `${href}`;
     }
   };
+  const TRUSTED_ORIGINS = [
+    "https://deco.cx",
+    "https://admin.deco.cx",
+    "https://play.deco.cx",
+    "https://admin-cx.deco.page",
+    "https://deco.chat",
+    "https://admin.decocms.com",
+    "https://decocms.com",
+    "https://studio.decocms.com",
+  ];
+  const isTrustedOrigin = (origin: string) =>
+    TRUSTED_ORIGINS.indexOf(origin) !== -1 ||
+    (origin.startsWith("https://") && origin.endsWith(".deco.cx")) ||
+    origin === globalThis.window.location.origin;
+
   const onMessage = (event: MessageEvent<EditorEvent>) => {
+    if (!isTrustedOrigin(event.origin)) {
+      return;
+    }
     const { data } = event;
+    if (
+      typeof data !== "object" || data === null ||
+      typeof (data as { type?: unknown }).type !== "string"
+    ) {
+      return;
+    }
     switch (data.type) {
       case "editor::inject": {
         return eval(data.args.script);


### PR DESCRIPTION
Mirrors deco-cx/deco#1183. Adds a trusted-origin allowlist and message shape validation before dispatching `editor::inject`, which calls `eval` on attacker-controlled input.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates postMessage origin and data shape in LiveControls to block XSS via `editor::inject`. Adds a trusted-origin allowlist and guards so `eval` only runs for trusted, well-formed messages.

- **Bug Fixes**
  - Added `TRUSTED_ORIGINS` allowlist (includes same-origin and `*.deco.cx`).
  - Early return on untrusted origins.
  - Validate payload is an object with a string `type` before handling.

<sup>Written for commit ad09bed52f83800026e53b2bf3ed2e8fca6bfe17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by adding validation checks for incoming messages, including origin verification against a trusted list and data type validation to prevent unauthorized or malformed requests from being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->