### PR TITLE
feat(image): add defaultImageQuality config to website mod.ts

### DIFF
--- a/website/components/Events.tsx
+++ b/website/components/Events.tsx
@@ -14,6 +14,7 @@ interface FeatureFlags {
   bypassPlatformImageOptimization: boolean;
   bypassDecoImageOptimization: boolean;
   cdnHost: string;
+  defaultImageQuality?: string;
 }
 declare global {
   interface Window {

--- a/website/components/Events.tsx
+++ b/website/components/Events.tsx
@@ -14,7 +14,6 @@ interface FeatureFlags {
   bypassPlatformImageOptimization: boolean;
   bypassDecoImageOptimization: boolean;
   cdnHost: string;
-  defaultImageQuality?: string;
 }
 declare global {
   interface Window {

--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -78,7 +78,7 @@ export type QualityOptions = "low" | "medium" | "high" | "original"; // 60% - 70
 export type DefaultQualityOptions = "low" | "medium" | "high";
 
 export const DefaultImageQualityContext = createContext<
-  DefaultQualityOptions | undefined
+  QualityOptions | undefined
 >(undefined);
 
 interface OptimizationOptions {

--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -1,6 +1,8 @@
 import { Head, IS_BROWSER } from "$fresh/runtime.ts";
 import type { JSX } from "preact";
+import { createContext } from "preact";
 import { forwardRef } from "preact/compat";
+import { useContext } from "preact/hooks";
 
 const DEFAULT_CDN_HOST = "https://decoims.com";
 
@@ -73,6 +75,10 @@ const bypassDecoImageOptimization = () =>
     : Deno.env.get("BYPASS_DECO_IMAGE_OPTIMIZATION") === "true";
 
 export type QualityOptions = "low" | "medium" | "high" | "original"; // 60% - 70% - 80% - 100%
+
+export const DefaultImageQualityContext = createContext<
+  QualityOptions | undefined
+>(undefined);
 
 interface OptimizationOptions {
   originalSrc: string;
@@ -302,6 +308,8 @@ export const getEarlyHintFromSrcProps = (srcProps: {
 
 const Image = forwardRef<HTMLImageElement, Props>((props, ref) => {
   const { preload, loading = "lazy" } = props;
+  const defaultQuality = useContext(DefaultImageQualityContext);
+  const quality = props.quality ?? defaultQuality;
 
   const shouldSetEarlyHint = !!props.setEarlyHint && preload;
   const srcSet = props.srcSet ??
@@ -311,7 +319,7 @@ const Image = forwardRef<HTMLImageElement, Props>((props, ref) => {
       props.height,
       props.fit,
       shouldSetEarlyHint ? FACTORS.slice(-1) : FACTORS,
-      props.quality,
+      quality,
     );
 
   const linkProps = srcSet &&
@@ -337,7 +345,7 @@ const Image = forwardRef<HTMLImageElement, Props>((props, ref) => {
         height: props.height,
         fetchpriority: props.fetchPriority,
         src: props.src,
-        quality: props.quality,
+        quality,
       }),
     );
   }

--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -75,6 +75,7 @@ const bypassDecoImageOptimization = () =>
     : Deno.env.get("BYPASS_DECO_IMAGE_OPTIMIZATION") === "true";
 
 export type QualityOptions = "low" | "medium" | "high" | "original"; // 60% - 70% - 80% - 100%
+export type DefaultQualityOptions = "low" | "medium" | "high";
 
 export const DefaultImageQualityContext = createContext<
   QualityOptions | undefined
@@ -228,7 +229,9 @@ export const getOptimizedMediaUrl = (opts: OptimizationOptions) => {
   params.set("fit", fit);
   params.set("width", `${width}`);
   height && params.set("height", `${height}`);
-  quality && params.set("quality", quality);
+  const srcQuality = quality ||
+    new URL(originalSrc).searchParams.get("quality");
+  srcQuality && params.set("quality", srcQuality);
 
   // Strip known CDN prefixes so the worker can hit GCS directly instead of
   // doing an absolute-URL hop. Anything left (path + any query string —

--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -78,7 +78,7 @@ export type QualityOptions = "low" | "medium" | "high" | "original"; // 60% - 70
 export type DefaultQualityOptions = "low" | "medium" | "high";
 
 export const DefaultImageQualityContext = createContext<
-  QualityOptions | undefined
+  DefaultQualityOptions | undefined
 >(undefined);
 
 interface OptimizationOptions {

--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -230,7 +230,7 @@ export const getOptimizedMediaUrl = (opts: OptimizationOptions) => {
   params.set("width", `${width}`);
   height && params.set("height", `${height}`);
   const srcQuality = quality ||
-    new URL(originalSrc).searchParams.get("quality");
+    new URL(originalSrc, "https://a.com").searchParams.get("quality");
   srcQuality && params.set("quality", srcQuality);
 
   // Strip known CDN prefixes so the worker can hit GCS directly instead of

--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -74,9 +74,15 @@ const bypassDecoImageOptimization = () =>
     ? (globalThis as any).DECO?.featureFlags?.bypassDecoImageOptimization
     : Deno.env.get("BYPASS_DECO_IMAGE_OPTIMIZATION") === "true";
 
+/** Quality options available per component (includes "original" = 100%). */
 export type QualityOptions = "low" | "medium" | "high" | "original"; // 60% - 70% - 80% - 100%
+
+/** Quality options for the site-wide default in mod.ts — "original" is excluded
+ *  because a global 100% quality default would hurt performance. */
 export type DefaultQualityOptions = "low" | "medium" | "high";
 
+/** Provides the site-wide default quality to Image/Picture components.
+ *  Typed as QualityOptions because components may override with "original". */
 export const DefaultImageQualityContext = createContext<
   QualityOptions | undefined
 >(undefined);

--- a/website/components/Picture.tsx
+++ b/website/components/Picture.tsx
@@ -4,6 +4,7 @@ import { ComponentChildren, createContext, JSX } from "preact";
 import { Head, IS_BROWSER } from "$fresh/runtime.ts";
 
 import {
+  DefaultImageQualityContext,
   FACTORS,
   getEarlyHintFromSrcProps,
   getSrcSet,
@@ -39,6 +40,8 @@ type SourceProps =
 export const Source = forwardRef<HTMLSourceElement, SourceProps>(
   (props, ref) => {
     const { preload } = useContext(Context);
+    const defaultQuality = useContext(DefaultImageQualityContext);
+    const quality = props.quality ?? defaultQuality;
 
     const shouldSetEarlyHint = !!props.setEarlyHint && preload;
     const srcSet = getSrcSet(
@@ -47,7 +50,7 @@ export const Source = forwardRef<HTMLSourceElement, SourceProps>(
       props.height,
       undefined,
       shouldSetEarlyHint ? FACTORS.slice(-1) : FACTORS,
-      props.quality,
+      quality,
     );
     const linkProps = {
       imagesrcset: srcSet,
@@ -68,7 +71,7 @@ export const Source = forwardRef<HTMLSourceElement, SourceProps>(
           height: props.height,
           fetchpriority: props.fetchPriority,
           src: props.src,
-          quality: props.quality,
+          quality,
         }),
       );
     }

--- a/website/mod.ts
+++ b/website/mod.ts
@@ -1,6 +1,6 @@
 import "./utils/unhandledRejection.ts";
 import type { Props as Seo } from "./components/Seo.tsx";
-import type { QualityOptions } from "./components/Image.tsx";
+import type { DefaultQualityOptions } from "./components/Image.tsx";
 import { Routes } from "./flags/audience.ts";
 import { TextReplace } from "./handlers/proxy.ts";
 import manifest, { Manifest } from "./manifest.gen.ts";
@@ -148,7 +148,7 @@ export interface Props {
    * @title Default Image Quality
    * @description The default quality for images when not explicitly set per component
    */
-  defaultImageQuality?: QualityOptions;
+  defaultImageQuality?: DefaultQualityOptions;
 
   /**
    * @title Disable image/asset proxy for this site

--- a/website/mod.ts
+++ b/website/mod.ts
@@ -1,5 +1,6 @@
 import "./utils/unhandledRejection.ts";
 import type { Props as Seo } from "./components/Seo.tsx";
+import type { QualityOptions } from "./components/Image.tsx";
 import { Routes } from "./flags/audience.ts";
 import { TextReplace } from "./handlers/proxy.ts";
 import manifest, { Manifest } from "./manifest.gen.ts";
@@ -142,6 +143,12 @@ export interface Props {
    * @hide true
    */
   sendToClickHouse?: boolean;
+
+  /**
+   * @title Default Image Quality
+   * @description The default quality for images when not explicitly set per component
+   */
+  defaultImageQuality?: QualityOptions;
 
   /**
    * @title Disable image/asset proxy for this site

--- a/website/pages/Page.tsx
+++ b/website/pages/Page.tsx
@@ -16,6 +16,7 @@ import {
 import { logger } from "@deco/deco/o11y";
 import { Component, JSX } from "preact";
 import ErrorPageComponent from "../../utils/defaultErrorPage.tsx";
+import { DefaultImageQualityContext } from "../components/Image.tsx";
 import OneDollarStats from "../components/OneDollarStats.tsx";
 import Events from "../components/Events.tsx";
 import { SEOSection } from "../components/Seo.tsx";
@@ -106,13 +107,14 @@ function Page(
     seo,
     unindexedDomain,
     avoidRedirectingToEditor,
+    defaultImageQuality,
   }: SectionProps<typeof loader>,
 ): JSX.Element {
   const context = Context.active();
   const site = { id: context.siteId, name: context.site };
   const deco = useDeco();
   return (
-    <>
+    <DefaultImageQualityContext.Provider value={defaultImageQuality}>
       {unindexedDomain && (
         <Head>
           <meta name="robots" content="noindex, nofollow" />
@@ -148,7 +150,7 @@ function Page(
         )}
         {sections?.map(renderSection)}
       </ErrorBoundary>
-    </>
+    </DefaultImageQualityContext.Provider>
   );
 }
 
@@ -183,13 +185,14 @@ export const loader = async (
     devMode,
     unindexedDomain,
     avoidRedirectingToEditor: ctx.avoidRedirectingToEditor,
+    defaultImageQuality: ctx.defaultImageQuality,
   };
 };
 export function Preview(props: SectionProps<typeof loader>) {
-  const { sections, seo } = props;
+  const { sections, seo, defaultImageQuality } = props;
   const deco = useDeco();
   return (
-    <>
+    <DefaultImageQualityContext.Provider value={defaultImageQuality}>
       <Head>
         <meta name="robots" content="noindex, nofollow" />
       </Head>
@@ -197,7 +200,7 @@ export function Preview(props: SectionProps<typeof loader>) {
       {seo && renderSection(seo)}
       <Events deco={deco} />
       {sections?.map(renderSection)}
-    </>
+    </DefaultImageQualityContext.Provider>
   );
 }
 const PAGE_NOT_FOUND = -1;


### PR DESCRIPTION
<img width="664" height="614" alt="image" src="https://github.com/user-attachments/assets/00095be7-78a1-448d-942a-328dc47e970d" />


## Summary
- Adds a `defaultImageQuality` option (`low` / `medium` / `high` / `original`) to the website app settings in `mod.ts`
- When set, all `<Image>` and `<Picture>/<Source>` components that don't have an explicit `quality` prop will use this default
- Uses a Preact context (`DefaultImageQualityContext`) provided at the Page level, fed from `AppContext`

## Changed files
- `website/mod.ts` — new `defaultImageQuality` prop on `Props`
- `website/components/Image.tsx` — context definition + fallback logic
- `website/components/Picture.tsx` — fallback logic for `Source`
- `website/pages/Page.tsx` — provides context from loader/AppContext
- `website/components/Events.tsx` — adds field to `FeatureFlags` interface

## Test plan
- [ ] Configure `defaultImageQuality` in the website app settings (e.g. set to `"medium"`)
- [ ] Verify that images without an explicit `quality` prop use the configured default (check `srcSet` URLs for `quality=medium`)
- [ ] Verify that images with an explicit `quality` prop still use their own value
- [ ] Verify that when no default is configured, behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a site-wide default image quality with a safe fallback to the `quality` in the image URL, so images render consistently without explicit props and relative URLs don’t crash.

- **New Features**
  - Added `defaultImageQuality` in website settings (`low`, `medium`, `high`); `original` is still allowed via an explicit prop.
  - `<Image>` and `<Picture>/<Source>` read from `DefaultImageQualityContext`; if no prop, they use the default or `quality` in `src`. A prop still wins.
  - `Page`/`Preview` provide the context; inline docs clarify quality types and context purpose.

- **Bug Fixes**
  - Prevented URL parsing errors on relative image paths when reading `quality` from `src`.
  - Removed unused `FeatureFlags` field.

<sup>Written for commit 5cc8e258a01188055dd1d13e621dc55bc3c84da2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Site-wide configurable default image quality (low, medium, high) that can be set at app or page level and is honored by previews.
  * Default quality is applied to responsive image generation and server preload (early-hint) links.

* **Improvements**
  * CDN image requests now prefer an explicit quality setting and otherwise inherit quality from the original image URL when available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/apps/pull/1585)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->