### PR TITLE
fix(vtex): use MatchContext signature in birthday and userSegment matchers

### DIFF
--- a/vtex/manifest.gen.ts
+++ b/vtex/manifest.gen.ts
@@ -97,6 +97,7 @@ import * as $$$47 from "./loaders/wishlist.ts";
 import * as $$$48 from "./loaders/workflow/product.ts";
 import * as $$$49 from "./loaders/workflow/products.ts";
 import * as $$$$$$$0 from "./matchers/birthday.ts";
+import * as $$$$$$$1 from "./matchers/userSegment.ts";
 import * as $$$$$$0 from "./sections/Analytics/Vtex.tsx";
 import * as $$$$$$$$$$0 from "./workflows/events.ts";
 import * as $$$$$$$$$$1 from "./workflows/product/index.ts";
@@ -162,6 +163,7 @@ const manifest = {
   },
   "matchers": {
     "vtex/matchers/birthday.ts": $$$$$$$0,
+    "vtex/matchers/userSegment.ts": $$$$$$$1,
   },
   "actions": {
     "vtex/actions/address/create.ts": $$$$$$$$$0,

--- a/vtex/matchers/birthday.ts
+++ b/vtex/matchers/birthday.ts
@@ -1,9 +1,5 @@
-import { AppContext } from "../mod.ts";
-import { parseCookie } from "../utils/vtexId.ts";
-
-interface Profile {
-  birthDate: string | null;
-}
+import { type MatchContext } from "@deco/deco/blocks";
+import { parseAuthCookie } from "../utils/vtexId.ts";
 
 /**
  * @title {{{match}}}
@@ -24,24 +20,17 @@ export interface Props {
  */
 const MatchBirthday = async (
   props: Props,
-  req: Request,
-  ctx: AppContext,
+  { request, invoke }: MatchContext,
 ): Promise<boolean> => {
   const { match = "day" } = props;
-  const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
 
-  if (!payload?.sub || !payload?.userId) {
-    return false;
-  }
+  const payload = parseAuthCookie(request.headers);
+  if (!payload?.sub || !payload?.userId) return false;
 
   try {
-    const query = "query getUserProfile { profile { birthDate }}";
-
-    const { profile } = await io.query<{ profile: Profile }, null>(
-      { query },
-      { headers: { cookie } },
-    );
+    // deno-lint-ignore no-explicit-any
+    const profile = await (invoke as any).vtex.loaders.profile
+      .getCurrentProfile({}) as { birthDate?: string } | null;
 
     if (!profile?.birthDate) {
       return false;
@@ -69,10 +58,8 @@ const MatchBirthday = async (
           birthMonth,
           birthDay,
         );
-        // Get the Sunday that starts the birthday week
         const weekStart = new Date(birthdayThisYear);
         weekStart.setDate(weekStart.getDate() - weekStart.getDay());
-        // Saturday that ends the birthday week
         const weekEnd = new Date(weekStart);
         weekEnd.setDate(weekEnd.getDate() + 6);
         weekEnd.setHours(23, 59, 59, 999);

--- a/vtex/matchers/userSegment.ts
+++ b/vtex/matchers/userSegment.ts
@@ -1,0 +1,148 @@
+import { type MatchContext } from "@deco/deco/blocks";
+import { parseAuthCookie } from "../utils/vtexId.ts";
+
+/** @title Anonymous without cart */
+interface AnonymousWithoutCart {
+  /**
+   * @hide true
+   */
+  segment: "anonymous-without-cart";
+}
+
+/** @title Anonymous with cart */
+interface AnonymousWithCart {
+  /**
+   * @hide true
+   */
+  segment: "anonymous-with-cart";
+}
+
+/** @title Logged in */
+interface LoggedIn {
+  /**
+   * @hide true
+   */
+  segment: "logged-in";
+}
+
+/** @title Logged in without orders */
+interface LoggedInWithoutOrders {
+  /**
+   * @hide true
+   */
+  segment: "logged-in-without-orders";
+}
+
+/** @title Logged in with orders */
+interface LoggedInWithOrders {
+  /**
+   * @hide true
+   */
+  segment: "logged-in-with-orders";
+}
+
+/** @title Logged in with recent orders */
+interface LoggedInWithRecentOrders {
+  /**
+   * @hide true
+   */
+  segment: "logged-in-with-recent-orders";
+  /**
+   * @title Months
+   * @description Number of months to consider an order as "recent"
+   * @default 3
+   */
+  months?: number;
+}
+
+export type Props =
+  | AnonymousWithoutCart
+  | AnonymousWithCart
+  | LoggedIn
+  | LoggedInWithoutOrders
+  | LoggedInWithOrders
+  | LoggedInWithRecentOrders;
+
+/**
+ * @title User Segment
+ * @description Segment users by authentication status, cart state, and order history
+ * @icon user-check
+ */
+const MatchUserSegment = async (
+  props: Props,
+  { request, invoke }: MatchContext,
+): Promise<boolean> => {
+  const { segment } = props;
+  // deno-lint-ignore no-explicit-any
+  const vtex = (invoke as any).vtex;
+
+  const payload = parseAuthCookie(request.headers);
+  const isLoggedIn = Boolean(payload?.sub && payload?.userId);
+
+  try {
+    if (segment === "anonymous-without-cart") {
+      if (isLoggedIn) return false;
+      const cart = await vtex.loaders.cart();
+      return (cart?.items?.length ?? 0) === 0;
+    }
+
+    if (segment === "anonymous-with-cart") {
+      if (isLoggedIn) return false;
+      const cart = await vtex.loaders.cart();
+      return (cart?.items?.length ?? 0) > 0;
+    }
+
+    // All remaining segments require login
+    if (!isLoggedIn || !payload?.sub) return false;
+
+    if (segment === "logged-in") {
+      return true;
+    }
+
+    const email = payload.sub;
+
+    if (segment === "logged-in-without-orders") {
+      const orders = await vtex.loaders.orders.list({
+        clientEmail: email,
+        per_page: "1",
+        page: "1",
+      });
+      return orders?.paging?.total === 0;
+    }
+
+    if (segment === "logged-in-with-orders") {
+      const orders = await vtex.loaders.orders.list({
+        clientEmail: email,
+        per_page: "1",
+        page: "1",
+      });
+      return orders?.paging?.total > 0;
+    }
+
+    if (segment === "logged-in-with-recent-orders") {
+      const { months = 3 } = props;
+      const orders = await vtex.loaders.orders.list({
+        clientEmail: email,
+        per_page: "15",
+        page: "1",
+      });
+
+      if (!orders?.paging?.total) return false;
+
+      const now = new Date();
+      const cutoff = new Date(now);
+      cutoff.setMonth(cutoff.getMonth() - months);
+
+      return orders.list.some((order: { creationDate: string }) => {
+        const created = new Date(order.creationDate);
+        return created >= cutoff;
+      });
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+};
+
+export default MatchUserSegment;

--- a/vtex/utils/vtexId.ts
+++ b/vtex/utils/vtexId.ts
@@ -13,6 +13,19 @@ interface CookiePayload {
   userId: string;
 }
 
+export const parseAuthCookie = (headers: Headers) => {
+  const cookies = getCookies(headers);
+  const token = cookies[VTEX_ID_CLIENT_COOKIE] ||
+    Object.entries(cookies).find(([k]) =>
+      k.startsWith(`${VTEX_ID_CLIENT_COOKIE}_`)
+    )?.[1];
+
+  if (!token) return null;
+
+  const decoded = decode(token);
+  return decoded?.[1] as CookiePayload | undefined ?? null;
+};
+
 export const parseCookie = (headers: Headers, account: string) => {
   const cookies = getCookies(headers);
   const cookie = cookies[VTEX_ID_CLIENT_COOKIE] ||


### PR DESCRIPTION
## Summary
- Fix `birthday` and `userSegment` matchers to use the correct `(props, ctx: MatchContext)` signature instead of the old `(props, req, ctx: AppContext)` pattern
- Extract shared cookie parsing logic into a new `parseAuthCookie` utility in `vtex/utils/vtexId.ts` that works without requiring `account`
- Check auth cookies before making API calls to avoid unnecessary fetches for unauthenticated users

## Test plan
- [ ] Verify `birthday` matcher correctly identifies users on their birthday (day/week/month modes)
- [ ] Verify `userSegment` matcher correctly segments anonymous vs logged-in users
- [ ] Verify unauthenticated users get fast `false` responses without API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `birthday` matcher to the `MatchContext` signature and added a `userSegment` matcher. Auth cookies are parsed early to skip VTEX calls when the user is not logged in.

- **New Features**
  - Added `userSegment` matcher to segment users by auth, cart, and order history, including a “recent orders” option with a configurable months window.

- **Bug Fixes**
  - Migrated `birthday` matcher to `MatchContext` from `@deco/deco/blocks` and switched to the VTEX profile loader for birthdate.
  - Extracted `parseAuthCookie` utility to share cookie parsing and short‑circuit anonymous users.

<sup>Written for commit 17052529304c65ce6a5fe011d6a25a3a53752227. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added user segmentation matcher to identify customers by login state, cart contents, and order history with configurable options.
  * Introduced improved authentication cookie parsing for enhanced security.

* **Refactor**
  * Updated birthday matcher to use new authentication and profile loading patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/apps/pull/1586)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->