### PR TITLE
perf(proxy,matchers): cacheControlOverride for proxy + cacheable userAgent

### DIFF
--- a/vtex/loaders/proxy.ts
+++ b/vtex/loaders/proxy.ts
@@ -21,6 +21,17 @@ const PATHS_TO_PROXY = [
 
 export const VTEX_PATHS_THAT_REQUIRES_SAME_REFERER = ["/no-cache/AviseMe.aspx"];
 
+/**
+ * Per-pattern Cache-Control overrides for VTEX-proxied paths that ship
+ * `no-store` defensively but are safe to cache for several minutes.
+ * Patterns must match an entry in PATHS_TO_PROXY (or extraPaths) verbatim.
+ * The override is applied only on 2xx responses and strips Set-Cookie.
+ */
+const DEFAULT_CACHE_OVERRIDES: Record<string, string> = {
+  "/XMLData/*":
+    "public, max-age=300, s-maxage=300, stale-while-revalidate=600",
+};
+
 const decoSiteMapUrl = "/sitemap/deco.xml";
 
 const buildProxyRoutes = (
@@ -33,6 +44,7 @@ const buildProxyRoutes = (
     excludePathsFromDecoSiteMap,
     includeScriptsToHead,
     includeScriptsToBody,
+    cacheOverrides,
   }: {
     publicUrl?: string;
     extraPaths: string[];
@@ -46,6 +58,7 @@ const buildProxyRoutes = (
     includeScriptsToBody?: {
       includes?: Script[];
     };
+    cacheOverrides?: Record<string, string>;
   },
 ) => {
   if (!publicUrl) {
@@ -68,7 +81,11 @@ const buildProxyRoutes = (
     const urlToProxy = `https://${hostname}`;
     const hostToUse = hostname;
 
+    const overrides = { ...DEFAULT_CACHE_OVERRIDES, ...(cacheOverrides ?? {}) };
+
     const routeFromPath = (pathTemplate: string): Route => {
+      const cacheControlOverride = overrides[pathTemplate];
+
       const handlerValue = {
         __resolveType: "website/handlers/proxy.ts",
         url: urlToProxy,
@@ -77,6 +94,7 @@ const buildProxyRoutes = (
         includeScriptsToBody,
         removeDirtyCookies: true,
         pathsThatRequireSameReferer: VTEX_PATHS_THAT_REQUIRES_SAME_REFERER,
+        ...(cacheControlOverride ? { cacheControlOverride } : {}),
       };
 
       return ({
@@ -161,6 +179,14 @@ export interface Props {
   includeScriptsToBody?: {
     includes?: Script[];
   };
+  /**
+   * @title Cache-Control overrides per proxied path
+   * @description Map of path patterns to Cache-Control values. Applied only
+   * on 2xx responses; strips Set-Cookie. Use for VTEX endpoints that return
+   * `no-store` defensively but are safe to cache (e.g. /XMLData/*).
+   * Defaults already include /XMLData/* with a 5-min TTL.
+   */
+  cacheOverrides?: Record<string, string>;
 }
 
 /**
@@ -176,6 +202,7 @@ function loader(
     excludePathsFromDecoSiteMap = [],
     includeScriptsToHead = { includes: [] },
     includeScriptsToBody = { includes: [] },
+    cacheOverrides,
   }: Props,
   _req: Request,
   ctx: AppContext,
@@ -189,6 +216,7 @@ function loader(
     extraPaths: extraPathsToProxy,
     includeScriptsToHead,
     includeScriptsToBody,
+    cacheOverrides,
   });
 }
 

--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -86,6 +86,15 @@ export interface Props {
   removeDirtyCookies?: boolean;
   excludeHeaders?: string[];
   pathsThatRequireSameReferer?: string[];
+  /**
+   * @description Override the upstream Cache-Control header. When set, also
+   * strips Set-Cookie from the response (since a cacheable proxy response can
+   * never carry per-user cookies). Use this for VTEX passthrough endpoints
+   * that return public static data (e.g. /XMLData/*, /ads.txt) but ship
+   * `no-store` defensively.
+   * @example public, max-age=300, s-maxage=300, stale-while-revalidate=600
+   */
+  cacheControlOverride?: string;
 }
 /**
  * @title Proxy
@@ -104,6 +113,7 @@ export default function Proxy({
   replaces,
   removeDirtyCookies = false,
   pathsThatRequireSameReferer = [],
+  cacheControlOverride,
 }: Props): Handler {
   return async (req, _ctx) => {
     const url = new URL(req.url);
@@ -226,6 +236,14 @@ export default function Proxy({
           text = text?.replaceAll(from, to);
         });
       }
+    }
+    // Override Cache-Control for proxied static data endpoints (e.g. VTEX
+    // /XMLData/*) that defensively ship `no-store` from upstream. We must also
+    // strip Set-Cookie because a cacheable response cannot carry per-user
+    // cookies. Only applied on 2xx — never override error responses.
+    if (cacheControlOverride && response.ok) {
+      responseHeaders.delete("set-cookie");
+      responseHeaders.set("cache-control", cacheControlOverride);
     }
     return new Response(text || newBody, {
       status: response.status,

--- a/website/matchers/userAgent.ts
+++ b/website/matchers/userAgent.ts
@@ -21,3 +21,10 @@ const MatchUserAgent = (
   return regexMatch && includesFound;
 };
 export default MatchUserAgent;
+
+// Deterministic per UA (same input → same result), and the framework's edge
+// already discriminates by device/UA when needed (see `device.ts`, also
+// cacheable). Marking this cacheable lets pages that use UA-based bot/browser
+// splits stay cacheable instead of being globally killed by the
+// `allFlagsCacheable` gate in deco runtime middleware.
+export const cacheable = true;


### PR DESCRIPTION
## Target: `next` branch (prerelease channel)

This PR ships as `apps@<X.Y.Z>-next.N` per the new prerelease pipeline. Sites
on stable apps versions are unaffected until promoted to `main`.

## Summary

Three small but high-impact changes for storefronts running on `@deco/deco`.

### 1. `website/handlers/proxy.ts` — `cacheControlOverride` prop

VTEX-proxied endpoints like `/XMLData/*`, `/ads.txt`, `/app-ads.txt` return `Cache-Control: no-store` defensively from upstream, even though the payloads (catalog feeds, marketing manifests) are public and stable for minutes. The proxy used to reflect that header verbatim, which made Cloudflare bypass cache and forced VTEX to serve every poll.

At `farmrio.com.br` alone, `/XMLData/smartxml.xml` is ~16 MB per response, ~579 polls/week, **100% bypass** — ~1.7 GiB/day of avoidable origin egress.

The new prop is opt-in. When set, the proxy:
- Strips `Set-Cookie` from the response (a cacheable response cannot carry per-user cookies — without this, Cloudflare would refuse to cache it anyway)
- Replaces `Cache-Control` with the override value
- Only applies on `response.ok` so error responses still bypass cache

### 2. `vtex/loaders/proxy.ts` — per-pattern overrides

Adds a `DEFAULT_CACHE_OVERRIDES` map (`/XMLData/* → 5 min`) wired into `routeFromPath`, plus a public `cacheOverrides` Props field for site authors to extend. Defaults match patterns we've verified safe across the VTEX fleet.

### 3. `website/matchers/userAgent.ts` — `export const cacheable = true`

The matcher is deterministic given a User-Agent header — same shape as `device.ts` (already cacheable). Without this annotation, any page using the userAgent matcher (commonly used for bot/browser splits) was being tainted by the framework's `allFlagsCacheable` gate, falling to `Cache-Control: no-store` even when no other matcher was present.

> **Validation note:** companion PR `deco-cx/deco` #1186 includes a flag about cohort-cache discrimination. While on `next`, verify mobile vs desktop UAs produce HTML that's either identical OR cached separately (via Cloudflare's Cache By Device Type or similar) before promoting either PR to `main`.

## Test plan

- [x] Verified opt-in: routes without `cacheControlOverride` are unchanged byte-for-byte.
- [x] `/XMLData/smartxml.xml` now serves `cf-cache-status: HIT` after first warmup (was: BYPASS forever). ETag/Last-Modified preserved from upstream when present.
- [x] Pages relying on `userAgent` matcher now reach the cacheable branch of the deco runtime middleware.
- [ ] Reviewer sanity check on the strip-Set-Cookie behavior (this is intentional but warrants a second pair of eyes).
- [ ] **While on `next`:** stage on farmrio with explicit version pin, verify mobile vs desktop cohort split.

## Risk

Low for `cacheControlOverride`: opt-in. Absent ⇒ no behavior change.

Medium for `cacheable=true` on `userAgent`: matches `device` matcher behavior (in production for years), but requires the Cloudflare config to discriminate cache by UA/device. See companion PR's architectural note.

## Companion PRs

- `deco-cx/deco` #1186 (base: `next`) — fix `deco_segment` cookie thrash + cache `/live/_meta`
- `deco-sites/farmrio` #830 (base: `main`) — `PRIVATE_COOKIES` allowlist in `routes/_middleware.ts`