### PR TITLE
docs: document prerelease channel (prerelease pipeline E2E test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ Open this repo in an AI Editor and use [NewAppPrompt.md](NewAppPrompt.md) as pro
 
 ---
 
+## Pre-release channel
+
+Stable releases ship from `main` (`apps@X.Y.Z`). Pre-releases ship from the `next` branch as `apps@X.Y.Z-next.N` and let you opt-in to in-progress changes. Pin an exact tag:
+
+```jsonc
+"apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@<X.Y.Z-next.N>/"
+```
+
+`deno task update` filters out semver prereleases by default, so sites stay on stable unless you explicitly pin a `-next.N` version.
+
 ## Debugging HTTP Requests
 
 To enable verbose HTTP request debugging logs, set the environment variable `DEBUG_HTTP` to `true` when running this repo:


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

End-to-end test of the new prerelease pipeline (PR #1588) while shipping a real doc improvement.

Adds a README section explaining the `next`-branch / `apps@X.Y.Z-next.N` flow and how consumers opt in via an explicit version pin in `deno.json`. Opening this PR should trigger the new `prerelease-tag-discussion` job and post a "## Prerelease Tagging" bot comment with the computed patch/minor/major bases against `0.151.1`. Merging would then trigger `determine-prerelease-tag` and ship a `0.151.2-next.1` tag + GitHub Pre-release.

## Issue Link

- Issue: N/A (companion to #1588)

## Loom Video

> N/A — docs + CI verification.

## Demonstration Link

> The bot comment that appears below this PR opening IS the demonstration. After confirming it shows correct bases, merge to ship `0.151.2-next.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a README section that documents the prerelease channel from `next` (`apps@X.Y.Z-next.N`) and how to opt in by pinning an exact tag in `deno.json`. Opening this PR also exercises the prerelease tagging pipeline end to end.

- **Migration**
  - To opt in, pin `"apps/"` to `https://cdn.jsdelivr.net/gh/deco-cx/apps@<X.Y.Z-next.N>/` in `deno.json`.
  - `deno task update` ignores prereleases by default; only explicit `-next.N` pins are used.

<sup>Written for commit 8d8f3fb4f8730cf6e9a828786f7b7b43092e934a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

