### PR TITLE
fix: removed height that causes vtex crop image

### DIFF
--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -123,20 +123,20 @@ const optmizeShopify = (opts: OptimizationOptions) => {
 };
 
 const optimizeVTEX = (opts: OptimizationOptions) => {
-  const { originalSrc, width, height } = opts;
+  const { originalSrc, width } = opts;
 
   const src = new URL(originalSrc);
 
   const [slash, arquivos, ids, rawId, ...rest] = src.pathname.split("/");
-  const [trueId, _w, _h] = rawId.split("-");
+  const [trueId] = rawId.split("-");
 
   src.pathname = [
-    slash,
-    arquivos,
-    ids,
-    `${trueId}-${width}-${height}`,
-    ...rest,
-  ].join("/");
+    slash, 
+    arquivos, 
+    ids, 
+    `${trueId}-${width}-0`,
+    ...rest]
+    .join("/");
 
   return src.href;
 };


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Please provide a brief description of the changes or enhancements you are proposing in this pull request.

Root cause - optimizeVTEX always forces the consumer's aspect ratio into the URL path ({id}-{width}-{height}), which triggers letterboxing whenever the requested ratio differs from the image's original ratio.

Solution - VTEX supports proportional resizing when one of the dimensions is 0. Replacing {id}-{width}-{height} with {id}-{width}-0 makes VTEX preserve the original aspect ratio, and the consumer's CSS object-cover then crops correctly within the layout.

<img width="1867" height="463" alt="image" src="https://github.com/user-attachments/assets/b6452adb-dc85-422a-9644-6ab74ba589ab" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented VTEX images from being letterboxed by removing the forced height in the optimizer. URLs now use height=0 so VTEX keeps the original aspect ratio and `object-cover` crops correctly.

- **Bug Fixes**
  - Updated `optimizeVTEX` in `website/components/Image.tsx` to build `${id}-${width}-0` instead of `${id}-${width}-{height}`.
  - Preserves original aspect ratio and eliminates unintended cropping/letterboxing.

<sup>Written for commit 39689b3b4a65f4a9bc562510d1fc2e256f3bec8e. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/apps/pull/1591?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image optimization to ensure better loading performance and consistent image display across the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/apps/pull/1591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->