### PR TITLE
fix: resolve erro fetch in request subacconts

### DIFF
--- a/vtex/actions/address/create.ts
+++ b/vtex/actions/address/create.ts
@@ -112,7 +112,7 @@ async function action(
   ctx: AppContext,
 ): Promise<PostalAddress> {
   const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
 
   if (!payload?.sub || !payload?.userId) {
     throw new Error("User cookie is invalid");

--- a/vtex/actions/address/delete.ts
+++ b/vtex/actions/address/delete.ts
@@ -53,7 +53,7 @@ interface Props {
  */
 async function action({ addressId }: Props, req: Request, ctx: AppContext) {
   const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
 
   if (!payload?.sub || !payload?.userId) {
     throw new Error("User cookie is invalid");

--- a/vtex/actions/address/update.ts
+++ b/vtex/actions/address/update.ts
@@ -96,7 +96,7 @@ async function action(
   ctx: AppContext,
 ): Promise<PostalAddress> {
   const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
 
   if (!payload?.sub || !payload?.userId) {
     throw new Error("User cookie is invalid");

--- a/vtex/actions/authentication/logout.ts
+++ b/vtex/actions/authentication/logout.ts
@@ -12,7 +12,7 @@ export default async function action(
   ctx: AppContext,
 ) {
   const cookies = getCookies(req.headers);
-  const { payload } = parseCookie(req.headers, ctx.account);
+  const { payload } = parseCookie(req.headers);
 
   for (const cookieName in cookies) {
     if (cookieName.startsWith("VtexIdclientAutCookie")) {

--- a/vtex/actions/cart/addItems.ts
+++ b/vtex/actions/cart/addItems.ts
@@ -1,6 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
-import { parseCookie } from "../../utils/orderForm.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import { getSegmentFromBag } from "../../utils/segment.ts";
 import type { OrderForm } from "../../utils/types.ts";
 import { forceHttpsOnAssets } from "../../utils/transform.ts";
@@ -33,8 +33,7 @@ const action = async (
     orderItems,
     allowedOutdatedData = ["paymentData"],
   } = props;
-  const { orderFormId } = parseCookie(req.headers);
-  const cookie = req.headers.get("cookie") ?? "";
+  const { orderFormId, cookie } = parseCookieWithoutAuth(req.headers);
   const segment = getSegmentFromBag(ctx);
 
   try {

--- a/vtex/actions/cart/addOfferings.ts
+++ b/vtex/actions/cart/addOfferings.ts
@@ -1,6 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
-import { parseCookie } from "../../utils/orderForm.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import { forceHttpsOnAssets } from "../../utils/transform.ts";
 import { OrderForm } from "../../utils/types.ts";
 import { DEFAULT_EXPECTED_SECTIONS } from "./updateItemAttachment.ts";
@@ -24,8 +24,7 @@ const action = async (
     props;
   const { vcsDeprecated } = ctx;
 
-  const { orderFormId } = parseCookie(req.headers);
-  const cookie = req.headers.get("cookie") ?? "";
+  const { orderFormId, cookie } = parseCookieWithoutAuth(req.headers);
 
   try {
     const response = await vcsDeprecated

--- a/vtex/actions/cart/clearOrderformMessages.ts
+++ b/vtex/actions/cart/clearOrderformMessages.ts
@@ -1,6 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
-import { parseCookie } from "../../utils/orderForm.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
 
 /**
@@ -13,8 +13,7 @@ const action = async (
   ctx: AppContext,
 ): Promise<OrderForm> => {
   const { vcsDeprecated } = ctx;
-  const { orderFormId } = parseCookie(req.headers);
-  const cookie = req.headers.get("cookie") ?? "";
+  const { orderFormId, cookie } = parseCookieWithoutAuth(req.headers);
 
   const response = await vcsDeprecated[
     "POST /api/checkout/pub/orderForm/:orderFormId/messages/clear"

--- a/vtex/actions/cart/getInstallment.ts
+++ b/vtex/actions/cart/getInstallment.ts
@@ -1,6 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
-import { parseCookie } from "../../utils/orderForm.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import type { InstallmentOption } from "../../utils/types.ts";
 import { getSegmentFromBag } from "../../utils/segment.ts";
 
@@ -20,8 +20,7 @@ const action = async (
 ): Promise<InstallmentOption> => {
   const { vcsDeprecated } = ctx;
   const { paymentSystem } = props;
-  const { orderFormId } = parseCookie(req.headers);
-  const cookie = req.headers.get("cookie") ?? "";
+  const { orderFormId, cookie } = parseCookieWithoutAuth(req.headers);
   const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated

--- a/vtex/actions/cart/removeItemAttachment.ts
+++ b/vtex/actions/cart/removeItemAttachment.ts
@@ -1,6 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
-import { parseCookie } from "../../utils/orderForm.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
 import { getSegmentFromBag } from "../../utils/segment.ts";
 
@@ -49,8 +49,7 @@ const action = async (
     noSplitItem = true,
     expectedOrderFormSections = DEFAULT_EXPECTED_SECTIONS,
   } = props;
-  const { orderFormId } = parseCookie(req.headers);
-  const cookie = req.headers.get("cookie") ?? "";
+  const { orderFormId, cookie } = parseCookieWithoutAuth(req.headers);
   const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated

--- a/vtex/actions/cart/removeItems.ts
+++ b/vtex/actions/cart/removeItems.ts
@@ -1,6 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
-import { parseCookie } from "../../utils/orderForm.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
 import { getSegmentFromBag } from "../../utils/segment.ts";
 
@@ -15,8 +15,7 @@ const action = async (
   ctx: AppContext,
 ): Promise<OrderForm> => {
   const { vcsDeprecated } = ctx;
-  const { orderFormId } = parseCookie(req.headers);
-  const cookie = req.headers.get("cookie") ?? "";
+  const { orderFormId, cookie } = parseCookieWithoutAuth(req.headers);
   const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated

--- a/vtex/actions/cart/removeOffering.ts
+++ b/vtex/actions/cart/removeOffering.ts
@@ -1,6 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
-import { parseCookie } from "../../utils/orderForm.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import { forceHttpsOnAssets } from "../../utils/transform.ts";
 import { OrderForm } from "../../utils/types.ts";
 import { DEFAULT_EXPECTED_SECTIONS } from "./updateItemAttachment.ts";
@@ -24,8 +24,7 @@ const action = async (
     props;
   const { vcsDeprecated } = ctx;
 
-  const { orderFormId } = parseCookie(req.headers);
-  const cookie = req.headers.get("cookie") ?? "";
+  const { orderFormId, cookie } = parseCookieWithoutAuth(req.headers);
 
   try {
     const response = await vcsDeprecated

--- a/vtex/actions/cart/simulation.ts
+++ b/vtex/actions/cart/simulation.ts
@@ -1,4 +1,5 @@
 import { AppContext } from "../../mod.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import type { SimulationOrderForm } from "../../utils/types.ts";
 import { getSegmentFromBag } from "../../utils/segment.ts";
 
@@ -25,7 +26,7 @@ const action = async (
   req: Request,
   ctx: AppContext,
 ): Promise<SimulationOrderForm> => {
-  const cookie = req.headers.get("cookie") ?? "";
+  const { cookie } = parseCookieWithoutAuth(req.headers);
   const { vcsDeprecated } = ctx;
   const { items, postalCode, country, RnbBehavior = 1 } = props;
   const segment = getSegmentFromBag(ctx);

--- a/vtex/actions/cart/updateAttachment.ts
+++ b/vtex/actions/cart/updateAttachment.ts
@@ -1,6 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
-import { parseCookie } from "../../utils/orderForm.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
 import { DEFAULT_EXPECTED_SECTIONS } from "./updateItemAttachment.ts";
 import { getSegmentFromBag } from "../../utils/segment.ts";
@@ -27,13 +27,11 @@ const action = async (
     body,
     expectedOrderFormSections = DEFAULT_EXPECTED_SECTIONS,
   } = props;
-  const { orderFormId } = parseCookie(req.headers);
+  const { orderFormId, cookie } = parseCookieWithoutAuth(req.headers);
 
   if (!orderFormId || orderFormId === "") {
     throw new Error("Order form ID is required");
   }
-
-  const cookie = req.headers.get("cookie") ?? "";
   const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated

--- a/vtex/actions/cart/updateCoupons.ts
+++ b/vtex/actions/cart/updateCoupons.ts
@@ -1,6 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
-import { parseCookie } from "../../utils/orderForm.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
 import { getSegmentFromBag } from "../../utils/segment.ts";
 
@@ -20,8 +20,7 @@ const action = async (
 ): Promise<OrderForm> => {
   const { vcsDeprecated } = ctx;
   const { text } = props;
-  const cookie = req.headers.get("cookie") ?? "";
-  const { orderFormId } = parseCookie(req.headers);
+  const { orderFormId, cookie } = parseCookieWithoutAuth(req.headers);
   const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated

--- a/vtex/actions/cart/updateGifts.ts
+++ b/vtex/actions/cart/updateGifts.ts
@@ -1,6 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
-import { parseCookie } from "../../utils/orderForm.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import type { OrderForm, SelectableGifts } from "../../utils/types.ts";
 import { DEFAULT_EXPECTED_SECTIONS } from "./updateItemAttachment.ts";
 
@@ -23,8 +23,7 @@ const action = async (
     id,
     selectedGifts,
   } = props;
-  const { orderFormId } = parseCookie(req.headers);
-  const cookie = req.headers.get("cookie") ?? "";
+  const { orderFormId, cookie } = parseCookieWithoutAuth(req.headers);
 
   const response = await vcsDeprecated[
     "POST /api/checkout/pub/orderForm/:orderFormId/selectable-gifts/:giftId"

--- a/vtex/actions/cart/updateItemAttachment.ts
+++ b/vtex/actions/cart/updateItemAttachment.ts
@@ -1,6 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
-import { parseCookie } from "../../utils/orderForm.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
 import { getSegmentFromBag } from "../../utils/segment.ts";
 
@@ -49,8 +49,7 @@ const action = async (
     noSplitItem = true,
     expectedOrderFormSections = DEFAULT_EXPECTED_SECTIONS,
   } = props;
-  const { orderFormId } = parseCookie(req.headers);
-  const cookie = req.headers.get("cookie") ?? "";
+  const { orderFormId, cookie } = parseCookieWithoutAuth(req.headers);
   const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated

--- a/vtex/actions/cart/updateItemPrice.ts
+++ b/vtex/actions/cart/updateItemPrice.ts
@@ -1,6 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
-import { parseCookie } from "../../utils/orderForm.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
 import { getSegmentFromBag } from "../../utils/segment.ts";
 
@@ -24,8 +24,7 @@ const action = async (
     itemIndex,
     price,
   } = props;
-  const { orderFormId } = parseCookie(req.headers);
-  const cookie = req.headers.get("cookie") ?? "";
+  const { orderFormId, cookie } = parseCookieWithoutAuth(req.headers);
   const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated

--- a/vtex/actions/cart/updateItems.ts
+++ b/vtex/actions/cart/updateItems.ts
@@ -1,6 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
-import { parseCookie } from "../../utils/orderForm.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import { getSegmentFromBag } from "../../utils/segment.ts";
 import type { OrderForm } from "../../utils/types.ts";
 
@@ -31,8 +31,7 @@ const action = async (
     allowedOutdatedData = ["paymentData"],
     noSplitItem,
   } = props;
-  const { orderFormId } = parseCookie(req.headers);
-  const cookie = req.headers.get("cookie") ?? "";
+  const { orderFormId, cookie } = parseCookieWithoutAuth(req.headers);
   const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated

--- a/vtex/actions/cart/updateProfile.ts
+++ b/vtex/actions/cart/updateProfile.ts
@@ -1,6 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
-import { parseCookie } from "../../utils/orderForm.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
 import { getSegmentFromBag } from "../../utils/segment.ts";
 
@@ -20,8 +20,7 @@ const action = async (
 ): Promise<OrderForm> => {
   const { vcsDeprecated } = ctx;
   const { ignoreProfileData } = props;
-  const { orderFormId } = parseCookie(req.headers);
-  const cookie = req.headers.get("cookie") ?? "";
+  const { orderFormId, cookie } = parseCookieWithoutAuth(req.headers);
   const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated

--- a/vtex/actions/cart/updateUser.ts
+++ b/vtex/actions/cart/updateUser.ts
@@ -1,6 +1,6 @@
 import { AppContext } from "../../mod.ts";
 import { proxySetCookie } from "../../utils/cookies.ts";
-import { parseCookie } from "../../utils/orderForm.ts";
+import { parseCookieWithoutAuth } from "../../utils/orderForm.ts";
 import type { OrderForm } from "../../utils/types.ts";
 import { getSegmentFromBag } from "../../utils/segment.ts";
 
@@ -15,8 +15,7 @@ const action = async (
   ctx: AppContext,
 ): Promise<OrderForm> => {
   const { vcsDeprecated } = ctx;
-  const { orderFormId } = parseCookie(req.headers);
-  const cookie = req.headers.get("cookie") ?? "";
+  const { orderFormId, cookie } = parseCookieWithoutAuth(req.headers);
   const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated

--- a/vtex/actions/masterdata/createDocument.ts
+++ b/vtex/actions/masterdata/createDocument.ts
@@ -22,7 +22,7 @@ const action = async (
 ): Promise<CreateNewDocument> => {
   const { vcs, vcsDeprecated } = ctx;
   const { data, acronym, isPrivateEntity, schema } = props;
-  const { cookie } = parseCookie(req.headers, ctx.account);
+  const { cookie } = parseCookie(req.headers);
 
   const requestOptions = {
     body: data,

--- a/vtex/actions/masterdata/updateDocument.ts
+++ b/vtex/actions/masterdata/updateDocument.ts
@@ -26,7 +26,7 @@ const action = async (
 ): Promise<unknown | IdHrefDocumentID> => {
   const { vcs } = ctx;
   const { id, data, acronym, createIfNotExists, schema } = props;
-  const { cookie } = parseCookie(req.headers, ctx.account);
+  const { cookie } = parseCookie(req.headers);
 
   const requestOptions = {
     body: createIfNotExists ? { ...data, id } : data,

--- a/vtex/actions/newsletter/updateNewsletterOptIn.ts
+++ b/vtex/actions/newsletter/updateNewsletterOptIn.ts
@@ -23,7 +23,7 @@ async function loader(
   ctx: AppContext,
 ): Promise<{ subscribed: boolean }> {
   const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
 
   if (!payload?.sub || !payload?.userId) {
     throw new Error("User cookie is invalid");

--- a/vtex/actions/orders/cancel.ts
+++ b/vtex/actions/orders/cancel.ts
@@ -17,7 +17,7 @@ async function action(
 ): Promise<unknown> {
   const { orderId, reason } = props;
   const { vcsDeprecated } = ctx;
-  const { cookie } = parseCookie(req.headers, ctx.account);
+  const { cookie } = parseCookie(req.headers);
 
   const response = await vcsDeprecated
     ["POST /api/checkout/pub/orders/:orderId/user-cancel-request"](

--- a/vtex/actions/payment/deletePaymentToken.ts
+++ b/vtex/actions/payment/deletePaymentToken.ts
@@ -23,7 +23,7 @@ async function loader(
   ctx: AppContext,
 ): Promise<DeleteCard> {
   const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
 
   if (!payload?.sub || !payload?.userId) {
     throw new Error("User cookie is invalid");

--- a/vtex/actions/profile/updateProfile.ts
+++ b/vtex/actions/profile/updateProfile.ts
@@ -31,7 +31,7 @@ async function action(
   ctx: AppContext,
 ): Promise<Profile> {
   const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
 
   if (!payload?.sub || !payload?.userId) {
     throw new Error("User cookie is invalid");

--- a/vtex/actions/session/deleteSession.ts
+++ b/vtex/actions/session/deleteSession.ts
@@ -23,7 +23,7 @@ async function action(
   ctx: AppContext,
 ): Promise<DeleteSession> {
   const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
 
   if (!payload?.sub || !payload?.userId) {
     throw new Error("User cookie is invalid");

--- a/vtex/actions/session/editSession.ts
+++ b/vtex/actions/session/editSession.ts
@@ -17,7 +17,7 @@ async function action(
   ctx: AppContext,
 ): Promise<CreateEditSessionResponse> {
   const { vcs } = ctx;
-  const { cookie } = parseCookie(req.headers, ctx.account);
+  const { cookie } = parseCookie(req.headers);
 
   const response = await vcs["PATCH /api/sessions"]({}, {
     body: {

--- a/vtex/actions/wishlist/addItem.ts
+++ b/vtex/actions/wishlist/addItem.ts
@@ -17,7 +17,7 @@ const action = async (
   ctx: AppContext,
 ): Promise<WishlistItem[]> => {
   const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
   const user = payload?.sub;
 
   if (!user) {

--- a/vtex/actions/wishlist/removeItem.ts
+++ b/vtex/actions/wishlist/removeItem.ts
@@ -15,7 +15,7 @@ const action = async (
   ctx: AppContext,
 ): Promise<WishlistItem[]> => {
   const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
   const user = payload?.sub;
   const { id } = props;
 

--- a/vtex/loaders/address/getUserAddresses.ts
+++ b/vtex/loaders/address/getUserAddresses.ts
@@ -35,7 +35,7 @@ async function loader(
   ctx: AppContext,
 ): Promise<PostalAddress[]> {
   const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
 
   if (!payload?.sub || !payload?.userId) {
     throw new Error("User cookie is invalid");

--- a/vtex/loaders/masterdata/searchDocuments.ts
+++ b/vtex/loaders/masterdata/searchDocuments.ts
@@ -52,7 +52,7 @@ export default async function loader(
 ): Promise<Document[]> {
   const { vcs } = ctx;
   const { acronym, fields, where, sort, skip = 0, take = 10, schema } = props;
-  const { cookie } = parseCookie(req.headers, ctx.account);
+  const { cookie } = parseCookie(req.headers);
   const limits = resourceRange(skip, take);
 
   const documents = await vcs["GET /api/dataentities/:acronym/search"]({

--- a/vtex/loaders/orders/getById.ts
+++ b/vtex/loaders/orders/getById.ts
@@ -15,7 +15,7 @@ export default async function loader(
   ctx: AppContext,
 ) {
   const { vcsDeprecated } = ctx;
-  const { cookie } = parseCookie(req.headers, ctx.account);
+  const { cookie } = parseCookie(req.headers);
 
   const order = await vcsDeprecated["GET /api/oms/user/orders/:orderId"](
     {

--- a/vtex/loaders/orders/list.ts
+++ b/vtex/loaders/orders/list.ts
@@ -19,7 +19,7 @@ export default async function loader(
 ): Promise<Userorderslist> {
   const { vcsDeprecated } = ctx;
   const { clientEmail, page = "0", per_page = "15" } = props;
-  const { cookie } = parseCookie(req.headers, ctx.account);
+  const { cookie } = parseCookie(req.headers);
 
   const ordersResponse = await vcsDeprecated
     ["GET /api/oms/user/orders"](

--- a/vtex/loaders/payment/paymentSystems.ts
+++ b/vtex/loaders/payment/paymentSystems.ts
@@ -39,7 +39,7 @@ async function loader(
   ctx: AppContext,
 ) {
   const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
 
   if (!payload?.sub || !payload?.userId) {
     throw new Error("User cookie is invalid");

--- a/vtex/loaders/payment/userPayments.ts
+++ b/vtex/loaders/payment/userPayments.ts
@@ -35,7 +35,7 @@ async function loader(
   ctx: AppContext,
 ): Promise<Payment[]> {
   const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
 
   if (!payload?.sub || !payload?.userId) {
     throw new Error("User cookie is invalid");

--- a/vtex/loaders/profile/getCurrentProfile.ts
+++ b/vtex/loaders/profile/getCurrentProfile.ts
@@ -69,7 +69,7 @@ async function loader(
   ctx: AppContext,
 ): Promise<Profile> {
   const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
 
   if (!payload?.sub || !payload?.userId) {
     throw new Error("User cookie is invalid");

--- a/vtex/loaders/profile/getProfileByEmail.ts
+++ b/vtex/loaders/profile/getProfileByEmail.ts
@@ -16,7 +16,7 @@ export async function loader(
   ctx: AppContext,
 ) {
   const { vcs } = ctx;
-  const { cookie } = parseCookie(req.headers, ctx.account);
+  const { cookie } = parseCookie(req.headers);
 
   const response = await vcs["GET /api/checkout/pub/profiles"]({
     email,

--- a/vtex/loaders/promotion/getPromotionById.ts
+++ b/vtex/loaders/promotion/getPromotionById.ts
@@ -22,7 +22,7 @@ export default async function loader(
 ): Promise<Document[]> {
   const { vcs } = ctx;
   const { idCalculatorConfiguration } = props;
-  const { cookie } = parseCookie(req.headers, ctx.account);
+  const { cookie } = parseCookie(req.headers);
 
   const promotionById = await vcs
     ["GET /api/rnb/pvt/calculatorconfiguration/:idCalculatorConfiguration"]({

--- a/vtex/loaders/session/getUserSessions.ts
+++ b/vtex/loaders/session/getUserSessions.ts
@@ -30,7 +30,7 @@ async function loader(
   ctx: AppContext,
 ): Promise<LoginSessionsInfo> {
   const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
 
   if (!payload?.sub || !payload?.userId) {
     throw new Error("User cookie is invalid");

--- a/vtex/loaders/user.ts
+++ b/vtex/loaders/user.ts
@@ -32,7 +32,7 @@ async function loader(
   ctx: AppContext,
 ): Promise<Person | null> {
   const { io } = ctx;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
 
   if (!payload?.sub || !payload?.userId) {
     return null;

--- a/vtex/loaders/wishlist.ts
+++ b/vtex/loaders/wishlist.ts
@@ -27,7 +27,7 @@ const loader = async (
   const url = new URL(req.url);
   const page = Number(url.searchParams.get("page")) || 0;
   const count = props.count || Infinity;
-  const { cookie, payload } = parseCookie(req.headers, ctx.account);
+  const { cookie, payload } = parseCookie(req.headers);
   const user = payload?.sub;
 
   if (!user) {

--- a/vtex/mod.ts
+++ b/vtex/mod.ts
@@ -148,7 +148,7 @@ export default function VTEX(
     fetcher: fetchSafe,
   });
   const vcsDeprecated = createHttpClient<VTEXCommerceStable>({
-    base: publicUrl,
+    base: `https://${account}.vtexcommercestable.com.br`,
     processHeaders: removeDirtyCookies,
     fetcher: fetchSafe,
   });

--- a/vtex/mod.ts
+++ b/vtex/mod.ts
@@ -45,6 +45,11 @@ export interface Props {
    * @description VTEX Account name. For more info, read here: https://help.vtex.com/en/tutorial/o-que-e-account-name--i0mIGLcg3QyEy8OCicEoC.
    */
   account: string;
+    /**
+   * @title Store Name
+   * @description VTEX Store name For more info, read here: https://help.vtex.com/en/tutorial/account-details-page--2vhUVOKfCaswqLguT2F9xq#stores
+   */
+    subAccount?: string;
   /**
    * @title Public store URL
    * @description Domain that is registered on License Manager (e.g: secure.mystore.com.br) to enable account/checkout/api proxy. Important: dont use the same domain as the public store url, or it will create a loop and break the app.
@@ -70,12 +75,6 @@ export interface Props {
   /**
    * @title Default Segment
    */
-  /**
-   * @title Set Refresh Token
-   * @description Set the refresh token in the cookies in headless login actions (actions/authentication/*)
-   * @default false
-   */
-  setRefreshToken?: boolean;
   defaultSegment?: SegmentCulture;
   usePortalSitemap?: boolean;
   /**
@@ -120,7 +119,7 @@ export const color = 0xf71963;
  * @logo https://decoims.com/mcp/0d6e795b-cefd-4853-9a51-93b346c52c3f/VTEX.svg
  */
 export default function VTEX(
-  { appKey, appToken, account, publicUrl: _publicUrl, salesChannel, ...props }:
+  { appKey, appToken, account, subAccount, publicUrl: _publicUrl, salesChannel, ...props }:
     Props,
 ) {
   const publicUrl = _publicUrl?.startsWith("https://")
@@ -152,16 +151,13 @@ export default function VTEX(
     processHeaders: removeDirtyCookies,
     fetcher: fetchSafe,
   });
-  const ioUrl = publicUrl.endsWith("/")
-    ? `${publicUrl}api/io/_v/private/graphql/v1`
-    : `${publicUrl}/api/io/_v/private/graphql/v1`;
   const io = createGraphqlClient({
-    endpoint: ioUrl,
+    endpoint:  `https://${subAccount || account}.vtexcommercestable.com.br/api/io/_v/private/graphql/v1`,
     processHeaders: removeDirtyCookies,
     fetcher: fetchSafe,
   });
   const vcs = createHttpClient<VCS>({
-    base: publicUrl,
+    base: `https://${account}.vtexcommercestable.com.br`,
     fetcher: fetchSafe,
     processHeaders: removeDirtyCookies,
     headers: headers,

--- a/vtex/utils/orderForm.ts
+++ b/vtex/utils/orderForm.ts
@@ -61,6 +61,28 @@ export const parseCookie = (headers: Headers) => {
   };
 };
 
+export const parseCookieWithoutAuth = (headers: Headers) => {
+  const cookies = getCookies(headers);
+  const ofidCookie = cookies[VTEX_CHECKOUT_COOKIE];
+
+  if (ofidCookie == null) {
+    return { orderFormId: "", cookie: "" };
+  }
+
+  if (!/^__ofid=([0-9a-fA-F])+$/.test(ofidCookie)) {
+    throw new Error(
+      `Not a valid VTEX orderForm cookie. Expected: /^__ofid=([0-9])+$/, receveid: ${ofidCookie}`,
+    );
+  }
+
+  const [_, id] = ofidCookie.split("=");
+
+  return {
+    orderFormId: id,
+    cookie: stringify({ [VTEX_CHECKOUT_COOKIE]: ofidCookie }),
+  };
+};
+
 export const formatCookie = (orderFormId: string): Cookie => ({
   value: `__ofid=${orderFormId}`,
   name: "checkout.vtex.com",

--- a/vtex/utils/vtexId.ts
+++ b/vtex/utils/vtexId.ts
@@ -15,6 +15,7 @@ interface CookiePayload {
 
 export const parseAuthCookie = (headers: Headers) => {
   const cookies = getCookies(headers);
+
   const token = cookies[VTEX_ID_CLIENT_COOKIE] ||
     Object.entries(cookies).find(([k]) =>
       k.startsWith(`${VTEX_ID_CLIENT_COOKIE}_`)
@@ -26,24 +27,23 @@ export const parseAuthCookie = (headers: Headers) => {
   return decoded?.[1] as CookiePayload | undefined ?? null;
 };
 
-export const parseCookie = (headers: Headers, account: string) => {
+export const parseCookie = (headers: Headers) => {
   const cookies = getCookies(headers);
-  const cookie = cookies[VTEX_ID_CLIENT_COOKIE] ||
-    cookies[`${VTEX_ID_CLIENT_COOKIE}_${account}`];
-  const decoded = cookie ? decode(cookie) : null;
 
+  const authCookieName = Object.keys(cookies)
+    .toSorted((a, z) => a.length - z.length)
+    .find((cookieName) => cookieName.startsWith("VtexIdclientAutCookie"));
+
+  if (!authCookieName) {
+    return { cookie: "", payload: undefined };
+  }
+
+  const cookie = cookies[authCookieName];
+  const decoded = cookie ? decode(cookie) : null;
   const payload = decoded?.[1] as CookiePayload | undefined;
 
   return {
-    cookie: stringify({
-      ...(cookies[VTEX_ID_CLIENT_COOKIE] &&
-        { [VTEX_ID_CLIENT_COOKIE]: cookies[VTEX_ID_CLIENT_COOKIE] }),
-      ...(cookies[`${VTEX_ID_CLIENT_COOKIE}_${account}`] &&
-        {
-          [`${VTEX_ID_CLIENT_COOKIE}_${account}`]:
-            cookies[`${VTEX_ID_CLIENT_COOKIE}_${account}`],
-        }),
-    }),
+    cookie: stringify({ [authCookieName]: cookie }),
     payload,
   };
 };

--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -177,6 +177,7 @@ export default function Proxy({
           // Prepare scripts to insert
           let scriptsInsert = "";
           for (const script of (includeScriptsToHead?.includes ?? [])) {
+            if (!script || !script.src) continue;
             scriptsInsert += typeof script.src === "string"
               ? script.src
               : script.src(req);
@@ -199,6 +200,7 @@ export default function Proxy({
           // Prepare scripts to insert
           let scriptsInsert = "";
           for (const script of (includeScriptsToBody?.includes ?? [])) {
+            if (!script || !script.src) continue;
             scriptsInsert += typeof script.src === "string"
               ? script.src
               : script.src(req);


### PR DESCRIPTION
# Fix: Sales Channel não respeitado no Intelligent Search

## Problema

Produtos de todas as políticas comerciais estavam sendo retornados, ignorando a configuração `salesChannel: "4"`.

## Causa Raiz

No arquivo `newapps-deco/apps/vtex/mod.ts` (linha ~150), o cliente HTTP `vcsDeprecated` estava configurado com:

```typescript
const vcsDeprecated = createHttpClient<VTEXCommerceStable>({
  base: publicUrl, // ❌ https://secure.lojaspaqueta.com.br
  processHeaders: removeDirtyCookies,
  fetcher: fetchSafe,
});
```

O domínio `secure.lojaspaqueta.com.br` possui um binding no License Manager da VTEX que não respeita corretamente o filtro de sales channel, retornando produtos de múltiplas políticas comerciais.

## Solução

Alterado para usar o domínio `vtexcommercestable`, que respeita corretamente a política comercial:

```typescript
const vcsDeprecated = createHttpClient<VTEXCommerceStable>({
  base: `https://${account}.vtexcommercestable.com.br`, // ✅ grupooscar.vtexcommercestable.com.br
  processHeaders: removeDirtyCookies,
  fetcher: fetchSafe,
});
```

## Impacto

- ✅ Intelligent Search agora respeita `salesChannel: "4"`
- ✅ Apenas produtos associados à política comercial 4 são retornados
- ✅ Compatível com a implementação original em `../apps/vtex/`

## Arquivo Modificado

- `/Users/matheus/Documents/Trabalho/newapps-deco/apps/vtex/mod.ts` (linha ~150)


# Fix: Null Script Error no Proxy Handler

**Arquivo:** `/Users/matheus/Documents/Trabalho/newapps-deco/apps/website/handlers/proxy.ts`

## Problema

```
TypeError: Cannot read properties of null (reading 'src')
    at proxy.ts:181:44
```

O proxy handler quebrava quando `includeScriptsToHead.includes` ou `includeScriptsToBody.includes` continham valores `null`/`undefined`.

## Causa

O loader `analytics/loaders/DecoAnalyticsScript.ts` configurado em `.deco/blocks/site.json` retorna `null` em determinadas situações, causando erro ao tentar acessar `script.src`.

## Solução

Adicionada validação para ignorar scripts nulos antes de acessar propriedades:

```typescript
// Antes (linha 179-184)
for (const script of (includeScriptsToHead?.includes ?? [])) {
  scriptsInsert += typeof script.src === "string"
    ? script.src
    : script.src(req);
}

// Depois
for (const script of (includeScriptsToHead?.includes ?? [])) {
  if (!script || !script.src) continue; // ✅ Validação adicionada
  scriptsInsert += typeof script.src === "string"
    ? script.src
    : script.src(req);
}
```

Aplicado em:
- `includeScriptsToHead` (linha ~179)
- `includeScriptsToBody` (linha ~203)

## Resultado

Proxy agora ignora scripts inválidos em vez de quebrar a aplicação.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes VTEX subaccount fetch/auth issues by routing clients through `vtexcommercestable` (with subaccount support) and ensures Intelligent Search respects the configured sales channel; also guards against null scripts in the proxy.

- **Bug Fixes**
  - Route VTEX clients via `https://${account}.vtexcommercestable.com.br` and set `io` GraphQL to `https://${subAccount || account}.vtexcommercestable.com.br/api/io/_v/private/graphql/v1` so subaccount requests work and Intelligent Search respects `salesChannel`.
  - Fix auth and checkout cookies: auto-detect the correct `VtexIdclientAutCookie` (account or subaccount) in `parseCookie`, and add `parseCookieWithoutAuth` to safely read `__ofid` and send only the checkout cookie in cart/simulation requests.
  - Ignore null/undefined scripts in `includeScriptsToHead` and `includeScriptsToBody` to avoid "Cannot read properties of null (reading 'src')" errors.

<sup>Written for commit b8e322f39d082062c407c74c46403e48efce39dd. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/apps/pull/1593?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional "Store Name" configuration for account selection.

* **Bug Fixes**
  * Corrected service endpoints to use stable account-based URLs.
  * Improved HTML proxy script injection to skip incomplete script entries and avoid errors.
  * Updated cookie parsing and checkout cookie handling to better support unauthenticated order/checkout flows across cart, profile, session, wishlist, and related actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/apps/pull/1593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->