### PR TITLE
Revert "feat(proxy): add cacheControl override; force immutable on VTEX /files/*?v=* (#1590)"

### DIFF
--- a/vtex/loaders/proxy.ts
+++ b/vtex/loaders/proxy.ts
@@ -68,17 +68,6 @@ const buildProxyRoutes = (
     const urlToProxy = `https://${hostname}`;
     const hostToUse = hostname;
 
-    // Versioned VTEX static assets (e.g. /files/foo.css?v=HASH) are immutable
-    // by definition: the hash changes whenever the content does. VTEX upstream
-    // serves them with short TTLs, so we force `immutable` on the proxy hop
-    // when the request carries a `v` query param. Unversioned variants of the
-    // same path keep upstream Cache-Control.
-    const IMMUTABLE_ASSET_PATHS = new Set([
-      "/files/*",
-      "/assets/*",
-      "/arquivos/*",
-    ]);
-
     const routeFromPath = (pathTemplate: string): Route => {
       const handlerValue = {
         __resolveType: "website/handlers/proxy.ts",
@@ -88,12 +77,6 @@ const buildProxyRoutes = (
         includeScriptsToBody,
         removeDirtyCookies: true,
         pathsThatRequireSameReferer: VTEX_PATHS_THAT_REQUIRES_SAME_REFERER,
-        ...(IMMUTABLE_ASSET_PATHS.has(pathTemplate) && {
-          cacheControl: {
-            value: "public, max-age=31536000, immutable",
-            matchQueryParam: "v",
-          },
-        }),
       };
 
       return ({

--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -86,26 +86,6 @@ export interface Props {
   removeDirtyCookies?: boolean;
   excludeHeaders?: string[];
   pathsThatRequireSameReferer?: string[];
-  /**
-   * @description Override Cache-Control on proxied responses. Use when the
-   *              upstream (e.g. VTEX IO) sends a Cache-Control that does not
-   *              match the resource's true cacheability — for example
-   *              versioned static assets at /files/*?v=HASH which are
-   *              immutable but get short upstream TTLs.
-   *
-   *              When matchQueryParam is set, the override only applies if
-   *              that query param is present on the incoming request URL.
-   *              This lets you safely opt in only the versioned variant of a
-   *              path (e.g. matchQueryParam: "v" → /files/x.js?v=abc gets
-   *              overridden, /files/x.js does not).
-   *
-   *              Only applied when the upstream response is 2xx, so error
-   *              responses retain their upstream caching semantics.
-   */
-  cacheControl?: {
-    value: string;
-    matchQueryParam?: string;
-  };
 }
 /**
  * @title Proxy
@@ -124,7 +104,6 @@ export default function Proxy({
   replaces,
   removeDirtyCookies = false,
   pathsThatRequireSameReferer = [],
-  cacheControl,
 }: Props): Handler {
   return async (req, _ctx) => {
     const url = new URL(req.url);
@@ -237,13 +216,6 @@ export default function Proxy({
       const location = responseHeaders.get("location");
       if (location) {
         responseHeaders.set("location", location.replace(proxyUrl, url.origin));
-      }
-    }
-    if (cacheControl && response.ok) {
-      const matches = !cacheControl.matchQueryParam ||
-        url.searchParams.has(cacheControl.matchQueryParam);
-      if (matches) {
-        responseHeaders.set("Cache-Control", cacheControl.value);
       }
     }
     let text: undefined | string = undefined;


### PR DESCRIPTION
Reverts 7e17085ced250aef214d82725fd27d400cd430d8 (PR #1590).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revert the proxy Cache-Control override feature, removing the forced immutable caching for VTEX versioned static assets. Proxied responses now follow upstream Cache-Control headers again.

<sup>Written for commit 9aa23d1f6c5a378ae20c66ee16daa53db2c8ec42. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/apps/pull/1594?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Proxy routing now targets hostname-based upstream servers instead of CDN domains, affecting request routing and response handling.
  * Removed automatic cache-control header injection for versioned static assets. Previously, static files with version parameters received extended cache headers; this behavior is now removed, potentially affecting browser caching behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/apps/pull/1594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->