### PR TITLE
refactor: remove bypassPlatformImageOptimization flag

### DIFF
--- a/website/components/Events.tsx
+++ b/website/components/Events.tsx
@@ -11,7 +11,6 @@ interface EventsAPI {
   ) => () => void;
 }
 interface FeatureFlags {
-  bypassPlatformImageOptimization: boolean;
   bypassDecoImageOptimization: boolean;
   cdnHost: string;
 }
@@ -31,8 +30,6 @@ declare global {
     };
   }
 }
-const BYPASS_PLATFORM_IMAGE_OPTIMIZATION =
-  Deno.env.get("BYPASS_PLATFORM_IMAGE_OPTIMIZATION") === "true";
 const BYPASS_DECO_IMAGE_OPTIMIZATION =
   Deno.env.get("BYPASS_DECO_IMAGE_OPTIMIZATION") === "true";
 const DECO_CDN_HOST = Deno.env.get("DECO_CDN_HOST") ?? "https://decoims.com";
@@ -101,7 +98,6 @@ function Events({ deco }: {
           deco,
           segmentCookie: DECO_SEGMENT,
           featureFlags: {
-            bypassPlatformImageOptimization: BYPASS_PLATFORM_IMAGE_OPTIMIZATION,
             bypassDecoImageOptimization: BYPASS_DECO_IMAGE_OPTIMIZATION,
             cdnHost: DECO_CDN_HOST,
           },

--- a/website/components/Image.tsx
+++ b/website/components/Image.tsx
@@ -56,17 +56,6 @@ export const FACTORS = [1, 2];
 
 type FitOptions = "contain" | "cover";
 
-// By default we use the platform image optimization, with functions like:
-// optimizeVTEX, optimizeWake, optmizeShopify
-// if you want to use deco optimization
-// you can set the BYPASS_PLATFORM_IMAGE_OPTIMIZATION environment variable to true
-// Default is false
-const bypassPlatformImageOptimization = () =>
-  IS_BROWSER
-    // deno-lint-ignore no-explicit-any
-    ? (globalThis as any).DECO?.featureFlags?.bypassPlatformImageOptimization
-    : Deno.env.get("BYPASS_PLATFORM_IMAGE_OPTIMIZATION") === "true";
-
 // Default is false
 const bypassDecoImageOptimization = () =>
   IS_BROWSER
@@ -196,34 +185,32 @@ export const getOptimizedMediaUrl = (opts: OptimizationOptions) => {
   if (originalSrc.startsWith("data:")) {
     return originalSrc;
   }
-  if (!bypassPlatformImageOptimization()) {
-    if (originalSrc.startsWith("https://media-storage.soureicdn.com")) {
-      return optimizeSourei(opts);
-    }
+  if (originalSrc.startsWith("https://media-storage.soureicdn.com")) {
+    return optimizeSourei(opts);
+  }
 
-    if (originalSrc.includes("media/catalog/product")) {
-      return optimizeMagento(opts);
-    }
+  if (originalSrc.includes("media/catalog/product")) {
+    return optimizeMagento(opts);
+  }
 
-    if (originalSrc.includes("fbitsstatic.net/img/")) {
-      return optimizeWake(opts);
-    }
+  if (originalSrc.includes("fbitsstatic.net/img/")) {
+    return optimizeWake(opts);
+  }
 
-    if (originalSrc.startsWith("https://cdn.vnda.")) {
-      return optmizeVNDA(opts);
-    }
+  if (originalSrc.startsWith("https://cdn.vnda.")) {
+    return optmizeVNDA(opts);
+  }
 
-    if (originalSrc.startsWith("https://cdn.shopify.com")) {
-      return optmizeShopify(opts);
-    }
+  if (originalSrc.startsWith("https://cdn.shopify.com")) {
+    return optmizeShopify(opts);
+  }
 
-    if (
-      /(vteximg.com.br|vtexassets.com|myvtex.com)\/arquivos\/ids\/\d+/.test(
-        originalSrc,
-      )
-    ) {
-      return optimizeVTEX(opts);
-    }
+  if (
+    /(vteximg.com.br|vtexassets.com|myvtex.com)\/arquivos\/ids\/\d+/.test(
+      originalSrc,
+    )
+  ) {
+    return optimizeVTEX(opts);
   }
 
   if (bypassDecoImageOptimization()) {


### PR DESCRIPTION
## Summary
- Removes the `BYPASS_PLATFORM_IMAGE_OPTIMIZATION` env var, client-side feature flag, and conditional guard
- Platform image optimizations (VTEX, Shopify, Wake, VNDA, Sourei, Magento) now always run unconditionally

## Test plan
- [ ] Verify images from each platform (VTEX, Shopify, Wake, VNDA, Sourei, Magento) are still optimized correctly
- [ ] Verify deco CDN fallback still works for non-platform images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `BYPASS_PLATFORM_IMAGE_OPTIMIZATION` flag and now always apply platform-specific image optimizations. VTEX, Shopify, Wake, VNDA, Sourei, and Magento URLs are optimized by default.

- **Refactors**
  - Simplified `getOptimizedMediaUrl` to always run platform optimizers.
  - Removed the `bypassPlatformImageOptimization` helper and related checks.
  - Dropped feature flag wiring from `Events.tsx`.

- **Migration**
  - Remove `BYPASS_PLATFORM_IMAGE_OPTIMIZATION` from envs and client feature flags (now a no-op).
  - To bypass Deco CDN for non-platform images, continue using `BYPASS_DECO_IMAGE_OPTIMIZATION` if needed.

<sup>Written for commit 35505c4feb93831ac6358fb008974df158f16c03. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/apps/pull/1596?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the platform image optimization bypass flag; platform-specific image optimizations are now consistently applied.
  * Simplified analytics feature flags configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/apps/pull/1596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->