### PR TITLE
feat(vtex): opt-in to CDN cache via PAGE_CACHE_ALLOWED_KEY

### DIFF
--- a/vtex/middleware.ts
+++ b/vtex/middleware.ts
@@ -1,5 +1,5 @@
 import { getCookies } from "std/http/cookie.ts";
-import { PAGE_DIRTY_KEY } from "@deco/deco/blocks";
+import { PAGE_CACHE_ALLOWED_KEY } from "@deco/deco/blocks";
 import { AppMiddlewareContext } from "./mod.ts";
 import {
   getISCookiesFromBag,
@@ -36,9 +36,9 @@ export const middleware = (
 
   const cacheable = isCacheableSegment(ctx) && !isLoggedIn;
 
-  // PAGE_DIRTY_KEY: marks page dirty for section-level caching and other consumers
-  if (!cacheable) {
-    ctx.bag.set(PAGE_DIRTY_KEY, true);
+  if (cacheable) {
+    ctx.bag.set(PAGE_CACHE_ALLOWED_KEY, true);
+  } else {
     ctx.response.headers.set(
       "Cache-Control",
       "no-store, no-cache, must-revalidate",


### PR DESCRIPTION
## Summary

- Switches vtex middleware from opt-out to opt-in caching model
- When page is cacheable (anonymous segment + not logged in), sets `PAGE_CACHE_ALLOWED_KEY` in the bag
- When not cacheable, sets `Cache-Control: no-store` directly (no dirty flag needed)
- Removes `PAGE_DIRTY_KEY` dependency from vtex middleware

## Context

Previously, the runtime applied CDN cache headers to **all** sites by default (opt-out model), and VTEX would mark pages as "dirty" when they shouldn't be cached. This PR flips the model: the runtime only applies public `Cache-Control` when an app explicitly sets `PAGE_CACHE_ALLOWED_KEY`, so CDN caching is scoped to apps that know when it's safe.

Depends on: deco-cx/deco#feat/page-cache-opt-in

## Test plan

- [ ] Anonymous VTEX user with no active campaigns/priceTables/regionId → page should receive `Cache-Control: public, max-age=90, ...`
- [ ] Logged-in VTEX user → page should receive `Cache-Control: no-store, no-cache, must-revalidate`
- [ ] VTEX user with active segment (campaigns/priceTables/regionId) → page should receive `Cache-Control: no-store, no-cache, must-revalidate`
- [ ] Non-VTEX site → no `Cache-Control` header set by deco runtime (existing proxy/CDN behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches VTEX middleware to opt-in CDN caching. Sets `PAGE_CACHE_ALLOWED_KEY` for anonymous, logged-out requests; otherwise sends `Cache-Control: no-store` and removes `PAGE_DIRTY_KEY` usage.

- **Dependencies**
  - Requires `deco-cx/deco#feat/page-cache-opt-in` (runtime only applies public cache headers when `PAGE_CACHE_ALLOWED_KEY` is set).

<sup>Written for commit aec5a412022edf319718d9d7e75e3eeca3a49326. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/apps/pull/1597?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page caching behavior for non-logged-in users to enhance performance.
  * Refined cache control header handling for better consistency.

* **Refactor**
  * Optimized caching logic for improved page load performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/apps/pull/1597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->