### PR TITLE
fix(website/asset): forward Sec-Fetch-* headers to upstream

### DIFF
--- a/website/loaders/asset.ts
+++ b/website/loaders/asset.ts
@@ -36,7 +36,24 @@ const loader = async (
     });
   }
 
-  const original = await fetchSafe(url.href, STALE);
+  // Some origins (notably fonts.gstatic.com, which declares
+  // `Vary: Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site`) degrade the
+  // response Content-Type when Fetch Metadata headers are missing — e.g.
+  // returning `text/html` for a `wOF2` binary, which then trips the
+  // Content-Type guard below and surfaces as a 403 to the client. Preserve
+  // the browser's original Fetch Metadata so upstream behaves the same as
+  // it would for a direct request.
+  const forwardedHeaders = new Headers();
+  for (const [name, value] of request.headers) {
+    if (name.toLowerCase().startsWith("sec-fetch-")) {
+      forwardedHeaders.set(name, value);
+    }
+  }
+
+  const original = await fetchSafe(url.href, {
+    ...STALE,
+    headers: forwardedHeaders,
+  });
   const response = new Response(original.body, original);
 
   // Check if the request's Accept header includes "text/html"


### PR DESCRIPTION
## Resumo

`website/loaders/asset.ts` faz proxy server-side de assets (fontes, imagens, etc.) e tem um guard que rejeita upstreams cujo `Content-Type` contém `text/html`. Hoje esse guard dispara incorretamente para um subconjunto de arquivos do Google Fonts, fazendo o browser receber `403` em vez do binário da fonte.

O root cause não é o guard — é o fetch upstream sair sem os headers de Fetch Metadata que o gstatic usa para decidir qual `Content-Type` devolver.

## Sintoma observado em produção

No site da Notta (`www.notta.com.br`, tema Helvetica via `website/loaders/fonts/googleFonts.ts`), 2 das 8 variantes de `@font-face` retornam `403` de forma persistente, derrubando peso `400` e `700` da fonte custom:

```
GET https://www.notta.com.br/live/invoke/website/loaders/asset.ts?src=https://fonts.gstatic.com/l/font?kit=JIAxUVNqfH9WuVQQRM4zVxOnPzMveA&skey=22efecd2bc0e2cb0&v=v10
→ 403 application/json
   {"message":"Forbidden: text/html not accepted as a response"}
```

O browser cai em fallback do sistema e a tipografia da página muda visualmente sem que nada tenha sido editado no CMS.

## Root cause

`fonts.gstatic.com` anuncia:

```
Vary: Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
```

e, quando esses headers chegam ausentes, devolve `200` com `Content-Type: text/html; charset=utf-8` no lugar de `font/woff2` — mesmo o body sendo um `wOF2` válido (`wOF2` magic number nos primeiros bytes). Aparenta ser uma proteção anti-hotlinking do Google Fonts contra fetches server-side.

`fetchSafe` em `asset.ts` chama o gstatic sem propagar os `Sec-Fetch-*` que o browser mandou para o nosso loader. O guard de `text/html` então rejeita a resposta e o browser nunca recebe a fonte.

## Teste reproduzível (rodado em 22/05/2026)

Mesma URL no `gstatic`, variando apenas o header:

| Headers enviados ao gstatic | `Content-Type` | Body |
|---|---|---|
| (nenhum `Sec-Fetch-*`) | `text/html; charset=utf-8` | `wOF2 ...` (12 617 bytes) |
| Vários headers de browser **sem** `Sec-Fetch-Dest` | `text/html; charset=utf-8` | mesmo binário |
| **Apenas** `Sec-Fetch-Dest: font` | `font/woff2` | mesmo binário |

Bastou um único header para o `Content-Type` voltar ao correto. Bytes idênticos nos dois casos.

## Mudança

Propaga todos os headers `Sec-Fetch-*` da `Request` original para o `fetchSafe` upstream. Não altera o guard, não muda cache, não relaxa CSP, não toca em nenhum outro loader.

```ts
const forwardedHeaders = new Headers();
for (const [name, value] of request.headers) {
  if (name.toLowerCase().startsWith("sec-fetch-")) {
    forwardedHeaders.set(name, value);
  }
}

const original = await fetchSafe(url.href, {
  ...STALE,
  headers: forwardedHeaders,
});
```

Quando o browser pede uma fonte via `@font-face`, ele já envia `Sec-Fetch-Dest: font`, `Sec-Fetch-Mode: cors`, `Sec-Fetch-Site: same-origin` para o nosso loader. Apenas repassamos.

## Impacto

- **Resolve:** kits de fonte do Google que hoje retornam 403 via proxy.
- **Sites afetados pelo bug atual:** qualquer site usando `website/loaders/fonts/googleFonts.ts` (Helvetica, Poppins, etc.). Confirmado na Notta; provável em outros tenants.
- **Compatibilidade:** mudança aditiva. Para requests que já funcionam, os headers extras são inofensivos (o upstream simplesmente os ignora ou serve a mesma resposta).
- **Segurança:** o guard de `text/html` continua intacto.

## Test plan

- [ ] `deno fmt`, `deno lint`, `deno check` no arquivo alterado (passou local).
- [ ] Após deploy, reexecutar contra `www.notta.com.br` o request que hoje devolve 403 e confirmar `200 font/woff2`.
- [ ] Spot-check em outros tenants com fontes Google (ex.: Poppins) para garantir nenhuma regressão.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward `Sec-Fetch-*` headers to upstream in `website/loaders/asset.ts` so Google Fonts returns the correct `font/woff2` Content-Type, fixing 403s in the asset proxy. The Content-Type guard stays unchanged.

- **Bug Fixes**
  - Forward browser Fetch Metadata (`Sec-Fetch-Dest/Mode/Site`) on upstream fetches.
  - Fixes persistent `403` on some Google Fonts requests by avoiding `text/html` downgrades.
  - No impact on other assets; headers are additive and ignored if not used by the origin.

<sup>Written for commit 65cde950b54097b89c4938eb3bbdd8aca470a6c6. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/apps/pull/1599?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed asset requests to properly preserve browser security headers, preventing content type degradation when loading upstream assets like fonts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/apps/pull/1599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->