### PR TITLE
fix(http): preserve caller's URL encoding in path params

### DIFF
--- a/utils/http.ts
+++ b/utils/http.ts
@@ -97,19 +97,10 @@ export interface HttpClientOptions {
 }
 
 /**
- * Encode path segment for URLs while preserving forward slashes
- * Encodes special characters but leaves / intact for API compatibility
- */
-function encodePathSegment(value: string): string {
-  // Split by /, encode each segment, then rejoin
-  return value
-    .split("/")
-    .map((segment) => encodeURIComponent(segment))
-    .join("/");
-}
-
-/**
- * Normalize and validate path parameters to prevent path traversal attacks
+ * Validate path parameters to prevent path traversal attacks.
+ * Validates against a fully-decoded copy of the value but returns the
+ * original input verbatim so the caller's encoding level is preserved
+ * (e.g. a caller-encoded "%2520" stays "%2520" rather than collapsing to "%20").
  */
 function normalizePathParam(
   value: string | number,
@@ -117,58 +108,46 @@ function normalizePathParam(
 ): string {
   const str = String(value);
 
-  // Step 1: Decode any URL encoding to catch encoded attacks
   let decoded = str;
   try {
-    // Decode multiple times to catch double-encoding
+    // Decode repeatedly so we can detect attacks hidden behind double-encoding.
     let prev = "";
     while (prev !== decoded) {
       prev = decoded;
       decoded = decodeURIComponent(decoded);
     }
   } catch {
-    // If decode fails, keep the last successful decoded value
-    // Do not reset to original string as that would bypass security checks
+    // Partial decode is acceptable for validation purposes.
   }
 
-  // Step 2: Check for path traversal in decoded value
   if (decoded.includes("../") || decoded.includes("..\\")) {
     throw new Error(
       `Path traversal detected in parameter '${paramName}'`,
     );
   }
 
-  // Step 3: Block absolute paths
   if (decoded.startsWith("/") || decoded.startsWith("\\")) {
     throw new Error(
       `Absolute paths not allowed in parameter '${paramName}'`,
     );
   }
 
-  // Step 4: Normalize path separators and clean up
-  const normalized = decoded
-    .replace(/\\/g, "/") // Convert backslashes to forward slashes
-    .replace(/\/+/g, "/") // Collapse multiple slashes
-    .replace(/^\/|\/$/g, ""); // Remove leading/trailing slashes
-
-  // Step 5: Final validation - ensure no ".." or "." segments remain
-  const segments = normalized.split("/");
+  const segments = decoded.replace(/\\/g, "/").split("/");
   for (const segment of segments) {
-    if (segment === ".." || segment === ".") {
+    if (segment === "..") {
       throw new Error(
         `Invalid path segment in parameter '${paramName}'`,
       );
     }
   }
 
-  // Step 6: Block null bytes
-  if (normalized.includes("\0")) {
+  if (str.includes("\0") || decoded.includes("\0")) {
     throw new Error(
       `Null byte detected in parameter '${paramName}'`,
     );
   }
 
-  return normalized;
+  return str;
 }
 
 /**
@@ -267,27 +246,20 @@ export const createHttpClient = <T>(
               throw new TypeError(`HttpClient: Missing ${name} at ${path}`);
             }
 
-            // Normalize and validate path parameters to prevent path traversal
+            // Validate path parameters to prevent path traversal.
+            // We intentionally pass the value through verbatim — re-encoding
+            // here would break callers that already pre-encoded special
+            // characters (e.g. "%2520" must reach the server as "%2520",
+            // not collapse to "%20" or "%2525").
             if (param !== undefined) {
               try {
-                // Handle array params (for wildcard routes like /*)
                 if (Array.isArray(param)) {
-                  return param.map((item) => {
-                    const itemStr = String(item);
-                    const normalized = normalizePathParam(itemStr, name);
-                    // Encode special chars but preserve forward slashes for API compatibility
-                    return encodePathSegment(normalized);
-                  });
+                  return param.map((item) =>
+                    normalizePathParam(String(item), name)
+                  );
                 }
-
-                // Handle single value params
-                const paramStr = String(param);
-                const normalized = normalizePathParam(paramStr, name);
-                // Encode special chars but preserve forward slashes for API compatibility
-                return encodePathSegment(normalized);
+                return normalizePathParam(String(param), name);
               } catch (_error) {
-                // Translate validation errors into generic HTTP 400 errors
-                // without exposing the original input value or error details
                 throw new HttpError(
                   400,
                   `Invalid parameter '${name}'`,


### PR DESCRIPTION
## Summary

Regression introduced by #1525 (commit 3ff0d908): when admin tries to fetch a file whose name contains a space (or any pre-encoded character), the path on the wire arrived wrong, causing 404s.

`normalizePathParam` decoded the input in a loop until fixed point, then `encodePathSegment` re-encoded only once — collapsing the caller's encoding level by one. The same path also encoded `/` as `%2F`, breaking wildcard route segments (later partially fixed in #1528 / #1533).

**Repro**: `filepath = "/.deco/blocks/pages-Home%2520ETC-330706.json"`
- Before (buggy): `GET /fs/file/.deco%2Fblocks%2Fpages-Home%20ETC-330706.json`
- After (this PR): `GET /fs/file/.deco/blocks/pages-Home%2520ETC-330706.json` ✓ (matches pre-#1525 behaviour)

## Fix

- Validate against a **fully-decoded copy** of the value (so encoded path traversal — including double-encoded — is still caught).
- Return the **original input verbatim**; drop the re-encode step.
- Drop the now-unused `encodePathSegment` helper.

This restores the pre-#1525 pass-through behaviour while preserving the security checks #1525 introduced: `../`, `..\`, absolute paths, and null bytes.

## Security

All attacks still blocked by validating the fully-decoded form:
- `../../etc/passwd` → `../` literal match
- `..%2F..%2Fpasswd` → multi-decode → `../../passwd` → caught
- `..%252F..%252Fpasswd` → decoded to fixed point → caught
- `/etc/passwd`, `%2Fetc%2Fpasswd` → absolute path check on decoded form
- `foo\0bar` → null-byte check on both raw and decoded
- Backslash variants (`..\`) → checked explicitly

One intentional relaxation: dropped the `segment === "."` rejection (a bare `.` segment is harmless; only `..` is a traversal vector). Happy to add it back if preferred.

## Test plan

- [ ] Admin can read `/.deco/blocks/pages-Home%2520ETC-330706.json` via the daemon fs/read loader
- [ ] Existing HTTP-client consumers (vtex, vnda, smarthint, konfidency, etc.) unaffected
- [ ] Path traversal attempts (`../`, `..%2F`, `..%252F`, leading `/`) still rejected with HTTP 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves caller URL encoding in HTTP path params to fix 404s and broken wildcard routes for pre-encoded filenames (e.g. `%2520`). Restores pre-#1525 pass-through while keeping traversal and absolute-path protections.

- **Bug Fixes**
  - Validate against a fully-decoded copy; return the original value verbatim (no re-encode).
  - Remove `encodePathSegment`; stop encoding `/` as `%2F` in wildcard params.
  - Continue rejecting `../`, `..\`, leading `/` or `\`, and null bytes (checked on raw and decoded).
  - Allow `.` segments again (only `..` is blocked).

<sup>Written for commit 8fdc9bdf13920c06a9832a5e1fcf0afae2c3a71d. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/apps/pull/1600?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced path parameter validation to properly handle and reject invalid parameters with appropriate error responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/apps/pull/1600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->