### PR TITLE
fix(matchers): declare random matcher cacheable=true

### DIFF
--- a/website/matchers/random.ts
+++ b/website/matchers/random.ts
@@ -8,6 +8,11 @@ export interface Props {
 // once selected the session will reuse the same value
 export const sticky = "session";
 
+// Sticky-session matchers persist the result in a deco_matcher_* cookie, and
+// CDNs are expected to include that cookie in the cache key — so per-variant
+// responses get distinct cache entries and the page is safely cacheable.
+export const cacheable = true;
+
 /**
  * @title Random
  * @description Target a percentage of the total traffic to do an A/B test


### PR DESCRIPTION
## Summary

`website/matchers/random.ts` (the engine behind every "ABTest {{{traffic}}}" matcher on the deco fleet) doesn't declare `cacheable = true`. After [`deco-cx/deco#1202`](https://github.com/deco-cx/deco/pull/1202) wires `flag.cacheable` into the page-cache decision via a strict `=== true` check, any matcher-wrapped page where the random matcher fires gets `Cache-Control: no-store`.

That's wrong for `random.ts` specifically — it has `sticky = "session"`, so the per-visitor result is persisted in the `deco_matcher_<hash>_<split>` Set-Cookie, and the documented CDN pattern (see [release notes for `1.200.1-next.2`](https://github.com/deco-cx/deco/releases/tag/1.200.1-next.2)) is to include that cookie in the custom cache key. Per-variant cache entries don't collide.

Same one-line declaration that already exists on `always.ts`, `site.ts`, `date.ts`, `device.ts`, `environment.ts`, `host.ts`, `queryString.ts`, etc.

## Test plan

Observed on Lojas Torra PDP (`www.lojastorra.com.br/*/p`) — the "Teste A/B - PDP Botão Comprar" block uses `random.ts` → `flag.cacheable === undefined` → `applyPageCacheDecision` writes `no-store`.

After this fix:
- [ ] Cut a next release that includes this commit.
- [ ] Bump a test site (`deco-sites/lojastorra-2` PR [#260](https://github.com/deco-sites/lojastorra-2/pull/260)) to that release.
- [ ] Re-curl PDP — expected `Cache-Control: public, max-age=90, stale-while-revalidate=3600, stale-if-error=86400` + `Deco-Cache-Vary-Cookies` hint header.
- [ ] Confirm the matcher Set-Cookie still flips between two requests with different cookie values (stickiness preserved).

## Follow-ups (out of scope here)

Audit of the other matchers without `cacheable=true`:
- `userAgent.ts` — varies per UA; safe if CDN varies cache key by UA hash or Vary: User-Agent
- `location.ts` — varies per geo; safe with geo cache key
- `cookie.ts` — varies per cookie value; safe with cookie cache key
- `cron.ts` — static per time window; should be cacheable

These each need separate consideration (CDN setup, etc.); intentionally not lumped in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `cacheable = true` in `website/matchers/random.ts` to restore safe caching for AB test pages using the random matcher. With CDNs varying the cache key by the `deco_matcher_*` cookie, per-variant responses are cached and the strict `flag.cacheable === true` check no longer forces `Cache-Control: no-store`.

<sup>Written for commit 93db1f8790857aaa79315279d251d4856c0a5643. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/apps/pull/1602?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced caching configuration for matcher variants to ensure consistent, safe delivery across CDN infrastructure. Matcher results are now properly configured for persistence, maintaining variant integrity while remaining safely cacheable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/apps/pull/1602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->