### PR TITLE
fix(extensions): declare cache: "no-cache" on 7 product-extension wrappers

### DIFF
--- a/commerce/loaders/extensions/productDetailsPage.ts
+++ b/commerce/loaders/extensions/productDetailsPage.ts
@@ -4,3 +4,5 @@ import loader from "../product/extensions/detailsPage.ts";
 const deprecated = (...args: Parameters<typeof loader>) => loader(...args);
 
 export default deprecated;
+
+export const cache = "no-cache";

--- a/commerce/loaders/extensions/productListingPage.ts
+++ b/commerce/loaders/extensions/productListingPage.ts
@@ -4,3 +4,5 @@ import loader from "../product/extensions/listingPage.ts";
 const deprecated = (...args: Parameters<typeof loader>) => loader(...args);
 
 export default deprecated;
+
+export const cache = "no-cache";

--- a/commerce/loaders/extensions/products.ts
+++ b/commerce/loaders/extensions/products.ts
@@ -4,3 +4,5 @@ import loader from "../product/extensions/list.ts";
 const deprecated = (...args: Parameters<typeof loader>) => loader(...args);
 
 export default deprecated;
+
+export const cache = "no-cache";

--- a/commerce/loaders/product/extensions/list.ts
+++ b/commerce/loaders/product/extensions/list.ts
@@ -12,3 +12,5 @@ export default function ProductsExt(
 ): Promise<Product[] | null> {
   return extend(props);
 }
+
+export const cache = "no-cache";

--- a/commerce/loaders/product/extensions/suggestions.ts
+++ b/commerce/loaders/product/extensions/suggestions.ts
@@ -14,3 +14,5 @@ export default function ProductDetailsExt(
 ): Promise<Suggestion | null> {
   return extend(props);
 }
+
+export const cache = "no-cache";

--- a/vtex/loaders/product/extensions/list.ts
+++ b/vtex/loaders/product/extensions/list.ts
@@ -20,4 +20,6 @@ async (products: Product[] | null) =>
     )
     : products;
 
+export const cache = "no-cache";
+
 export default loader;

--- a/vtex/loaders/product/extensions/suggestions.ts
+++ b/vtex/loaders/product/extensions/suggestions.ts
@@ -28,4 +28,6 @@ async (suggestion: Suggestion | null) => {
   };
 };
 
+export const cache = "no-cache";
+
 export default loader;


### PR DESCRIPTION
## Summary

Adds `export const cache = "no-cache";` to 7 product-extension wrapper loaders that lack a cache declaration but delegate to loaders that already have `cache = "no-cache"`.

## Files changed (7, all `+2 lines`)

| File | Delegates to |
|---|---|
| `commerce/loaders/product/extensions/list.ts` | `website/loaders/extension.ts` (pure passthrough) |
| `commerce/loaders/product/extensions/suggestions.ts` | `website/loaders/extension.ts` (pure passthrough) |
| `vtex/loaders/product/extensions/list.ts` | invokes `vtex/loaders/product/extend.ts` (declares `no-cache`) |
| `vtex/loaders/product/extensions/suggestions.ts` | invokes `vtex/loaders/product/extend.ts` |
| `commerce/loaders/extensions/productDetailsPage.ts` (deprecated) | wraps `product/extensions/detailsPage.ts` (`no-cache`) |
| `commerce/loaders/extensions/productListingPage.ts` (deprecated) | wraps `product/extensions/listingPage.ts` (`no-cache`) |
| `commerce/loaders/extensions/products.ts` (deprecated) | wraps `product/extensions/list.ts` |

## Why

The framework reads the `cache` directive from each loader module directly — it does **not** propagate transitively through delegated invokes. Without a declaration on a wrapper, a downstream module's cache contract can fail to bubble up to the full-page cache decision.

Concrete case: the osklen PDP migration to deco@1.201.x traced to `no-store` even though the underlying `extend` loader had `cache = "no-cache"`, because the extension wrapper sat between them with no declaration.

## Decision: `"no-cache"` vs alternatives

All sibling peer files in the same directories (`detailsPage.ts`, `listingPage.ts`) chose `no-cache`. The wrappers should match.

- ✅ `no-cache` — cacheable but always revalidate. Matches peer pattern. Doesn't force page no-store. Subject to per-loader cache decisions downstream.
- ❌ `stale-while-revalidate` — too aggressive; the underlying `extend` pipeline can include `simulate` which reads cart context (per-user).
- ❌ `no-store` — wrong direction; would force the page no-store and defeat the purpose.
- ❌ Leave unset — empirically observed to leak into PDP no-store at osklen.

## Test plan

- [x] `deno fmt --check` passes on all 7 files
- [x] `deno lint` passes on all 7 files
- [ ] Manual PDP/PLP probe on osklen preview after this lands + `apps/` pin bumped

## Out of scope

Not bumping `deno.json` — opening this as a regular PR per the request (no prerelease tag). When merged, the bot will create the next stable tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare `export const cache = "no-cache"` on 7 product-extension wrapper loaders to match their underlying loaders and prevent unintended page `no-store`. Ensures the framework reads the cache directive on wrappers so PDP/PLP stay cacheable while always revalidating.

- **Bug Fixes**
  - Added `cache = "no-cache"` to wrapper modules so the directive is read directly (no transitive propagation needed).
  - Prevents PDP/PLP from resolving to `no-store` when a wrapper sits between the page and the underlying `extend` loader.
  - Aligns with peer files that already use `no-cache`; avoids `stale-while-revalidate` due to cart-context reads.

<sup>Written for commit 86ebbd49f21476afc14a292805dc33acda894c28. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/apps/pull/1604?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized caching behavior for product loaders to ensure customers always receive the most current product details, listings, and recommendation suggestions without serving outdated information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/apps/pull/1604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->