### PR TITLE
feat(intelligentSearch): support multi-ID search with client-side pagination

### DIFF
--- a/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -311,19 +311,49 @@ const loader = async (
     ctx.defaultSegment?.cultureInfo ?? "pt-BR";
 
   const params = withDefaultParams({ ...searchArgs, page, locale });
+
+  // Multiple items search format: ?query=product:98765;98743 or ?query=sku:123;456
+  // The facets path must be empty because the API returns exactly the specified IDs
+  const query = searchArgs.query ?? "";
+  const isMultipleItemsSearch = query.startsWith("product:") ||
+    query.startsWith("sku:");
+  const facetsPath = isMultipleItemsSearch ? "" : toPath(selected);
+  const fFacetsPath = isMultipleItemsSearch ? "" : toPath(fselected);
+
+  // For multi-ID searches, paginate client-side: slice the IDs by page/count
+  // and send only that slice to VTEX in a single request
+  let multiIdsTotalCount = 0;
+  const searchParams = (() => {
+    if (!isMultipleItemsSearch) {
+      return params;
+    }
+
+    const [prefix, idsStr] = query.split(":");
+    const allIds = idsStr.split(";");
+    multiIdsTotalCount = allIds.length;
+    const start = page * searchArgs.count;
+    const pageIds = allIds.slice(start, start + searchArgs.count);
+
+    return {
+      ...params,
+      query: `${prefix}:${pageIds.join(";")}`,
+      page: 1,
+    };
+  })();
+
   // search products on VTEX. Feel free to change any of these parameters
   const [productsResult, facetsResult] = await Promise.all([
     vcsDeprecated
       ["GET /api/io/_v/api/intelligent-search/product_search/*facets"]({
-        ...params,
-        facets: toPath(selected),
+        ...searchParams,
+        facets: facetsPath,
       }, {
         ...STALE,
         headers: segment ? withSegmentCookie(segment) : undefined,
       }).then((res) => res.json()),
     vcsDeprecated["GET /api/io/_v/api/intelligent-search/facets/*facets"]({
-      ...params,
-      facets: toPath(fselected),
+      ...searchParams,
+      facets: fFacetsPath,
     }, { ...STALE, headers: segment ? withSegmentCookie(segment) : undefined })
       .then((res) => res.json()),
   ]);
@@ -399,7 +429,13 @@ const loader = async (
     .filter((f) => !f.hidden)
     .map(toFilter(selectedFacets, paramsToPersist));
   const itemListElement = pageTypesToBreadcrumbList(pageTypes, baseUrl);
-  const hasNextPage = Boolean(pagination.next.proxyUrl);
+  // For multi-ID searches, pagination is handled client-side
+  const totalRecords = isMultipleItemsSearch
+    ? multiIdsTotalCount
+    : recordsFiltered;
+  const hasNextPage = isMultipleItemsSearch
+    ? (page + 1) * searchArgs.count < multiIdsTotalCount
+    : Boolean(pagination.next.proxyUrl);
   const hasPreviousPage = page > 0;
   const nextPage = new URLSearchParams(url.searchParams);
   const previousPage = new URLSearchParams(url.searchParams);
@@ -423,7 +459,7 @@ const loader = async (
       nextPage: hasNextPage ? `?${nextPage}` : undefined,
       previousPage: hasPreviousPage ? `?${previousPage}` : undefined,
       currentPage,
-      records: recordsFiltered,
+      records: totalRecords,
       recordPerPage: pagination.perPage,
       pageTypes: allPageTypes.map(parsePageType),
     },


### PR DESCRIPTION
## Summary
- Handle `?query=product:id1;id2;...;idN` and `?query=sku:id1;id2` multi-ID search formats
- Paginate IDs client-side by slicing per `page`/`count`, sending only that slice to VTEX in a single request — avoids 414 URI Too Long errors on large ID lists (e.g. 2000 products)
- Set facets path to empty for multi-ID queries since the API returns exactly the specified IDs
- Compute pagination (`hasNextPage`, `records`) client-side from the total ID count

## Test plan
- [ ] Test with `?query=product:id1;id2;...;id2000` and verify no 414 errors
- [ ] Verify pagination works correctly (next/previous page navigate through the ID list)
- [ ] Verify `records` in `pageInfo` reflects the total number of IDs
- [ ] Test with regular (non-multi-ID) searches to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination for multi-ID product searches (queries using multiple product IDs or SKUs) to display accurate result counts and proper page navigation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/apps/pull/1605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->