### PR TITLE
feat: add label field to SelectedFacet for CMS identification

### DIFF
--- a/vtex/utils/types.ts
+++ b/vtex/utils/types.ts
@@ -542,8 +542,8 @@ export interface SearchArgs {
   segment?: Partial<Segment>;
 }
 /**
-* @title {{{key}}} > {{{value}}}
-*/
+ * @title {{{key}}} > {{{value}}}
+ */
 export interface SelectedFacet {
   /**
    * @title Key

--- a/vtex/utils/types.ts
+++ b/vtex/utils/types.ts
@@ -544,8 +544,8 @@ export interface SearchArgs {
 
 export interface SelectedFacet {
   /**
-   * @title Use this to identify the facet
-   * @description This is an optional field that can be used to identify the facet in the CMS. Ex: "category-1 > Collection", "productClusterIds > 123".
+   * @title Facet label
+   * @description Optional label used to identify this facet in the CMS Admin. Examples: "category-1 > Collection", "productClusterIds > 123".
    */
   label?: string;
   /**

--- a/vtex/utils/types.ts
+++ b/vtex/utils/types.ts
@@ -541,13 +541,10 @@ export interface SearchArgs {
   locale?: string;
   segment?: Partial<Segment>;
 }
-
+/**
+* @title {{{key}}} > {{{value}}}
+*/
 export interface SelectedFacet {
-  /**
-   * @title Facet label
-   * @description Optional label used to identify this facet in the CMS Admin. Examples: "category-1 > Collection", "productClusterIds > 123".
-   */
-  label?: string;
   /**
    * @title Key
    * @description The key of the facet (e.g. "brand", "category-1", "productClusterIds")

--- a/vtex/utils/types.ts
+++ b/vtex/utils/types.ts
@@ -544,6 +544,11 @@ export interface SearchArgs {
 
 export interface SelectedFacet {
   /**
+   * @title Use this to identify the facet
+   * @description This is an optional field that can be used to identify the facet in the CMS. Ex: "category-1 > Collection", "productClusterIds > 123".
+   */
+  label?: string;
+  /**
    * @title Key
    * @description The key of the facet (e.g. "brand", "category-1", "productClusterIds")
    */


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this contribution about?

This PR adds an optional `label` field to the `SelectedFacet` interface to improve the configuration experience in the Deco CMS Admin.

Currently, `SelectedFacet` entries only expose `key` and `value`, which can make it difficult for editors to identify what each facet represents in a list.

The new `label` field provides a human-readable description, such as `category-1 > Collection` or `productClusterIds > 123`, that appears in the Admin UI without affecting the search query behavior.

## Impact

- No search query behavior changes
- No runtime logic changes
- Existing configurations remain compatible because the field is optional

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a human-readable label for `SelectedFacet` in Deco CMS Admin via a `@title` template (`{{{key}}} > {{{value}}}`), e.g., `category-1 > Collection` or `productClusterIds > 123`. No search or runtime changes; fully backward compatible.

<sup>Written for commit 14efbd8a8f97ed9739f48a3aa63f2510373b2f6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an inline documentation note describing how facet titles are formatted using a templated `{{key}} > {{value}}` pattern.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->