### PR TITLE
hotfix(shopify): remove buyerIdentity input from CreateCart mutation

### DIFF
--- a/shopify/utils/storefront/queries.ts
+++ b/shopify/utils/storefront/queries.ts
@@ -274,11 +274,7 @@ export const CreateCart = {
     $countryCode: CountryCode,
     $languageCode: LanguageCode
   ) @inContext(country: $countryCode, language: $languageCode) {
-    payload: cartCreate(
-      input: {
-        buyerIdentity: { countryCode: $countryCode }
-      }
-    ) { 
+    payload: cartCreate {
       cart { id }
       userErrors { field message }
     }


### PR DESCRIPTION
## Summary

- Removes `input: { buyerIdentity: { countryCode: $countryCode } }` from the `cartCreate` call in the `CreateCart` mutation
- The `@inContext` directive still receives `countryCode` and `languageCode` for locale-aware storefront responses
- No changes to cart loader logic, error handling, or retry mechanisms

## Test plan

- [x] Create a cart on a Shopify storefront — cart should be created successfully without the `buyerIdentity` input
- [x] Verify locale-aware responses still work via `@inContext` directive
- [x] Verify error handling and NOT_FOUND retry logic remain intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `buyerIdentity` from the Shopify `cartCreate` call in the `CreateCart` mutation. We now rely on `@inContext` for `countryCode`/`languageCode`, with no changes to loaders or error handling.

<sup>Written for commit 992a91289674f43455f5ffba87c272d110a36115. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified cart creation logic by streamlining the internal process for initializing new shopping carts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->