### PR TITLE
fix(vtex): filter undefined products from sortProducts

### DIFF
--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -1135,7 +1135,7 @@ export const sortProducts = (
     productMap[product[prop] || product["sku"]] = product;
   });
 
-  return orderOfIdsOrSkus.map((id) => productMap[id]);
+  return orderOfIdsOrSkus.map((id) => productMap[id]).filter(Boolean);
 };
 
 export const parsePageType = (p: PageTypeVTEX): PageType => {


### PR DESCRIPTION
## Summary
- When requesting products by SKU IDs via `intelligentSearch/productList.ts`, if a SKU doesn't exist or is inactive, the VTEX API omits it from the response
- The `sortProducts` function maps over the original ID list, which resulted in `undefined` entries for missing SKUs
- Added `.filter(Boolean)` to remove `undefined` entries from the returned array

## Test plan
- [ ] Configure a product shelf with SKU IDs where at least one is inactive/nonexistent
- [ ] Verify the loader returns only valid products without `undefined` entries
- [ ] Verify the remaining products maintain the original order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes VTEX product sorting when requesting by SKU IDs by removing undefined entries for missing/inactive SKUs, preserving the order of valid products. Implemented by adding .filter(Boolean) to `sortProducts` in `vtex/utils/transform.ts`.

<sup>Written for commit 10efdbd2cda91a3c330393355b3f7a19dcffa3eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed product sorting to exclude missing or unavailable products from results. Undefined entries that appeared when requested products weren't found are now properly filtered out, providing cleaner and more reliable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->