### PR TITLE
feat(website): native ?renderJson support in the Fresh handler

### DIFF
--- a/website/handlers/fresh.ts
+++ b/website/handlers/fresh.ts
@@ -180,7 +180,11 @@ export default function Fresh(
       // configured in the website app props) + the section's own
       // `renderJson === false` export.
       const getSectionModule = renderJson ? await sectionModuleLookup() : null;
-      const sectionsToIgnore = appContext.renderJson?.sectionsToIgnore ?? [];
+      // Trim and drop blank suffixes — an empty entry would make `endsWith("")`
+      // match every section and drop the whole page.
+      const sectionsToIgnore = (appContext.renderJson?.sectionsToIgnore ?? [])
+        .map((suffix) => suffix.trim())
+        .filter((suffix) => suffix.length > 0);
       const isDroppedSection = (resolveType: string) =>
         !!getSectionModule &&
         (sectionsToIgnore.some((suffix) => resolveType.endsWith(suffix)) ||

--- a/website/handlers/fresh.ts
+++ b/website/handlers/fresh.ts
@@ -118,10 +118,8 @@ export default function Fresh(
     const startedAt = Date.now();
     const asJson = url.searchParams.get("asJson");
     // Structured JSON rendering (sections serialized honoring the section's
-    // `renderJson` export). `appJson` is the legacy param name — remove once
-    // consumers switch to `renderJson`.
-    const renderJson = url.searchParams.has("renderJson") ||
-      url.searchParams.has("appJson");
+    // `renderJson` export).
+    const renderJson = url.searchParams.has("renderJson");
     // One-shot JSON responses (asJson/renderJson) never use async render.
     const isJsonOneShot = asJson !== null || renderJson;
     const delayFromProps = appContext.firstByteThresholdMS ? 1 : 0;

--- a/website/handlers/fresh.ts
+++ b/website/handlers/fresh.ts
@@ -180,11 +180,15 @@ export default function Fresh(
       // configured in the website app props) + the section's own
       // `renderJson === false` export.
       const getSectionModule = renderJson ? await sectionModuleLookup() : null;
-      // Trim and drop blank suffixes — an empty entry would make `endsWith("")`
-      // match every section and drop the whole page.
-      const sectionsToIgnore = (appContext.renderJson?.sectionsToIgnore ?? [])
-        .map((suffix) => suffix.trim())
-        .filter((suffix) => suffix.length > 0);
+      // sectionsToIgnore is admin config (external JSON), so it is not
+      // type-guaranteed at runtime. Keep only non-empty string suffixes: a
+      // blank entry would make `endsWith("")` match every section (dropping the
+      // whole page), and a non-string would throw on `.trim()` (500ing the request).
+      const sectionsToIgnore =
+        ((appContext.renderJson?.sectionsToIgnore ?? []) as unknown[])
+          .filter((suffix): suffix is string => typeof suffix === "string")
+          .map((suffix) => suffix.trim())
+          .filter((suffix) => suffix.length > 0);
       const isDroppedSection = (resolveType: string) =>
         !!getSectionModule &&
         (sectionsToIgnore.some((suffix) => resolveType.endsWith(suffix)) ||

--- a/website/handlers/fresh.ts
+++ b/website/handlers/fresh.ts
@@ -8,9 +8,14 @@ import {
   allowCorsFor,
   asResolved,
   type BaseContext,
+  computeRenderCb,
   type DecoState,
   isDeferred,
   RequestContext,
+  type ResolvedSection,
+  sectionModuleLookup,
+  type SerializeContext,
+  serializeResolvedSection,
 } from "@deco/deco";
 import type { Exception } from "npm:@opentelemetry/api@1.9.0";
 
@@ -100,6 +105,7 @@ export default function Fresh(
     | "firstByteThresholdMS"
     | "isBot"
     | "flavor"
+    | "renderJson"
   >,
 ) {
   return async (req: Request, ctx: ConnInfo) => {
@@ -111,6 +117,13 @@ export default function Fresh(
     const url = new URL(req.url);
     const startedAt = Date.now();
     const asJson = url.searchParams.get("asJson");
+    // Structured JSON rendering (sections serialized honoring the section's
+    // `renderJson` export). `appJson` is the legacy param name — remove once
+    // consumers switch to `renderJson`.
+    const renderJson = url.searchParams.has("renderJson") ||
+      url.searchParams.has("appJson");
+    // One-shot JSON responses (asJson/renderJson) never use async render.
+    const isJsonOneShot = asJson !== null || renderJson;
     const delayFromProps = appContext.firstByteThresholdMS ? 1 : 0;
     const delay = Number(url.searchParams.get(__DECO_FBT) ?? delayFromProps);
     /** Controller to abort third party fetch (loaders) */
@@ -128,7 +141,7 @@ export default function Fresh(
      * 2. Async Rendering Feature is activated
      * 3. Is not a bot (bot requires the whole page html for boosting SEO)
      */
-    const firstByteThreshold = !asJson && delay && !appContext.isBot
+    const firstByteThreshold = !isJsonOneShot && delay && !appContext.isBot
       ? (delay === 1
         ? (() => {
           console.warn(
@@ -152,7 +165,7 @@ export default function Fresh(
       : undefined;
 
     // Propagate client aborts to loaders only when async render is enabled
-    if (!asJson && delay && !appContext.isBot) {
+    if (!isJsonOneShot && delay && !appContext.isBot) {
       abortCtrl = abortHandler(ctrl, req.signal, {
         url: `${url.pathname}${url.search}`,
         startedAt,
@@ -165,6 +178,16 @@ export default function Fresh(
       registerFinilizer(req, abortCtrl);
     }
     try {
+      // Section drop for renderJson = consumer override (app-owned sections
+      // configured in the website app props) + the section's own
+      // `renderJson === false` export.
+      const getSectionModule = renderJson ? await sectionModuleLookup() : null;
+      const sectionsToIgnore = appContext.renderJson?.sectionsToIgnore ?? [];
+      const isDroppedSection = (resolveType: string) =>
+        !!getSectionModule &&
+        (sectionsToIgnore.some((suffix) => resolveType.endsWith(suffix)) ||
+          getSectionModule(resolveType)?.renderJson === false);
+
       const getPage = RequestContext.bind(
         { signal: ctrl.signal },
         async () =>
@@ -177,12 +200,39 @@ export default function Fresh(
             ? await freshConfig.page({ context: ctx }, {
               propagateOptions: true,
               hooks: {
-                onPropsResolveStart: (resolve, _props, resolver) => {
+                // Dropped sections short-circuit child resolution (their
+                // prop-loaders never run) — see deco engine/core/resolver.ts.
+                onPropsResolveStart: (
+                  resolve,
+                  _props,
+                  resolver,
+                  resolveType,
+                ) => {
+                  if (renderJson && isDroppedSection(resolveType)) {
+                    return Promise.resolve([]);
+                  }
                   let next = resolve;
                   if (resolver?.type === "matchers") { // matchers should not have a timeout.
                     next = RequestContext.bind({ signal: req.signal }, resolve);
                   }
                   return next();
+                },
+                // Skip the dropped section's own inline `mod.loader` by
+                // stubbing before the section resolver runs. Cast via
+                // `unknown` because the hook is generic over T.
+                onResolveStart: <T>(
+                  proceed: () => Promise<T>,
+                  _props: T,
+                  _resolver: unknown,
+                  resolveType: string,
+                ): Promise<T> => {
+                  if (renderJson && isDroppedSection(resolveType)) {
+                    const stub: ResolvedSection = {
+                      metadata: { component: resolveType },
+                    };
+                    return Promise.resolve(stub as unknown as T);
+                  }
+                  return proceed();
                 },
               },
             })
@@ -196,7 +246,7 @@ export default function Fresh(
             if (pathTemplate) {
               span?.setAttribute?.("deco.path_template", pathTemplate);
             }
-            if (delay && !asJson && !appContext.isBot) {
+            if (delay && !isJsonOneShot && !appContext.isBot) {
               span?.setAttribute?.(
                 "deco.async_render.first_byte_threshold_ms",
                 delay,
@@ -232,6 +282,41 @@ export default function Fresh(
           }
         },
       );
+      // renderJson takes precedence over asJson when both params are sent.
+      if (renderJson) {
+        didFinish = true;
+        const pageProps = (page as unknown as Record<string, unknown>)?.props as
+          | Record<string, unknown>
+          | undefined;
+        // appContext runtime spreads state.global (= the full request state),
+        // so vary/revision/release/deco are reachable here even though the
+        // type declares a narrower surface.
+        // deno-lint-ignore no-explicit-any
+        const appCtx = appContext as any;
+        const cb = computeRenderCb({
+          revision: appCtx?.revision ?? (await appCtx?.release?.revision?.()),
+          vary: appCtx?.vary?.build?.(),
+          href: req.url,
+          deploymentId: appCtx?.deco?.ctx?.deploymentId,
+        });
+        const serializeCtx: SerializeContext = {
+          href: req.url,
+          pathTemplate: pathTemplate ?? url.pathname,
+          cb,
+          getSectionModule: getSectionModule ?? undefined,
+        };
+        const sections = ((pageProps?.sections as Array<ResolvedSection>) ?? [])
+          .map((section) => serializeResolvedSection(section, serializeCtx))
+          // Drops renderJson === false sections (serialized to null) and the
+          // stubs left by onResolveStart for the ignored list.
+          .filter((s): s is NonNullable<typeof s> =>
+            s !== null && !isDroppedSection(s.component)
+          );
+        return Response.json(
+          { name: pageProps?.name, path: pageProps?.path, sections },
+          { headers: allowCorsFor(req) },
+        );
+      }
       if (asJson !== null) {
         didFinish = true;
         return Response.json(page, { headers: allowCorsFor(req) });
@@ -264,7 +349,7 @@ export default function Fresh(
                   pagePath: ctx.state.pathTemplate,
                 },
               });
-              if (!asJson && delay && !appContext.isBot) {
+              if (!isJsonOneShot && delay && !appContext.isBot) {
                 console.info(
                   `[fresh][async-render-response] returned initial HTML with async render` +
                     ` url=${url.pathname}${url.search}` +

--- a/website/mod.ts
+++ b/website/mod.ts
@@ -117,6 +117,17 @@ export interface Props {
    */
   firstByteThresholdMS?: boolean;
   /**
+   * @title renderJson
+   * @description Options for the structured JSON rendering of pages (?renderJson)
+   */
+  renderJson?: {
+    /**
+     * @title Ignored Sections
+     * @description App-owned sections excluded from the renderJson response, matched by resolveType suffix (e.g. "SeoV2.tsx"). Site-owned sections should prefer `export const renderJson = false` in their own file.
+     */
+    sectionsToIgnore?: string[];
+  };
+  /**
    * @title Avoid redirecting to editor
    * @description Disable going to editor when "." or "Ctrl + Shift + E" is pressed
    */


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->
## What is this Contribution About?

Native `?renderJson` support in the website Fresh handler — the consumer side of the section-controlled JSON rendering introduced in **deco-cx/deco#1209**.

- `website/handlers/fresh.ts`: a native `?renderJson` branch (sibling of `?asJson`, with `renderJson` taking precedence, guarded by `!isJsonOneShot`). Serves the JSON projection produced by each section's `renderJson` export via the runtime's `serializeResolvedSection` / `computeRenderCb`.
- `website/mod.ts`: a `renderJson.sectionsToIgnore` admin prop so a site can override which sections are dropped from the JSON payload, instead of a hardcoded denylist.
- Drops the legacy `?appJson` alias — `?renderJson` is its replacement. The standalone `?asJson` mode is left untouched.

## Issue Link

Companion to the runtime feature — depends on it:

- deco-cx/deco#1209 — adds the `renderJson` export, `serializeResolvedSection`, `computeRenderCb`, `ResolvedSection`, `sectionModuleLookup`, `SerializeContext`.

## Status / dependency

> [!IMPORTANT]
> **Draft — blocked on deco-cx/deco#1209.** This PR imports `computeRenderCb`, `serializeResolvedSection`, `ResolvedSection`, `sectionModuleLookup` and `SerializeContext` from `@deco/deco`. Until #1209 is merged and published to JSR, `deno task check` fails with 5× `TS2305: has no exported member ...` for those symbols. `deno fmt --check` and `deno lint` are clean.

## Test plan

- [x] `deno fmt --check` clean
- [ ] `deno check` — blocked on #1209 (5× TS2305 for the not-yet-published runtime exports)
- [x] Dogfooded on a real deco storefront (oficina-reserva, pinned to the fork build): `?asJson` and HTML byte-identical to baseline, `?renderJson` matches the runtime serialization, lazy fetch applies the per-section projection.

## Loom Video / Demonstration

Validated on the oficina-reserva storefront preview (pinned to the fork build). Loom/demo available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native `?renderJson` to the website Fresh handler to return a structured JSON view of pages, honoring each section’s `renderJson` export. Adds `renderJson.sectionsToIgnore` in app props and removes the `?appJson` alias; `?asJson` stays as-is.

- **New Features**
  - `website/handlers/fresh.ts`: new `?renderJson` path serializes sections via `serializeResolvedSection` and `computeRenderCb` from `@deco/deco`, returning `{ name, path, sections }`.
  - Sections opted out of JSON are skipped before loaders run; site-owned sections use `export const renderJson = false`; app-owned sections can be ignored via `renderJson.sectionsToIgnore` (matched by resolveType suffix).
  - `?renderJson` takes precedence over `?asJson`; JSON responses bypass async render (first-byte threshold).

- **Bug Fixes**
  - Hardened `renderJson.sectionsToIgnore` handling: filter to strings, trim, and drop empties to prevent TypeErrors and accidental full-page drops.

<sup>Written for commit 75cdee29b33a5668501d54bd6f9f5f02c3ac99dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new JSON rendering mode with configurable section filtering capabilities.
  * Users can now exclude specific sections from JSON responses via configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->