### PR TITLE
fix: add type json in headers

### DIFF
--- a/verified-reviews/utils/client.ts
+++ b/verified-reviews/utils/client.ts
@@ -8,7 +8,9 @@ import {
   toReview,
 } from "./transform.ts";
 import { context } from "@deco/deco";
+
 export type ClientVerifiedReviews = ReturnType<typeof createClient>;
+
 export interface PaginationOptions {
   count?: number;
   offset?: number;
@@ -43,25 +45,28 @@ const MessageError = {
   fullReview:
     "🔴⭐ Error on call Full Review of Verified Review - probably unidentified product",
 };
+
 const baseUrl = "https://awsapis3.netreviews.eu/product";
+const jsonHeaders = { "content-type": "application/json" };
+
 export const createClient = (params: ConfigVerifiedReviews | undefined) => {
   if (!params) {
     return;
   }
   const { idWebsite } = params;
+
   /** @description https://documenter.getpostman.com/view/2336519/SVzw6MK5#338f8f1b-4379-40a2-8893-080fe5234679 */
-  const rating = async ({ productId }: {
-    productId: string;
-  }) => {
+  const rating = async ({ productId }: { productId: string }) => {
     const payload = {
       query: "average",
       products: [productId],
-      idWebsite: idWebsite,
+      idWebsite,
       plateforme: "br",
     };
     try {
       const data = await fetchAPI<Ratings>(`${baseUrl}`, {
         method: "POST",
+        headers: jsonHeaders,
         body: JSON.stringify(payload),
       });
       return Object.keys(data).length ? data : undefined;
@@ -74,19 +79,19 @@ export const createClient = (params: ConfigVerifiedReviews | undefined) => {
       return undefined;
     }
   };
+
   /** @description https://documenter.getpostman.com/view/2336519/SVzw6MK5#6d8ab05a-28b6-48b3-9e8f-6bbbc046619a */
-  const ratings = async ({ productsIds }: {
-    productsIds: string[];
-  }) => {
+  const ratings = async ({ productsIds }: { productsIds: string[] }) => {
     const payload = {
       query: "average",
       products: productsIds,
-      idWebsite: idWebsite,
+      idWebsite,
       plateforme: "br",
     };
     try {
       const data = await fetchAPI<Ratings>(`${baseUrl}`, {
         method: "POST",
+        headers: jsonHeaders,
         body: JSON.stringify(payload),
       });
       return Object.keys(data).length ? data : undefined;
@@ -100,19 +105,16 @@ export const createClient = (params: ConfigVerifiedReviews | undefined) => {
       return undefined;
     }
   };
+
   /** @description https://documenter.getpostman.com/view/2336519/SVzw6MK5#daf51360-c79e-451a-b627-33bdd0ef66b8 */
-  const reviews = (
+  const reviews = async (
     {
       productId,
       count = 5,
       offset = 0,
       order: _order = "date_desc",
       customizeOrder = false,
-    }:
-      & PaginationOptions
-      & {
-        productId: string | string[];
-      },
+    }: PaginationOptions & { productId: string | string[] },
   ) => {
     const order = customizeOrder
       ? _order
@@ -121,15 +123,16 @@ export const createClient = (params: ConfigVerifiedReviews | undefined) => {
     const payload = {
       query: "reviews",
       product: Array.isArray(productId) ? productId : [productId],
-      idWebsite: idWebsite,
+      idWebsite,
       plateforme: "br",
-      offset: offset,
+      offset,
       limit: count,
-      order: order,
+      order,
     };
 
     return fetchAPI<Reviews[]>(`${baseUrl}`, {
       method: "POST",
+      headers: jsonHeaders,
       body: JSON.stringify(payload),
     });
   };
@@ -145,16 +148,10 @@ export const createClient = (params: ConfigVerifiedReviews | undefined) => {
     try {
       const isMultiProduct = Array.isArray(productId);
 
-      const response = await Promise.all([
-        ratings({
-          productsIds: isMultiProduct ? productId : [productId],
-        }),
+      const [responseRating, responseReview] = await Promise.all([
+        ratings({ productsIds: isMultiProduct ? productId : [productId] }),
         reviews({ productId, count, offset, order }),
-      ]);
-      const [responseRating, responseReview] = response.flat() as [
-        Ratings,
-        Reviews | null,
-      ];
+      ]) as [Ratings, Reviews | null];
 
       const aggregateRating = isMultiProduct
         ? getWeightedRatingProduct(responseRating)
@@ -162,34 +159,27 @@ export const createClient = (params: ConfigVerifiedReviews | undefined) => {
 
       return {
         aggregateRating: aggregateRating
-          ? {
-            ...aggregateRating,
-            stats: responseReview?.stats,
-          }
+          ? { ...aggregateRating, stats: responseReview?.stats }
           : undefined,
         review: responseReview ? responseReview.reviews?.map(toReview) : [],
       };
     } catch (error) {
       if (context.isDeploy) {
-        console.error(MessageError.ratings, error);
+        console.error(MessageError.fullReview, error);
       } else {
         throw new Error(`${MessageError.fullReview} - ${error}`);
       }
-      return {
-        aggregateRating: undefined,
-        review: [],
-      };
+      return { aggregateRating: undefined, review: [] };
     }
   };
+
   const storeReview = async (): Promise<Reviews["reviews"] | null> => {
     try {
       const response = await fetchAPI<Reviews["reviews"]>(
         `https://cl.avis-verifies.com/br/cache/8/6/a/${idWebsite}/AWS/WEBSITE_API/reviews.json`,
-        {
-          method: "GET",
-        },
+        { method: "GET" },
       );
-      return (response ? response : []);
+      return response ?? [];
     } catch (error) {
       if (context.isDeploy) {
         console.error(MessageError.ratings, error);
@@ -199,13 +189,9 @@ export const createClient = (params: ConfigVerifiedReviews | undefined) => {
       return null;
     }
   };
-  return {
-    rating,
-    ratings,
-    reviews,
-    fullReview,
-    storeReview,
-  };
+
+  return { rating, ratings, reviews, fullReview, storeReview };
 };
+
 export const getProductId = (product: Product) =>
   product.isVariantOf!.productGroupID;

--- a/verified-reviews/utils/client.ts
+++ b/verified-reviews/utils/client.ts
@@ -148,10 +148,12 @@ export const createClient = (params: ConfigVerifiedReviews | undefined) => {
     try {
       const isMultiProduct = Array.isArray(productId);
 
-      const [responseRating, responseReview] = await Promise.all([
+      const [responseRating, responseReviews] = await Promise.all([
         ratings({ productsIds: isMultiProduct ? productId : [productId] }),
         reviews({ productId, count, offset, order }),
-      ]) as [Ratings, Reviews | null];
+      ]) as [Ratings | undefined, Reviews[]];
+
+      const responseReview = responseReviews?.[0];
 
       const aggregateRating = isMultiProduct
         ? getWeightedRatingProduct(responseRating)


### PR DESCRIPTION
Adicionei "content-type": "application/json" nas três chamadas (rating, ratings, reviews).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add JSON Content-Type to Verified Reviews POST requests and fix how `fullReview` formats and merges data. Prevents API failures and returns correctly structured reviews with stats.

- **Bug Fixes**
  - Set `content-type: application/json` for `rating`, `ratings`, and `reviews` via shared `jsonHeaders`.
  - Fix `fullReview` to merge ratings with the first reviews payload and include `stats`; map items with `toReview`.
  - Use the correct `fullReview` error message and return empty arrays/undefined consistently.

<sup>Written for commit fc385afc4e0cb91594ccfec3b5e285bbd0303637. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the internal implementation of the verified reviews client while keeping the same public response shape and pagination behavior.
* **Bug Fixes**
  * Enhanced how full reviews and stored reviews handle edge cases (such as empty or missing responses), ensuring consistent aggregate rating and review lists even when requests fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->