### PR TITLE
style(vnda): fix deno fmt CI failure in productListingPage loader

### DIFF
--- a/vnda/loaders/productListingPage.ts
+++ b/vnda/loaders/productListingPage.ts
@@ -100,7 +100,9 @@ interface TypeTag {
   isProperty: boolean;
 }
 
-const parseTypeTagsFromUrl = (url: URL): { typeTags: TypeTag[]; cleanUrl: URL } => {
+const parseTypeTagsFromUrl = (
+  url: URL,
+): { typeTags: TypeTag[]; cleanUrl: URL } => {
   const TYPE_TAG_PATTERN = /^type_tags\[(.+)\]\[\]$/;
 
   const typeTags = [...url.searchParams.entries()]
@@ -150,7 +152,9 @@ const searchLoader = async (
   const priceFilterRegex = /de-(\d+)-a-(\d+)/;
   const filterMatch = url.href.match(priceFilterRegex) ?? [];
 
-  const categoryTagName = (props.term || url.pathname.slice(1) || "").split("/");
+  const categoryTagName = (props.term || url.pathname.slice(1) || "").split(
+    "/",
+  );
 
   const properties1 = url.searchParams.getAll("type_tags[property1][]");
   const properties2 = url.searchParams.getAll("type_tags[property2][]");
@@ -158,7 +162,9 @@ const searchLoader = async (
 
   const uniquePathNames = [
     ...new Set(
-      categoryTagName.filter((item): item is string => typeof item === "string"),
+      categoryTagName.filter((item): item is string =>
+        typeof item === "string"
+      ),
     ),
   ];
 


### PR DESCRIPTION
## What

Applies `deno fmt` to `vnda/loaders/productListingPage.ts`, fixing the `deno fmt --check` CI failure introduced by #1563.

## Why

The format check job was failing with `Found 1 not formatted file`. The reformatting is purely cosmetic (param wrapping, `.split("/")` line break, arrow body, trailing newline) — no logic changes.

## Verification

```
deno fmt --check vnda/loaders/productListingPage.ts
# Checked 1 file
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies `deno fmt` to `vnda/loaders/productListingPage.ts` to fix the `deno fmt --check` CI failure introduced by #1563. Formatting only; no logic changes.

<sup>Written for commit d1d48157500399c3d5a1e9bd9d356d320be2921e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting and line-wrapping in internal modules for better readability.

*Note: This release contains no user-visible changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->