### PR TITLE
fix(blog): guard getRecordsByPath against null resolvables

### DIFF
--- a/blog/core/records.ts
+++ b/blog/core/records.ts
@@ -14,15 +14,17 @@ export async function getRecordsByPath<T>(
     __resolveType: "resolvables",
   }) as unknown as Record<string, Resolvable<T>>;
   const current = Object.entries(resolvables).flatMap(([key, value]) => {
-    return key.startsWith(path) ? value : [];
+    return key.startsWith(path) && value != null ? value : [];
   });
-  return (current as Record<string, T>[]).map((item) => {
-    const id = (item.name as string).split(path)[1]?.replace("/", "");
-    return {
-      ...item[accessor],
-      id,
-    };
-  });
+  return (current as Record<string, T>[])
+    .filter((item) => item != null && typeof item.name === "string")
+    .map((item) => {
+      const id = (item.name as string).split(path)[1]?.replace("/", "");
+      return {
+        ...item[accessor],
+        id,
+      };
+    });
 }
 
 export async function getRatingsBySlug(


### PR DESCRIPTION
## Summary

`blog/core/records.ts#getRecordsByPath` maps over resolvables matching a path prefix and reads `item.name` on each entry. When a resolvable points to a record whose backing JSON has been deleted (orphan entries in the index), the value resolves to `null`, and the loader crashes:

```
TypeError: Cannot read properties of null (reading 'name')
    at blog/core/records.ts:20
    at Array.map
    at getRecordsByPath
    at BlogPostList (blog/loaders/BlogpostListing.ts:69)
```

The fix filters out null values and items without a string `name` before mapping. The loader keeps working in the presence of stale index entries, returning only the records that are actually present.

## Test plan
- [ ] `BlogpostListing` / `BlogPostList` loaders return successfully when the resolvables index contains an entry pointing to a missing/null record
- [ ] Existing posts continue to load normally
- [ ] No type errors (`deno check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent loader crashes when the blog index has orphan resolvables by guarding `getRecordsByPath` against null records. Listings now skip missing entries and keep rendering.

- **Bug Fixes**
  - Filter out `null` resolvables and items without a string `name` before mapping.
  - Preserve ID parsing and mapping for valid records; existing posts load as before.

<sup>Written for commit 0e081c4843b33de5ac258648b9bd15b73714e793. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data retrieval to properly validate and filter entries, ensuring more reliable handling of record results and preventing errors from invalid data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->