### PR TITLE
fix(blog): filter invalid categories before sort in GetCategories

### DIFF
--- a/blog/loaders/GetCategories.ts
+++ b/blog/loaders/GetCategories.ts
@@ -56,11 +56,20 @@ export default async function GetCategories(
     return null;
   }
 
+  const validCategories = categories.filter((c) =>
+    typeof c?.name === "string" && c.name.length > 0 &&
+    typeof c?.slug === "string" && c.slug.length > 0
+  );
+
   if (slug) {
-    return categories.filter((c) => c.slug === slug);
+    return validCategories.filter((c) => c.slug === slug);
   }
 
-  const sortedCategories = categories.sort((a, b) => {
+  if (!validCategories.length) {
+    return null;
+  }
+
+  const sortedCategories = validCategories.sort((a, b) => {
     const comparison = a.name.localeCompare(b.name);
     return sortBy.endsWith("_desc") ? comparison : -comparison;
   });


### PR DESCRIPTION
## Summary
- Categories stored with missing `name` or `slug` (legacy/empty records like `{ "category": {} }`) currently reach the `localeCompare` sort and throw `Cannot read properties of undefined (reading 'localeCompare')`, breaking every page that loads the categories listing.
- Filter out entries without a usable `name`/`slug` before sorting; return `null` if nothing valid remains.
- Slug lookup also filters first to avoid leaking invalid entries.

## Test plan
- [ ] Repro with a category block containing `{ "category": {} }` — listing no longer throws.
- [ ] Sorted ascending/descending still works for valid categories.
- [ ] Slug filter still returns the matching category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents category list crashes by filtering out invalid records (missing name/slug) before sorting in `GetCategories`, ensuring pages no longer throw during `localeCompare`.

- **Bug Fixes**
  - Filter categories to only those with a non-empty `name` and `slug` before sorting.
  - Apply the same filter for slug lookups to avoid leaking invalid entries.
  - Return `null` when no valid categories remain.

<sup>Written for commit cdc09f2939bd0e7a2225965df7b0ddf99ad1b337. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

