### PR TITLE
feat(blog): add expandedCategories to BlogpostListing

### DIFF
--- a/blog/loaders/BlogpostListing.ts
+++ b/blog/loaders/BlogpostListing.ts
@@ -44,6 +44,12 @@ export interface Props {
    * @description Overrides the query term at url
    */
   query?: string;
+  /**
+   * @title Expanded categories
+   * @description When enabled, returns all categories and resolves the active category only from the categories collection.
+   * @default true
+   */
+  expandedCategories?: boolean;
 }
 
 /**
@@ -56,7 +62,7 @@ export interface Props {
  * @returns A promise that resolves to an array of blog posts.
  */
 export default async function BlogPostList(
-  { page, count, slug, sortBy, query }: Props,
+  { page, count, slug, sortBy, query, expandedCategories = true }: Props,
   req: Request,
   ctx: AppContext,
 ): Promise<BlogPostListingPage | null> {
@@ -95,14 +101,25 @@ export default async function BlogPostList(
     }
 
     let category: Category | null = null;
-    if (slug) {
+    let categories: Category[] | null = null;
+
+    if (expandedCategories) {
       try {
-        const categories = await getRecordsByPath<Category>(
+        categories = await loadCategories(ctx);
+        if (slug) {
+          category = categories.find((c) => c.slug === slug) ?? null;
+        }
+      } catch (e) {
+        logger.error(e);
+      }
+    } else if (slug) {
+      try {
+        const categoryRecords = await getRecordsByPath<Category>(
           ctx,
           CATEGORIES_PATH,
           CATEGORY_ACCESSOR,
         );
-        category = categories?.find((c) => c.slug === slug) ?? null;
+        category = categoryRecords?.find((c) => c.slug === slug) ?? null;
       } catch (e) {
         logger.error(e);
       }
@@ -113,6 +130,7 @@ export default async function BlogPostList(
     return {
       posts: slicedPosts,
       category,
+      categories,
       pageInfo: toPageInfo(handledPosts, postsPerPage, pageNumber, params),
       seo: {
         title: category?.name ?? "",
@@ -154,4 +172,19 @@ const toPageInfo = (
     records: totalPosts,
     recordPerPage: postsPerPage,
   };
+};
+
+const loadCategories = async (ctx: AppContext): Promise<Category[]> => {
+  const categories = await getRecordsByPath<Category>(
+    ctx,
+    CATEGORIES_PATH,
+    CATEGORY_ACCESSOR,
+  );
+
+  return (categories ?? [])
+    .filter((c) =>
+      typeof c?.name === "string" && c.name.length > 0 &&
+      typeof c?.slug === "string" && c.slug.length > 0
+    )
+    .sort((a, b) => a.name.localeCompare(b.name));
 };

--- a/blog/types.ts
+++ b/blog/types.ts
@@ -122,6 +122,8 @@ export interface BlogPostListingPage {
   posts: BlogPost[];
   /** @title Active category */
   category?: Category | null;
+  /** @title Categories */
+  categories?: Category[] | null;
   pageInfo: PageInfo;
   seo: Seo;
 }


### PR DESCRIPTION
## Summary
- Adds `expandedCategories` prop (default `true`) to `BlogpostListing`
- When enabled, returns all categories in `listing.categories` and resolves the active category only from the collection (no post-embedded fallback)
- When disabled, keeps the previous slug fallback via `slicedPosts[0].categories`

## Test plan
- [ ] Blog listing page shows category sidebar from `listing.categories` without a separate `GetCategories` loader
- [ ] Category page resolves `listing.category` from the collection
- [ ] `expandedCategories: false` still falls back to post-embedded category data


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `expandedCategories` to `BlogpostListing` (default true) to return all categories and resolve the active category from the categories collection only. This lets the listing page build the sidebar from `listing.categories` and avoids reliance on post-embedded data.

- **New Features**
  - Loader now returns `categories` (filtered and name-sorted) and sets `category` by matching the `slug` from the collection.
  - New `expandedCategories` prop; set to false to keep the old fallback via `slicedPosts[0].categories`.
  - Updated `BlogPostListingPage` to include optional `categories`.

- **Migration**
  - Render the sidebar from `listing.categories` and remove any separate `GetCategories` loader.
  - If the categories collection isn’t ready, set `expandedCategories: false` to keep previous behavior.

<sup>Written for commit 5de8e4febeecfbf1ea626f95d61556845412395c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

