### PR TITLE
fix(blog): drop category field from BlogpostListing

### DIFF
--- a/blog/loaders/BlogpostListing.ts
+++ b/blog/loaders/BlogpostListing.ts
@@ -46,7 +46,7 @@ export interface Props {
   query?: string;
   /**
    * @title Expanded categories
-   * @description When enabled, returns all categories and resolves the active category only from the categories collection.
+   * @description When enabled, returns all categories from the collection.
    * @default true
    */
   expandedCategories?: boolean;
@@ -70,8 +70,7 @@ export default async function BlogPostList(
   const params = url.searchParams;
   const postsPerPage = Number(count ?? params.get("count") ?? 12);
   const pageNumber = Number(page ?? params.get("page") ?? 1);
-  const pageSort = sortBy ?? params.get("sortBy") as SortBy ??
-    "date_desc";
+  const pageSort = sortBy ?? (params.get("sortBy") as SortBy) ?? "date_desc";
   const term = query ?? params.get("q") ?? undefined;
 
   const posts = await getRecordsByPath<BlogPost>(
@@ -100,41 +99,29 @@ export default async function BlogPostList(
       return null;
     }
 
-    let category: Category | null = null;
     let categories: Category[] | null = null;
 
     if (expandedCategories) {
       try {
         categories = await loadCategories(ctx);
-        if (slug) {
-          category = categories.find((c) => c.slug === slug) ?? null;
-        }
       } catch (e) {
         logger.error(e);
       }
-    } else if (slug) {
-      try {
-        const categoryRecords = await getRecordsByPath<Category>(
-          ctx,
-          CATEGORIES_PATH,
-          CATEGORY_ACCESSOR,
-        );
-        category = categoryRecords?.find((c) => c.slug === slug) ?? null;
-      } catch (e) {
-        logger.error(e);
-      }
-      category ??= slicedPosts[0].categories?.find((c) => c.slug === slug) ??
-        null;
     }
+
+    const activeCategory = slug
+      ? categories?.find((c) => c.slug === slug) ??
+        slicedPosts[0].categories?.find((c) => c.slug === slug) ??
+        null
+      : null;
 
     return {
       posts: slicedPosts,
-      category,
       categories,
       pageInfo: toPageInfo(handledPosts, postsPerPage, pageNumber, params),
       seo: {
-        title: category?.name ?? "",
-        description: category?.description,
+        title: activeCategory?.name ?? "",
+        description: activeCategory?.description,
         canonical: new URL(url.pathname, url.origin).href,
       },
     };
@@ -182,9 +169,12 @@ const loadCategories = async (ctx: AppContext): Promise<Category[]> => {
   );
 
   return (categories ?? [])
-    .filter((c) =>
-      typeof c?.name === "string" && c.name.length > 0 &&
-      typeof c?.slug === "string" && c.slug.length > 0
+    .filter(
+      (c) =>
+        typeof c?.name === "string" &&
+        c.name.length > 0 &&
+        typeof c?.slug === "string" &&
+        c.slug.length > 0,
     )
     .sort((a, b) => a.name.localeCompare(b.name));
 };

--- a/blog/loaders/BlogpostListing.ts
+++ b/blog/loaders/BlogpostListing.ts
@@ -95,15 +95,12 @@ export default async function BlogPostList(
 
     const slicedPosts = slicePosts(handledPosts, pageNumber, postsPerPage);
 
-    if (slicedPosts.length === 0) {
-      return null;
-    }
-
     let categories: Category[] | null = null;
 
     if (expandedCategories) {
       try {
-        categories = await loadCategories(ctx);
+        const allCategories = await loadCategories(ctx);
+        categories = filterCategoriesWithPosts(allCategories, handledPosts);
       } catch (e) {
         logger.error(e);
       }
@@ -118,9 +115,14 @@ export default async function BlogPostList(
 
     const activeCategory = slug
       ? categories?.find((c) => c.slug === slug) ??
-        slicedPosts[0].categories?.find((c) => c.slug === slug) ??
+        slicedPosts[0]?.categories?.find((c) => c.slug === slug) ??
+        handledPosts[0]?.categories?.find((c) => c.slug === slug) ??
         null
       : null;
+
+    if (slicedPosts.length === 0) {
+      return null;
+    }
 
     return {
       posts: slicedPosts,
@@ -173,6 +175,19 @@ const isValidCategory = (category: Category): boolean =>
   category.name.length > 0 &&
   typeof category?.slug === "string" &&
   category.slug.length > 0;
+
+const filterCategoriesWithPosts = (
+  categories: Category[],
+  posts: BlogPost[],
+): Category[] => {
+  const slugs = new Set(
+    posts.flatMap((post) =>
+      post.categories?.map((category) => category.slug) ?? []
+    ),
+  );
+
+  return categories.filter((category) => slugs.has(category.slug));
+};
 
 const loadCategories = async (ctx: AppContext): Promise<Category[]> => {
   const categories = await getRecordsByPath<Category>(

--- a/blog/loaders/BlogpostListing.ts
+++ b/blog/loaders/BlogpostListing.ts
@@ -47,7 +47,7 @@ export interface Props {
   /**
    * @title Expanded categories
    * @description When enabled, returns all categories from the collection.
-   * @default true
+   * @default false
    */
   expandedCategories?: boolean;
 }
@@ -62,7 +62,7 @@ export interface Props {
  * @returns A promise that resolves to an array of blog posts.
  */
 export default async function BlogPostList(
-  { page, count, slug, sortBy, query, expandedCategories = true }: Props,
+  { page, count, slug, sortBy, query, expandedCategories = false }: Props,
   req: Request,
   ctx: AppContext,
 ): Promise<BlogPostListingPage | null> {
@@ -104,6 +104,13 @@ export default async function BlogPostList(
     if (expandedCategories) {
       try {
         categories = await loadCategories(ctx);
+      } catch (e) {
+        logger.error(e);
+      }
+    } else if (slug) {
+      try {
+        const match = await loadCategoryBySlug(ctx, slug);
+        categories = match ? [match] : null;
       } catch (e) {
         logger.error(e);
       }
@@ -161,6 +168,12 @@ const toPageInfo = (
   };
 };
 
+const isValidCategory = (category: Category): boolean =>
+  typeof category?.name === "string" &&
+  category.name.length > 0 &&
+  typeof category?.slug === "string" &&
+  category.slug.length > 0;
+
 const loadCategories = async (ctx: AppContext): Promise<Category[]> => {
   const categories = await getRecordsByPath<Category>(
     ctx,
@@ -169,12 +182,22 @@ const loadCategories = async (ctx: AppContext): Promise<Category[]> => {
   );
 
   return (categories ?? [])
-    .filter(
-      (c) =>
-        typeof c?.name === "string" &&
-        c.name.length > 0 &&
-        typeof c?.slug === "string" &&
-        c.slug.length > 0,
-    )
+    .filter(isValidCategory)
     .sort((a, b) => a.name.localeCompare(b.name));
+};
+
+const loadCategoryBySlug = async (
+  ctx: AppContext,
+  slug: string,
+): Promise<Category | null> => {
+  const categories = await getRecordsByPath<Category>(
+    ctx,
+    CATEGORIES_PATH,
+    CATEGORY_ACCESSOR,
+  );
+
+  return (categories ?? []).find((c) =>
+    isValidCategory(c) && c.slug === slug
+  ) ??
+    null;
 };

--- a/blog/types.ts
+++ b/blog/types.ts
@@ -120,8 +120,6 @@ export type SortBy =
 
 export interface BlogPostListingPage {
   posts: BlogPost[];
-  /** @title Active category */
-  category?: Category | null;
   /** @title Categories */
   categories?: Category[] | null;
   pageInfo: PageInfo;


### PR DESCRIPTION
## Summary
- Removes `category` from `BlogPostListingPage`; listings expose only `categories`
- `expandedCategories` loads the full categories array without duplicating active category resolution
- SEO still derives the active category from slug (collection first, post fallback)

## Test plan
- [ ] Blog listing page sidebar uses `listing.categories`
- [ ] Category page SEO title/description still resolve from slug
- [ ] `expandedCategories: false` returns `categories: null`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dropped the `category` field from `BlogPostListingPage`; listings now expose only `categories`. `expandedCategories` defaults to `false` and, when enabled, returns only categories that have posts in the full (pre-pagination) result set; SEO still resolves the active category from the slug with post fallbacks.

- **Refactors**
  - Listings expose only `categories`.
  - `expandedCategories` defaults to `false`; when `true`, loads categories from the collection filtered to slugs present in the handled posts.
  - Without expansion: if a `slug` is provided, `categories` is a single-item array with the matched category; otherwise `null`.

- **Migration**
  - Replace any `listing.category` usage with `listing.categories`.
  - Handle `listing.categories` as `[category]` when filtering by slug without expansion, else `null`.

<sup>Written for commit fdd8aac4eebf55005eee76d12a064de3cee83836. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

