### PR TITLE
fix(blog): always return categories on BlogpostListing

### DIFF
--- a/blog/loaders/BlogpostListing.ts
+++ b/blog/loaders/BlogpostListing.ts
@@ -44,12 +44,6 @@ export interface Props {
    * @description Overrides the query term at url
    */
   query?: string;
-  /**
-   * @title Expanded categories
-   * @description When enabled, returns all categories and resolves the active category only from the categories collection.
-   * @default true
-   */
-  expandedCategories?: boolean;
 }
 
 /**
@@ -62,7 +56,7 @@ export interface Props {
  * @returns A promise that resolves to an array of blog posts.
  */
 export default async function BlogPostList(
-  { page, count, slug, sortBy, query, expandedCategories = true }: Props,
+  { page, count, slug, sortBy, query }: Props,
   req: Request,
   ctx: AppContext,
 ): Promise<BlogPostListingPage | null> {
@@ -70,8 +64,7 @@ export default async function BlogPostList(
   const params = url.searchParams;
   const postsPerPage = Number(count ?? params.get("count") ?? 12);
   const pageNumber = Number(page ?? params.get("page") ?? 1);
-  const pageSort = sortBy ?? params.get("sortBy") as SortBy ??
-    "date_desc";
+  const pageSort = sortBy ?? (params.get("sortBy") as SortBy) ?? "date_desc";
   const term = query ?? params.get("q") ?? undefined;
 
   const posts = await getRecordsByPath<BlogPost>(
@@ -100,30 +93,24 @@ export default async function BlogPostList(
       return null;
     }
 
-    let category: Category | null = null;
     let categories: Category[] | null = null;
+    try {
+      categories = await loadCategories(ctx);
+    } catch (e) {
+      logger.error(e);
+    }
 
-    if (expandedCategories) {
-      try {
-        categories = await loadCategories(ctx);
-        if (slug) {
-          category = categories.find((c) => c.slug === slug) ?? null;
+    let category: Category | null = null;
+    if (slug) {
+      category = categories?.find((c) => c.slug === slug) ?? null;
+      if (!category) {
+        try {
+          category = await loadCategoryBySlug(ctx, slug);
+        } catch (e) {
+          logger.error(e);
         }
-      } catch (e) {
-        logger.error(e);
       }
-    } else if (slug) {
-      try {
-        const categoryRecords = await getRecordsByPath<Category>(
-          ctx,
-          CATEGORIES_PATH,
-          CATEGORY_ACCESSOR,
-        );
-        category = categoryRecords?.find((c) => c.slug === slug) ?? null;
-      } catch (e) {
-        logger.error(e);
-      }
-      category ??= slicedPosts[0].categories?.find((c) => c.slug === slug) ??
+      category ??= slicedPosts[0]?.categories?.find((c) => c.slug === slug) ??
         null;
     }
 
@@ -187,4 +174,21 @@ const loadCategories = async (ctx: AppContext): Promise<Category[]> => {
       typeof c?.slug === "string" && c.slug.length > 0
     )
     .sort((a, b) => a.name.localeCompare(b.name));
+};
+
+const loadCategoryBySlug = async (
+  ctx: AppContext,
+  slug: string,
+): Promise<Category | null> => {
+  const categories = await getRecordsByPath<Category>(
+    ctx,
+    CATEGORIES_PATH,
+    CATEGORY_ACCESSOR,
+  );
+
+  return (categories ?? []).find((c) =>
+    typeof c?.name === "string" && c.name.length > 0 &&
+    typeof c?.slug === "string" && c.slug.length > 0 &&
+    c.slug === slug
+  ) ?? null;
 };


### PR DESCRIPTION
## Summary
- Removes the `expandedCategories` loader prop
- Always returns the full `categories` array from the collection on every listing request
- Sets `category` only when the loader is called with a `slug` filter (category pages / SEO)

## Test plan
- [ ] Blog home listing returns `categories` with all collection categories
- [ ] Category page (`slug` set) returns `category` populated and `categories` still present
- [ ] Listing without `slug` returns `category: null`
- [ ] Category sidebar works without `expandedCategories` in page JSON


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always return the full `categories` array in `BlogpostListing` and set `category` only when a `slug` filter is used. This removes `expandedCategories` and fixes missing/partial category data on listings.

- **Bug Fixes**
  - Always includes full `categories` from the collection on every request.
  - Resolves `category` when `slug` is set (checks collection first, then post fallback).
  - Safer parsing for `sortBy` and null guards to avoid crashes.

- **Migration**
  - Remove `expandedCategories` from loader props and page JSON; no replacement needed.

<sup>Written for commit 33f39c344c643f30f36dc4f836ad3d369dfc9e27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved category resolution with enhanced fallback mechanisms in blog post listings to ensure categories load correctly even when initial lookups fail.

* **Chores**
  * Removed the `expandedCategories` configuration option; category loading is now handled automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->