### PR TITLE
fix(vtex): rewrite legacy decocache/decoassets video URLs to decoims.com

### DIFF
--- a/vtex/utils/transform.ts
+++ b/vtex/utils/transform.ts
@@ -435,7 +435,10 @@ export const toProduct = <P extends LegacyProductVTEX | ProductVTEX>(
   }) ?? [DEFAULT_IMAGE];
 
   const finalVideos = nonEmptyVideos?.map((video) => {
-    const url = video;
+    const url = video.replace(
+      /^https:\/\/(?:assets\.decocache\.com|data\.decoassets\.com)\//,
+      "https://decoims.com/",
+    );
     const alternateName = "Product video";
     const name = "Product video";
     const encodingFormat = "video";


### PR DESCRIPTION
## Problem
VTEX product catalogs may have videos registered with `assets.decocache.com` or `data.decoassets.com` URLs. These are passed through as-is in `toProduct` → `finalVideos` → `contentUrl`, generating Azion proxy requests on every PDP load.

## Fix
One-line regex replace at the point where the `url` is set in `finalVideos`:

```ts
const url = video.replace(
  /^https:\/\/(?:assets\.decocache\.com|data\.decoassets\.com)\//,
  "https://decoims.com/",
);
```

## Impact
- Affects all VTEX sites using `deco-cx/apps`
- Fixes Azion proxy requests from product video fields without requiring VTEX catalog updates
- No behavior change for videos already on `decoims.com` or other CDNs

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites VTEX product video URLs from `assets.decocache.com` and `data.decoassets.com` to `decoims.com` in `toProduct` so `contentUrl` uses the right CDN. Prevents Azion proxy requests on PDP loads and leaves existing `decoims.com` or other CDN URLs unchanged.

<sup>Written for commit 2721e33c968090c9e20b090017f3dba31cada705. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video links are now normalized to use the correct asset host, improving playback consistency for product videos.
  * URLs from older asset domains are automatically rewritten to the current media domain instead of being left unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->