### PR TITLE
feat(commerce/seo): add descriptionSource option to SeoPDPV2

### DIFF
--- a/commerce/sections/Seo/SeoPDPV2.tsx
+++ b/commerce/sections/Seo/SeoPDPV2.tsx
@@ -16,6 +16,13 @@ export interface Props {
   /** @title Description Override */
   description?: string;
   /**
+   * @title Description Source
+   * @description Choose which field to use as the meta description when no Description Override is set.
+   * "seo" uses the SEO description from the search index (default).
+   * "product" uses the product's own description field, stripping HTML tags — useful when the SEO description is empty or you prefer the richer product copy.
+   */
+  descriptionSource?: "seo" | "product";
+  /**
    * @title Disable indexing
    * @description In testing, you can use this to prevent search engines from indexing your site
    */
@@ -38,10 +45,22 @@ export function loader(_props: Props, _req: Request, ctx: AppContext) {
   const {
     title: titleProp,
     description: descriptionProp,
+    descriptionSource = "seo",
     jsonLD,
     omitVariants,
     ignoreStructuredData,
   } = props;
+
+  const productDescription = jsonLD?.product.description
+    ?.replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  const resolvedDescription = descriptionProp ||
+    (descriptionSource === "product"
+      ? productDescription || jsonLD?.seo?.description
+      : jsonLD?.seo?.description || productDescription) ||
+    ctx.seo?.description || "";
 
   const title = renderTemplateString(
     titleTemplate,
@@ -49,7 +68,7 @@ export function loader(_props: Props, _req: Request, ctx: AppContext) {
   );
   const description = renderTemplateString(
     descriptionTemplate,
-    descriptionProp || jsonLD?.seo?.description || ctx.seo?.description || "",
+    resolvedDescription,
   );
   const image = jsonLD?.product.image?.[0]?.url;
   const canonical = jsonLD?.seo?.canonical


### PR DESCRIPTION
## Summary

Adds a `descriptionSource` prop to `SeoPDPV2.tsx` so sites can choose which field to use as the meta description without needing a custom component.

- `"seo"` (default) — uses `jsonLD.seo.description`, same as current behavior. No breaking change.
- `"product"` — strips HTML from `jsonLD.product.description`, useful when the SEO description is empty or the product copy is preferred.

## Motivation

In VTEX, `product.description` is a rich-text HTML field meant for page display. `seo.description` maps to `metaTagDescription` — a plain-text field designed for `<meta name="description">`. Some sites had the `seo.description` empty and were creating custom SEO components just to fetch `metaTagDescription` from a separate API. This option covers that use case natively.

When `"product"` is selected and `product.description` is empty, it falls back to `seo.description` automatically (and vice versa).

## Example

```json
{
  "__resolveType": "commerce/sections/Seo/SeoPDPV2.tsx",
  "jsonLD": { "__resolveType": "..." },
  "descriptionSource": "product"
}
```

## Test plan

- [ ] Default behavior (`descriptionSource` omitted or `"seo"`) renders `jsonLD.seo.description` unchanged
- [ ] `"product"` renders `jsonLD.product.description` with HTML tags stripped
- [ ] If chosen source is empty, falls back to the other source gracefully
- [ ] `description` manual override still takes priority over both sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `descriptionSource` option to `SeoPDPV2` to choose the meta description source. Defaults to the SEO description, with an option to use the product description (HTML stripped) and graceful fallbacks.

- **New Features**
  - `descriptionSource`: `"seo"` (default) uses `jsonLD.seo.description`.
  - `"product"` uses `jsonLD.product.description` with HTML tags removed.
  - Falls back to the other source if the chosen one is empty.
  - Manual `description` prop still overrides both.

<sup>Written for commit dd63a83e25d9932d837af67c2dd2a77c50e9c583. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option to control which product description is used in page metadata.
  * Improved how meta descriptions are generated by cleaning product text and using it when needed.
* **Bug Fixes**
  * Meta description output now falls back more reliably when a manual description isn’t provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->