### PR TITLE
feat(htmx): always include head-support extension

### DIFF
--- a/htmx/mod.ts
+++ b/htmx/mod.ts
@@ -45,7 +45,10 @@ export default function Site(state: Props): App<Manifest, Required<Props>> {
     state: {
       version: state.version ?? "1.9.12",
       cdn: state.cdn ?? "https://cdn.jsdelivr.net/npm",
-      extensions: state.extensions ?? [],
+      extensions: [
+        "head-support",
+        ...(state.extensions ?? []).filter((ext) => ext !== "head-support"),
+      ],
     },
     manifest,
   };


### PR DESCRIPTION
## Summary
- Ensures the `head-support` HTMX extension is always loaded by the HTMX app, regardless of whether the user added it to the `extensions` prop
- User-provided `head-support` entries are deduplicated so the script is not loaded twice

## Test plan
- [ ] Configure the HTMX app with no `extensions` and confirm `head-support` is present in `hx-ext` and that `htmx.org@<version>/dist/ext/head-support.js` is loaded
- [ ] Configure the HTMX app with `extensions: ["json-enc"]` and confirm both `head-support` and `json-enc` are loaded
- [ ] Configure the HTMX app with `extensions: ["head-support", "json-enc"]` and confirm there is no duplicate `head-support` script tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always load the `head-support` HTMX extension by default so head updates work out of the box. If users include `head-support` in `extensions`, we de-dupe it to avoid loading the script twice.

<sup>Written for commit 8498ad657ffd3e3b022d9df3e90c0f98786cea1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the app always includes `head-support` exactly once, even when custom extensions are provided.
  * Prevented duplicate extension entries, improving consistency and reducing unexpected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->