### PR TITLE
refactor(website): remove deprecated firstByteThresholdMS config

### DIFF
--- a/website/handlers/fresh.ts
+++ b/website/handlers/fresh.ts
@@ -97,7 +97,6 @@ export default function Fresh(
     | "monitoring"
     | "response"
     | "caching"
-    | "firstByteThresholdMS"
     | "isBot"
     | "flavor"
   >,
@@ -111,8 +110,7 @@ export default function Fresh(
     const url = new URL(req.url);
     const startedAt = Date.now();
     const asJson = url.searchParams.get("asJson");
-    const delayFromProps = appContext.firstByteThresholdMS ? 1 : 0;
-    const delay = Number(url.searchParams.get(__DECO_FBT) ?? delayFromProps);
+    const delay = Number(url.searchParams.get(__DECO_FBT) ?? 0);
     /** Controller to abort third party fetch (loaders) */
     const ctrl = new AbortController();
     const pathTemplate = isFreshCtx<DecoState>(ctx)

--- a/website/mod.ts
+++ b/website/mod.ts
@@ -110,13 +110,6 @@ export interface Props {
    */
   caching?: Caching;
   /**
-   * @title Global Async Rendering (Deprecated)
-   * @description Please disable this setting and enable each section individually. More info at https://deco.cx/en/blog/async-render-default
-   * @deprecated true
-   * @default false
-   */
-  firstByteThresholdMS?: boolean;
-  /**
    * @title Avoid redirecting to editor
    * @description Disable going to editor when "." or "Ctrl + Shift + E" is pressed
    */


### PR DESCRIPTION
## Summary
- Remove the deprecated `firstByteThresholdMS` flag from `website/mod.ts`. Even though marked `@deprecated`, when set it still triggered the global async-render path in `website/handlers/fresh.ts` (immediate loader abort via `delayFromProps = 1`).
- Simplify `delay` in the Fresh handler to come solely from the `?__decoFBT=` URL override (fallback `0`), so the only remaining async-render mechanism is per-section `Lazy` / deferred rendering.

## Test plan
- [ ] Verify pages render normally with no `firstByteThresholdMS` reference in admin/CMS config.
- [ ] Confirm per-section `Lazy` (deferred) sections still async-render as expected.
- [ ] Confirm `?__decoFBT=<ms>` URL override still aborts loaders at the requested delay.
- [ ] Confirm `?__decoFBT=0` still forces synchronous render (via `shouldForceRender`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deprecated `firstByteThresholdMS` config and its handler logic to prevent unintended global async-render aborts. `Fresh` now reads delay only from the `?__decoFBT=` URL param (default 0), leaving async rendering to per-section Lazy.

<sup>Written for commit 28908468e4b9cc2007a7ff3a78e68a1bece42444. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

