### PR TITLE
fix(vnda): filter proxy cookies to prevent RequestHeaderSectionTooLarge

### DIFF
--- a/vnda/loaders/proxy.ts
+++ b/vnda/loaders/proxy.ts
@@ -38,6 +38,12 @@ const API_PATHS = [
 const decoSiteMapUrl = "/sitemap/deco.xml";
 
 const VNDA_HOST_HEADER = "X-Shop-Host";
+const VNDA_ALLOWED_COOKIES = [
+  "vnda_cart_id",
+  "cart_id",
+  "ahoy_visit",
+  "ahoy_visitor",
+];
 export interface Props {
   /** @description ex: /p/fale-conosco */
   pagesToProxy?: string[];
@@ -100,6 +106,7 @@ function loader(
           : internalDomain,
         host: url.hostname,
         customHeaders,
+        allowedCookies: VNDA_ALLOWED_COOKIES,
       },
     },
   }));
@@ -123,6 +130,7 @@ function loader(
         url: `https://api.vnda.com.br/`,
         host: url.hostname,
         customHeaders,
+        allowedCookies: VNDA_ALLOWED_COOKIES,
       },
     },
   }));

--- a/website/handlers/proxy.ts
+++ b/website/handlers/proxy.ts
@@ -24,6 +24,23 @@ export const removeCFHeaders = (headers: Headers) => {
     }
   });
 };
+export const filterCookies = (headers: Headers, allowed: string[]) => {
+  const cookie = headers.get("cookie");
+  if (!cookie) return;
+  const filtered = cookie
+    .split(";")
+    .map((c) => c.trim())
+    .filter((c) => {
+      const name = c.split("=")[0]?.trim();
+      return name && allowed.includes(name);
+    })
+    .join("; ");
+  if (filtered) {
+    headers.set("cookie", filtered);
+  } else {
+    headers.delete("cookie");
+  }
+};
 /**
  * @title {{{key}}} - {{{value}}}
  */
@@ -86,6 +103,10 @@ export interface Props {
   removeDirtyCookies?: boolean;
   excludeHeaders?: string[];
   pathsThatRequireSameReferer?: string[];
+  /**
+   * @description Only forward cookies whose names match this list. When set, all other cookies are stripped from the proxied request.
+   */
+  allowedCookies?: string[];
 }
 /**
  * @title Proxy
@@ -104,6 +125,7 @@ export default function Proxy({
   replaces,
   removeDirtyCookies = false,
   pathsThatRequireSameReferer = [],
+  allowedCookies,
 }: Props): Handler {
   return async (req, _ctx) => {
     const url = new URL(req.url);
@@ -126,6 +148,9 @@ export default function Proxy({
     removeCFHeaders(headers); // cf-headers are not ASCII-compliant
     if (removeDirtyCookies) {
       removeDirtyCookiesFn(headers);
+    }
+    if (allowedCookies && allowedCookies.length > 0) {
+      filterCookies(headers, allowedCookies);
     }
     if (isFreshCtx<DecoSiteState>(_ctx)) {
       _ctx?.state?.monitoring?.logger?.log?.("proxy sent headers", headers);


### PR DESCRIPTION
## Summary
- Adds `allowedCookies` option to the generic proxy handler (`website/handlers/proxy.ts`) that filters cookies to an allowlist before forwarding
- Configures VNDA proxy to only forward VNDA-relevant cookies: `vnda_cart_id`, `cart_id`, `ahoy_visit`, `ahoy_visitor`
- Strips analytics/tracking cookies (`_ga`, `_fbp`, `_gcl_au`, `_hj*`, `_pin_unauth`, etc.) and Cloudflare cookies (`__cf_bm`, `_cfuvid`, `cf_clearance`) that were inflating request headers beyond the 8KB limit, causing `RequestHeaderSectionTooLarge` errors on checkout

## Test plan
- [ ] Test VNDA checkout flow end-to-end (add to cart → checkout → payment)
- [ ] Verify cart persists across page navigations
- [ ] Confirm no `RequestHeaderSectionTooLarge` errors on `/checkout/*` routes
- [ ] Test login/account pages (`/entrar`, `/conta`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters cookies in the proxy to prevent `RequestHeaderSectionTooLarge` errors on VNDA checkout. Adds an `allowedCookies` option and enables it for VNDA to forward only required cookies.

- **Bug Fixes**
  - Added `allowedCookies` prop in `website/handlers/proxy.ts` to whitelist cookie names.
  - VNDA proxy now forwards only `vnda_cart_id`, `cart_id`, `ahoy_visit`, `ahoy_visitor`.
  - Strips analytics and Cloudflare cookies to keep request headers under 8KB on `/checkout/*`.

<sup>Written for commit 517d85b488a688fedb0e9f9b473dddf0b11e2bb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie forwarding through proxy requests by only passing along approved cookies.
  * Removed stray cookies from proxied requests when they are not needed, helping reduce unexpected session or auth behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->