### PR TITLE
fix(seo): set og:type=product on product detail pages

### DIFF
--- a/commerce/sections/Seo/SeoPDPV2.tsx
+++ b/commerce/sections/Seo/SeoPDPV2.tsx
@@ -16,6 +16,13 @@ export interface Props {
   /** @title Description Override */
   description?: string;
   /**
+   * @title Description Source
+   * @description Choose which field to use as the meta description when no Description Override is set.
+   * "seo" uses the SEO description from the search index (default).
+   * "product" uses the product's own description field, stripping HTML tags — useful when the SEO description is empty or you prefer the richer product copy.
+   */
+  descriptionSource?: "seo" | "product";
+  /**
    * @title Disable indexing
    * @description In testing, you can use this to prevent search engines from indexing your site
    */
@@ -38,10 +45,22 @@ export function loader(_props: Props, _req: Request, ctx: AppContext) {
   const {
     title: titleProp,
     description: descriptionProp,
+    descriptionSource = "seo",
     jsonLD,
     omitVariants,
     ignoreStructuredData,
   } = props;
+
+  const productDescription = jsonLD?.product.description
+    ?.replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  const resolvedDescription = descriptionProp ||
+    (descriptionSource === "product"
+      ? productDescription || jsonLD?.seo?.description
+      : jsonLD?.seo?.description || productDescription) ||
+    ctx.seo?.description || "";
 
   const title = renderTemplateString(
     titleTemplate,
@@ -49,7 +68,7 @@ export function loader(_props: Props, _req: Request, ctx: AppContext) {
   );
   const description = renderTemplateString(
     descriptionTemplate,
-    descriptionProp || jsonLD?.seo?.description || ctx.seo?.description || "",
+    resolvedDescription,
   );
   const image = jsonLD?.product.image?.[0]?.url;
   const canonical = jsonLD?.seo?.canonical

--- a/commerce/sections/Seo/SeoPDPV2.tsx
+++ b/commerce/sections/Seo/SeoPDPV2.tsx
@@ -94,6 +94,7 @@ export function loader(_props: Props, _req: Request, ctx: AppContext) {
     canonical,
     noIndexing,
     jsonLDs,
+    type: "product" as const,
   };
 }
 

--- a/website/components/Seo.tsx
+++ b/website/components/Seo.tsx
@@ -7,7 +7,7 @@ export const renderTemplateString = (template: string, value: string) =>
   template.replace("%s", value);
 
 export type SEOSection = JSX.Element;
-export type OGType = "website" | "article";
+export type OGType = "website" | "article" | "product";
 
 export interface Props {
   title?: string;


### PR DESCRIPTION
## Summary

- Adds `"product"` to the `OGType` union in `website/components/Seo.tsx`
- `SeoPDPV2` loader now explicitly returns `type: "product"` so PDPs emit the correct Open Graph type instead of inheriting `"website"` from site config

## Root cause

`OGType` only had `"website" | "article"`. `SeoPDPV2` spreads `ctx.seo` props (which default to `type: "website"`) without overriding the type, so every PDP rendered `<meta property="og:type" content="website">`.

## Test plan

- [ ] Load a PDP with `?__decoFBT=0` and inspect `og:type` in page source — should be `product`
- [ ] Home/category pages unaffected (still use `SeoCategoryV2` / `SeoPLP`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `og:type=product` on product detail pages and add a `descriptionSource` option for meta descriptions to improve SEO and social previews.
Product pages no longer inherit `og:type=website`.

- **Bug Fixes**
  - Added `"product"` to `OGType` in `website/components/Seo.tsx`.
  - `SeoPDPV2` loader now sets `type: "product"` for PDPs.

- **New Features**
  - `descriptionSource` prop ("seo" | "product") in `SeoPDPV2`.
  - Strips HTML from product descriptions and falls back between `jsonLD.seo.description` and `jsonLD.product.description` when needed.

<sup>Written for commit d277ecceb2ec5b4ef924ad2475db18046f7f89ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product pages now support product-specific SEO metadata, including a product Open Graph type.
  * Meta descriptions can now use either SEO or product content when no custom description is set.

* **Bug Fixes**
  * Improved how page descriptions are generated by normalizing product text before use.
  * Updated social sharing metadata so product pages display the correct preview format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->