### PR TITLE
fix(seo): set og:type=product on product detail pages

### DIFF
--- a/commerce/sections/Seo/SeoPDPV2.tsx
+++ b/commerce/sections/Seo/SeoPDPV2.tsx
@@ -1,5 +1,6 @@
 import Seo from "../../../website/components/Seo.tsx";
 import {
+  OGType,
   renderTemplateString,
   SEOSection,
 } from "../../../website/components/Seo.tsx";
@@ -25,6 +26,11 @@ export interface Props {
    * @description By default, Structured Data is sent to everyone. Use this to prevent Structured Data from being sent to your customers, it will still be sent to crawlers and bots. Be aware that some integrations may not work if Structured Data is not sent.
    */
   ignoreStructuredData?: boolean;
+  /**
+   * @title OG Type
+   * @default product
+   */
+  type?: OGType;
 }
 
 /** @title Product details */
@@ -41,6 +47,7 @@ export function loader(_props: Props, _req: Request, ctx: AppContext) {
     jsonLD,
     omitVariants,
     ignoreStructuredData,
+    type: typeProp,
   } = props;
 
   const title = renderTemplateString(
@@ -75,7 +82,7 @@ export function loader(_props: Props, _req: Request, ctx: AppContext) {
     canonical,
     noIndexing,
     jsonLDs,
-    type: "product" as const,
+    type: typeProp ?? "product",
   };
 }
 

--- a/commerce/sections/Seo/SeoPDPV2.tsx
+++ b/commerce/sections/Seo/SeoPDPV2.tsx
@@ -75,6 +75,7 @@ export function loader(_props: Props, _req: Request, ctx: AppContext) {
     canonical,
     noIndexing,
     jsonLDs,
+    type: "product" as const,
   };
 }
 

--- a/website/components/Seo.tsx
+++ b/website/components/Seo.tsx
@@ -7,7 +7,7 @@ export const renderTemplateString = (template: string, value: string) =>
   template.replace("%s", value);
 
 export type SEOSection = JSX.Element;
-export type OGType = "website" | "article";
+export type OGType = "website" | "article" | "product";
 
 export interface Props {
   title?: string;


### PR DESCRIPTION
## Summary

- Adds `"product"` to the `OGType` union in `website/components/Seo.tsx`
- `SeoPDPV2` loader now explicitly returns `type: "product"` so PDPs emit the correct Open Graph type instead of inheriting `"website"` from site config

## Root cause

`OGType` only had `"website" | "article"`. `SeoPDPV2` spreads `ctx.seo` props (which default to `type: "website"`) without overriding the type, so every PDP rendered `<meta property="og:type" content="website">`.

## Test plan

- [ ] Load a PDP with `?__decoFBT=0` and inspect `og:type` in page source — should be `product`
- [ ] Home/category pages unaffected (still use `SeoCategoryV2` / `SeoPLP`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix PDPs emitting `og:type=website` by defaulting to `og:type=product`.

Adds `product` to the `OGType` union and exposes a `type` prop in `SeoPDPV2` (defaults to `product`) so sections can override as needed; other pages are unchanged.

<sup>Written for commit 9cca3c95f351b0907385e30285da64f3d5458db5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

