### PR TITLE
fix(vtex): filter unavailable items in PDPDefaultPath

### DIFF
--- a/vtex/loaders/paths/PDPDefaultPath.ts
+++ b/vtex/loaders/paths/PDPDefaultPath.ts
@@ -1,6 +1,6 @@
 import { DefaultPathProps } from "../../../website/pages/Page.tsx";
 import { AppContext } from "../../mod.ts";
-import productList from "../legacy/productList.ts";
+import productList from "../intelligentSearch/productList.ts";
 
 export interface Props {
   count: number;
@@ -20,9 +20,10 @@ const loader = async (
   const response = await productList(
     {
       props: {
-        term: "",
+        query: "",
         count,
-        sort: "OrderByTopSaleDESC",
+        sort: "orders:desc",
+        hideUnavailableItems: true,
       },
     },
     req,


### PR DESCRIPTION
## Summary
- Switch `PDPDefaultPath` from legacy to intelligent search `productList`
- Enable `hideUnavailableItems: true` to prevent out-of-stock products from being returned as default PDP paths

## Test plan
- [ ] Verify that PDPDefaultPath returns only available products
- [ ] Confirm product detail pages load correctly when no slug is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched PDPDefaultPath to the intelligent search productList and updated parameters (term→query, sort→orders:desc). Enabled hideUnavailableItems so default PDP paths exclude out-of-stock products.

<sup>Written for commit 18b04c0f155e6d89fe8724b320f9448cf024fdca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated product listing behavior to use the newer search experience, improving how default product pages load and display results.
  * Search results now respect the configured item count, use a more consistent sort order, and hide unavailable items by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->