### PR TITLE
fix(vtex): check for :slug prefix instead of just : in PDP loaders

### DIFF
--- a/vtex/loaders/intelligentSearch/productDetailsPage.ts
+++ b/vtex/loaders/intelligentSearch/productDetailsPage.ts
@@ -71,7 +71,7 @@ const loader = async (
   const { vcsDeprecated } = ctx;
   const { url: baseUrl } = req;
   const { slug } = props;
-  const haveToUseSlug = slug && !slug.startsWith(":");
+  const haveToUseSlug = slug && !slug.startsWith(":slug");
   let defaultPaths;
 
   if (!haveToUseSlug) {

--- a/vtex/loaders/legacy/productDetailsPage.ts
+++ b/vtex/loaders/legacy/productDetailsPage.ts
@@ -45,7 +45,7 @@ async function loader(
   const { vcsDeprecated } = ctx;
   const { url: baseUrl } = req;
   const { slug } = props;
-  const haveToUseSlug = slug && !slug.startsWith(":");
+  const haveToUseSlug = slug && !slug.startsWith(":slug");
   let defaultPaths;
   if (!haveToUseSlug) {
     defaultPaths = await PDPDefaultPath({ count: 1 }, req, ctx);


### PR DESCRIPTION
## Summary
- Fix slug prefix check from `startsWith(":")` to `startsWith(":slug")` in both intelligent search and legacy PDP loaders
- The previous check was too broad, matching any string starting with `:` instead of the specific `:slug` placeholder

## Test plan
- [ ] Verify PDP pages load correctly with valid slugs
- [ ] Verify fallback to `PDPDefaultPath` triggers only when slug is the `:slug` placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix PDP slug placeholder detection by checking for ':slug' instead of any ':' in both intelligent search and legacy loaders. Prevents unnecessary fallback to PDPDefaultPath for valid slugs so PDP pages resolve correctly.

<sup>Written for commit c666565669993da3552bc4498822ea19cfbd816a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

