### PR TITLE
feat(vtex/intelligentSearch): make filtered PLP caching opt-in via advancedConfigs.cacheFilteredPLP

### DIFF
--- a/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -444,8 +444,12 @@ export const cacheKey = (props: Props, req: Request, ctx: AppContext) => {
     return null;
   }
 
+  // By default, don't cache PLPs with `filter.*` params: bots crawling
+  // arbitrary filter combinations would explode the number of distinct cache
+  // keys. Opt in via advancedConfigs.cacheFilteredPLP when the filter surface
+  // is bounded — filter.* params are already whitelisted into the key below.
   if (
-    url.search.includes("filter.")
+    !ctx.advancedConfigs?.cacheFilteredPLP && url.search.includes("filter.")
   ) {
     return null;
   }

--- a/vtex/mod.ts
+++ b/vtex/mod.ts
@@ -92,6 +92,16 @@ export interface Props {
      * @description Remove UTM from cache key to prevent cache fragmentation.
      */
     removeUTMFromCacheKey?: boolean;
+    /**
+     * @title Cache PLPs with `filter.*` params
+     * @description By default, PLP URLs carrying `filter.*` query params are NOT
+     * cached, to avoid bots crawling arbitrary filter combinations and
+     * exploding the number of distinct cache keys. Enable this only if your
+     * filter surface is bounded and you want filtered PLPs to be cacheable.
+     * Each filter combination still produces a distinct cache key.
+     * @default false
+     */
+    cacheFilteredPLP?: boolean;
   };
 
   /**


### PR DESCRIPTION
## Context

`vtex/loaders/intelligentSearch/productListingPage.ts` `cacheKey` short-circuits to `null` whenever the URL search string contains `filter.`, so every filtered PLP responds `Cache-Control: no-store, no-cache, must-revalidate` and never hits the CDN.

**This guard is intentional.** It was added to stop bots crawling arbitrary `filter.*` combinations from exploding the number of distinct cache keys (cardinality blowup). Removing it outright would regress that protection for every site.

But for sites with a **bounded** filter surface, the guard is pure downside — the filtered PLPs are perfectly cacheable and currently aren't.

## Change

Gate the guard behind a new opt-in flag on the **VTEX app config** (`advancedConfigs` in `mod.ts`, next to `removeUTMFromCacheKey`):

```ts
if (!ctx.advancedConfigs?.cacheFilteredPLP && url.search.includes("filter.")) {
  return null;
}
```

- Set **once at the app level**, not per PLP block (cacheKey reads `ctx.advancedConfigs`, the app config — not per-loader props).
- **Default `false` → behavior unchanged** (filtered PLPs stay uncached, cardinality protection intact).
- **`cacheFilteredPLP: true` → filtered PLPs become cacheable.** `filter.*` params are already whitelisted into the cache key via `isFilterParam(key)` in the params loop below, so each filter combination produces a distinct key (no cross-filter bleed). Segment/UTM handling untouched.

## Propagation chain (why a null cacheKey becomes no-store)

1. `apps` `cacheKey` → returns `null`.
2. `deco` `blocks/loader.ts` (`wrapLoader`): `cacheKey===null` ⇒ `ctx.vary.shouldCache=false`.
3. `deco` `runtime/middleware.ts` (`applyPageCacheDecision`): `shouldCache=false` ⇒ `Cache-Control: no-store, no-cache, must-revalidate`.

## Validation

Enable `cacheFilteredPLP` on the VTEX app of a bounded-filter storefront, then:

```bash
curl -sS -o /dev/null -D - \
  "https://<site>/<plp>?filter.price=0:500&_cb=$RANDOM" \
  -A "Mozilla/5.0 ... Chrome/126" | grep -i '^cache-control:'
# Disabled/default: no-store, no-cache, must-revalidate
# Enabled:          public,max-age=300,stale-while-revalidate=3600
```

Two hits without buster → `cf-cache-status: HIT` on the 2nd. Two different `filter.*` values → distinct bodies (distinct cache keys).

## Diff

`+15 / -3` across the loader and the app config.