### PR TITLE
fix(vtex): gate vtex_segment cookie on isCacheableSegment

### DIFF
--- a/vtex/middleware.ts
+++ b/vtex/middleware.ts
@@ -7,6 +7,7 @@ import {
 } from "./utils/intelligentSearch.ts";
 import {
   getSegmentFromBag,
+  hasUTM,
   isCacheableSegment,
   setSegmentBag,
 } from "./utils/segment.ts";
@@ -34,7 +35,13 @@ export const middleware = (
       cookies[`${VTEX_ID_CLIENT_COOKIE}_${ctx.account}`],
   );
 
-  const cacheable = isCacheableSegment(ctx) && !isLoggedIn;
+  // UTM can drive VTEX promotions and change price, so a UTM-carrying request
+  // is only cacheable when the store opts into removeUTMFromCacheKey (the same
+  // flag the product loaders use to strip UTM from their cache key). Channel is
+  // left cacheable (CDN varies by VTEXSC), matching isCacheableSegment.
+  const utmBlocksCache = !ctx.advancedConfigs?.removeUTMFromCacheKey &&
+    hasUTM(ctx);
+  const cacheable = isCacheableSegment(ctx) && !utmBlocksCache && !isLoggedIn;
 
   if (cacheable) {
     ctx.bag.set(PAGE_CACHE_ALLOWED_KEY, true);

--- a/vtex/middleware.ts
+++ b/vtex/middleware.ts
@@ -7,7 +7,6 @@ import {
 } from "./utils/intelligentSearch.ts";
 import {
   getSegmentFromBag,
-  hasUTM,
   isCacheableSegment,
   setSegmentBag,
 } from "./utils/segment.ts";
@@ -35,13 +34,7 @@ export const middleware = (
       cookies[`${VTEX_ID_CLIENT_COOKIE}_${ctx.account}`],
   );
 
-  // UTM can drive VTEX promotions and change price, so a UTM-carrying request
-  // is only cacheable when the store opts into removeUTMFromCacheKey (the same
-  // flag the product loaders use to strip UTM from their cache key). Channel is
-  // left cacheable (CDN varies by VTEXSC), matching isCacheableSegment.
-  const utmBlocksCache = !ctx.advancedConfigs?.removeUTMFromCacheKey &&
-    hasUTM(ctx);
-  const cacheable = isCacheableSegment(ctx) && !utmBlocksCache && !isLoggedIn;
+  const cacheable = isCacheableSegment(ctx) && !isLoggedIn;
 
   if (cacheable) {
     ctx.bag.set(PAGE_CACHE_ALLOWED_KEY, true);

--- a/vtex/utils/extensions/simulation.ts
+++ b/vtex/utils/extensions/simulation.ts
@@ -30,10 +30,17 @@ const doSimulate = (items: {
     },
   } = getSegmentFromBag(ctx);
 
+  // When removeUTMFromCacheKey is on the store has declared UTM does not
+  // affect content/price, so the page is cached with UTM stripped from the
+  // cache key. Feeding UTM into the simulation here would let a UTM-triggered
+  // promotion change the price and get cached generically, so skip it to keep
+  // the simulation consistent with the caching contract.
+  const utmInKey = !ctx.advancedConfigs?.removeUTMFromCacheKey;
+
   const md = new Map<string, unknown>();
-  utm_campaign && md.set("utmCampaign", utm_campaign);
-  utm_source && md.set("utmSource", utm_source);
-  utmi_campaign && md.set("utmiCampaign", utmi_campaign);
+  utmInKey && utm_campaign && md.set("utmCampaign", utm_campaign);
+  utmInKey && utm_source && md.set("utmSource", utm_source);
+  utmInKey && utmi_campaign && md.set("utmiCampaign", utmi_campaign);
   campaigns && md.set("campaigns", [{ id: campaigns }]);
   const marketingData = md.size > 0
     ? Object.fromEntries(md.entries())

--- a/vtex/utils/segment.ts
+++ b/vtex/utils/segment.ts
@@ -70,16 +70,6 @@ export const isCacheableSegment = (ctx: AppContext) => {
   return !campaigns && !priceTables && !regionId;
 };
 
-/** Whether the segment carries any UTM/UTMI marketing param. */
-export const hasUTM = (ctx: AppContext): boolean => {
-  const p = getSegmentFromBag(ctx)?.payload;
-  if (!p) return false;
-  return Boolean(
-    p.utm_campaign || p.utm_source || p.utm_medium ||
-      p.utmi_campaign || p.utmi_page || p.utmi_part,
-  );
-};
-
 const setSegmentInBag = (ctx: AppContext, data: WrappedSegment) =>
   ctx?.bag?.set(SEGMENT, data);
 

--- a/vtex/utils/segment.ts
+++ b/vtex/utils/segment.ts
@@ -260,11 +260,19 @@ export const setSegmentBag = (
     });
   }
 
-  // Only set vtex_segment on non-cacheable responses so cacheable ones (incl.
-  // UTM-only and non-default sales channel) stay Set-Cookie-free and CDN-
-  // cacheable. Mirrors the middleware's cacheability check (isCacheableSegment)
-  // so the cookie gate and the Cache-Control decision never disagree.
-  if (vtex_segment !== token && !isCacheableSegment(ctx)) {
+  // The vtex_segment cookie disqualifies CDN caching (Cloudflare skips
+  // Set-Cookie responses). Gate its emission on whether the response is
+  // cacheable. UTM can drive VTEX promotions and change price, so treating
+  // UTM-only requests as cacheable is only safe when the store opts in via
+  // removeUTMFromCacheKey (the same flag the loaders use to strip UTM from
+  // their cache key). With the flag on we use isCacheableSegment (ignores
+  // UTM); otherwise we keep isAnonymous, which keeps UTM-carrying requests
+  // non-cacheable and cookie-bearing.
+  const nonCacheable = ctx.advancedConfigs?.removeUTMFromCacheKey
+    ? !isCacheableSegment(ctx)
+    : !isAnonymous(ctx);
+
+  if (vtex_segment !== token && nonCacheable) {
     setCookie(ctx.response.headers, {
       value: token,
       name: SEGMENT_COOKIE_NAME,

--- a/vtex/utils/segment.ts
+++ b/vtex/utils/segment.ts
@@ -70,6 +70,16 @@ export const isCacheableSegment = (ctx: AppContext) => {
   return !campaigns && !priceTables && !regionId;
 };
 
+/** Whether the segment carries any UTM/UTMI marketing param. */
+export const hasUTM = (ctx: AppContext): boolean => {
+  const p = getSegmentFromBag(ctx)?.payload;
+  if (!p) return false;
+  return Boolean(
+    p.utm_campaign || p.utm_source || p.utm_medium ||
+      p.utmi_campaign || p.utmi_page || p.utmi_part,
+  );
+};
+
 const setSegmentInBag = (ctx: AppContext, data: WrappedSegment) =>
   ctx?.bag?.set(SEGMENT, data);
 

--- a/vtex/utils/segment.ts
+++ b/vtex/utils/segment.ts
@@ -260,9 +260,11 @@ export const setSegmentBag = (
     });
   }
 
-  // Only set vtex_segment when the channel is non-default so that default-SC
-  // responses remain cacheable by the CDN without a Set-Cookie header.
-  if (vtex_segment !== token && !isAnonymous(ctx)) {
+  // Only set vtex_segment on non-cacheable responses so cacheable ones (incl.
+  // UTM-only and non-default sales channel) stay Set-Cookie-free and CDN-
+  // cacheable. Mirrors the middleware's cacheability check (isCacheableSegment)
+  // so the cookie gate and the Cache-Control decision never disagree.
+  if (vtex_segment !== token && !isCacheableSegment(ctx)) {
     setCookie(ctx.response.headers, {
       value: token,
       name: SEGMENT_COOKIE_NAME,


### PR DESCRIPTION
## Problem

`Set-Cookie: vtex_segment` was emitted whenever `isAnonymous()` returned `false`, and `isAnonymous` treats any request carrying `utm_source`/`utm_campaign`/`utmi_campaign` as non-anonymous. `vtex_segment` is a non-framework ("foreign") cookie, so deco's `applyPageCacheDecision` forces `no-store` whenever it is set. Landing pages arriving with UTM params therefore stopped being cacheable — origin dropped from `public, max-age=300` to `no-store`.

## Fix

Two changes, both gated on the existing `advancedConfigs.removeUTMFromCacheKey` flag — the same flag the product loaders already use to strip UTM from their cache key (#1517). The flag is the store's explicit contract: "UTM does not affect content/price here."

**1. Cookie gate (`utils/segment.ts`)**
- flag on → gate on `!isCacheableSegment(ctx)` (ignores UTM). UTM-only requests emit no cookie → stay cacheable.
- flag off (default) → keep `!isAnonymous(ctx)`. UTM-carrying requests stay cookie-bearing → `no-store`. Identical to `main`.

**2. Price simulation (`utils/extensions/simulation.ts`)**
- flag on → do not feed UTM into `marketingData`. Since the page is cached with UTM stripped from the key, a UTM-triggered promotion computed here would otherwise be cached and served generically. Campaigns / priceTables / regionId / channel are still simulated.
- flag off → unchanged (UTM still drives the simulation, and those pages are not cached anyway).

The segment payload/token are untouched — UTM still reaches the VTEX API where relevant and stays on the client (querystring/JS) for GA/pixel. Channel continuity rides on `VTEXSC`. `isAnonymous`, `isCacheableSegment` and the middleware are unchanged.

## Behavior

| request | flag off (default) | flag on |
|---|---|---|
| UTM-only, default channel | cookie + `no-store` (= main) | no cookie → `public, max-age=300`, UTM out of cache key & simulation |
| campaigns / priceTables / regionId | cookie + `no-store` | cookie + `no-store` |
| logged in / channelPrivacy private | cookie + `no-store` | cookie + `no-store` |

With the flag off, behavior is identical to `main`. Enabling the flag is the store's assertion that UTM is analytics-only; the simulation gate makes that assertion airtight against a later UTM-driven promotion being cached generically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simulation requests by omitting UTM values when configured to exclude them from cache keys.
  * Adjusted segment cookie handling to better preserve CDN caching for cacheable requests.
  * Ensured non-cacheable requests continue receiving the appropriate segment cookie.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->