### PR TITLE
fix(blog): emit valid schema.org JSON-LD in blog SEO sections

### DIFF
--- a/blog/mod.ts
+++ b/blog/mod.ts
@@ -1,6 +1,7 @@
 import manifest, { Manifest } from "./manifest.gen.ts";
 import { PreviewContainer } from "../utils/preview.tsx";
 import { type App, type FnContext } from "@deco/deco";
+import type { Publisher } from "./types.ts";
 export type State = {
   /**
    * @title Category Slug
@@ -14,6 +15,17 @@ export type State = {
    * @example /blog/:category/:slug
    */
   pageSlug?: string;
+  /**
+   * @title Canonical Base URL
+   * @description Overrides the origin of the url/mainEntityOfPage emitted in the JSON-LD by the SEO sections, which otherwise use the request host.
+   * @example https://www.mysite.com
+   */
+  canonicalBaseUrl?: string;
+  /**
+   * @title Publisher
+   * @description Emitted as the publisher of the blog posts in the JSON-LD.
+   */
+  publisher?: Publisher;
 };
 export type AppContext = FnContext<State, Manifest>;
 /**

--- a/blog/sections/Seo/SeoBlogPost.tsx
+++ b/blog/sections/Seo/SeoBlogPost.tsx
@@ -5,7 +5,11 @@ import {
 } from "../../../website/components/Seo.tsx";
 import { BlogPostPage } from "../../types.ts";
 import { AppContext } from "../../mod.ts";
-import { toBlogPosting } from "../../utils/jsonLD.ts";
+import {
+  toBlogPosting,
+  toBreadcrumbList,
+  withCanonicalBase,
+} from "../../utils/jsonLD.ts";
 
 export interface Props {
   /** @title Data Source */
@@ -44,8 +48,16 @@ export function loader(props: Props, req: Request, ctx: AppContext) {
   const canonical = jsonLD?.seo?.canonical ? jsonLD?.seo?.canonical : undefined;
   const noIndexing = !jsonLD || jsonLD.seo?.noIndexing;
 
+  const { canonicalBaseUrl, publisher } = ctx;
+  const pageUrl = withCanonicalBase(canonical ?? req.url, canonicalBaseUrl);
   const jsonLDs = jsonLD?.post
-    ? [toBlogPosting(jsonLD.post, canonical ?? req.url)]
+    ? [
+      toBlogPosting(jsonLD.post, pageUrl, publisher),
+      toBreadcrumbList(pageUrl, {
+        currentName: jsonLD.post.title,
+        categories: jsonLD.post.categories,
+      }),
+    ]
     : [];
 
   return {

--- a/blog/sections/Seo/SeoBlogPost.tsx
+++ b/blog/sections/Seo/SeoBlogPost.tsx
@@ -45,11 +45,13 @@ export function loader(props: Props, req: Request, ctx: AppContext) {
 
   const image = jsonLD?.post?.seo?.image || jsonLD?.seo?.image ||
     jsonLD?.post?.image;
-  const canonical = jsonLD?.seo?.canonical ? jsonLD?.seo?.canonical : undefined;
+  const { canonicalBaseUrl, publisher } = ctx;
+  const canonical = jsonLD?.seo?.canonical
+    ? withCanonicalBase(jsonLD.seo.canonical, canonicalBaseUrl)
+    : undefined;
   const noIndexing = !jsonLD || jsonLD.seo?.noIndexing;
 
-  const { canonicalBaseUrl, publisher } = ctx;
-  const pageUrl = withCanonicalBase(canonical ?? req.url, canonicalBaseUrl);
+  const pageUrl = canonical ?? withCanonicalBase(req.url, canonicalBaseUrl);
   const jsonLDs = jsonLD?.post
     ? [
       toBlogPosting(jsonLD.post, pageUrl, publisher),

--- a/blog/sections/Seo/SeoBlogPost.tsx
+++ b/blog/sections/Seo/SeoBlogPost.tsx
@@ -5,6 +5,7 @@ import {
 } from "../../../website/components/Seo.tsx";
 import { BlogPostPage } from "../../types.ts";
 import { AppContext } from "../../mod.ts";
+import { toBlogPosting } from "../../utils/jsonLD.ts";
 
 export interface Props {
   /** @title Data Source */
@@ -16,7 +17,7 @@ export interface Props {
 }
 
 /** @title Blog Post details */
-export function loader(props: Props, _req: Request, ctx: AppContext) {
+export function loader(props: Props, req: Request, ctx: AppContext) {
   const rawSeo = (ctx as unknown as { seo: Record<string, unknown> }).seo ?? {};
   const titleTemplate = typeof rawSeo.titleTemplate === "string"
     ? rawSeo.titleTemplate
@@ -43,11 +44,9 @@ export function loader(props: Props, _req: Request, ctx: AppContext) {
   const canonical = jsonLD?.seo?.canonical ? jsonLD?.seo?.canonical : undefined;
   const noIndexing = !jsonLD || jsonLD.seo?.noIndexing;
 
-  // Some HTML can break the meta tag
-  const jsonLDWithoutContent = {
-    ...jsonLD,
-    post: { ...jsonLD?.post, content: undefined },
-  };
+  const jsonLDs = jsonLD?.post
+    ? [toBlogPosting(jsonLD.post, canonical ?? req.url)]
+    : [];
 
   return {
     ...seoSiteProps,
@@ -56,7 +55,7 @@ export function loader(props: Props, _req: Request, ctx: AppContext) {
     image,
     canonical,
     noIndexing,
-    jsonLDs: [jsonLDWithoutContent],
+    jsonLDs,
   };
 }
 

--- a/blog/sections/Seo/SeoBlogPost.tsx
+++ b/blog/sections/Seo/SeoBlogPost.tsx
@@ -46,8 +46,12 @@ export function loader(props: Props, req: Request, ctx: AppContext) {
   const image = jsonLD?.post?.seo?.image || jsonLD?.seo?.image ||
     jsonLD?.post?.image;
   const { canonicalBaseUrl, publisher } = ctx;
+  // Configured canonicals may be relative; resolve against the request URL
   const canonical = jsonLD?.seo?.canonical
-    ? withCanonicalBase(jsonLD.seo.canonical, canonicalBaseUrl)
+    ? withCanonicalBase(
+      new URL(jsonLD.seo.canonical, req.url).href,
+      canonicalBaseUrl,
+    )
     : undefined;
   const noIndexing = !jsonLD || jsonLD.seo?.noIndexing;
 

--- a/blog/sections/Seo/SeoBlogPostListing.tsx
+++ b/blog/sections/Seo/SeoBlogPostListing.tsx
@@ -5,6 +5,7 @@ import {
 } from "../../../website/components/Seo.tsx";
 import { BlogPostListingPage } from "../../types.ts";
 import { AppContext } from "../../mod.ts";
+import { toBlogPosting } from "../../utils/jsonLD.ts";
 
 export interface Props {
   /** @title Data Source */
@@ -15,8 +16,8 @@ export interface Props {
   description?: string;
 }
 
-/** @title Blog Post details */
-export function loader(props: Props, _req: Request, ctx: AppContext) {
+/** @title Blog Post listing */
+export function loader(props: Props, req: Request, ctx: AppContext) {
   const rawSeo = (ctx as unknown as { seo: Record<string, unknown> }).seo ?? {};
   const titleTemplate = typeof rawSeo.titleTemplate === "string"
     ? rawSeo.titleTemplate
@@ -41,11 +42,17 @@ export function loader(props: Props, _req: Request, ctx: AppContext) {
   const canonical = jsonLD?.seo?.canonical ? jsonLD?.seo?.canonical : undefined;
   const noIndexing = !jsonLD || jsonLD.seo?.noIndexing;
 
-  // Some HTML can break the meta tag
-  const jsonLDWithoutContent = {
-    ...jsonLD,
-    post: { ...jsonLD?.posts, content: undefined },
-  };
+  const url = canonical ?? req.url;
+  const jsonLDs = jsonLD
+    ? [{
+      "@type": "Blog" as const,
+      ...(title ? { name: title } : {}),
+      ...(description ? { description } : {}),
+      url,
+      mainEntityOfPage: { "@type": "WebPage" as const, "@id": url },
+      blogPost: jsonLD.posts?.map((post) => toBlogPosting(post)) ?? [],
+    }]
+    : [];
 
   return {
     ...seoSiteProps,
@@ -53,7 +60,7 @@ export function loader(props: Props, _req: Request, ctx: AppContext) {
     description,
     canonical,
     noIndexing,
-    jsonLDs: [jsonLDWithoutContent],
+    jsonLDs,
   };
 }
 

--- a/blog/sections/Seo/SeoBlogPostListing.tsx
+++ b/blog/sections/Seo/SeoBlogPostListing.tsx
@@ -45,8 +45,12 @@ export function loader(props: Props, req: Request, ctx: AppContext) {
   );
 
   const { canonicalBaseUrl, publisher } = ctx;
+  // Configured canonicals may be relative; resolve against the request URL
   const canonical = jsonLD?.seo?.canonical
-    ? withCanonicalBase(jsonLD.seo.canonical, canonicalBaseUrl)
+    ? withCanonicalBase(
+      new URL(jsonLD.seo.canonical, req.url).href,
+      canonicalBaseUrl,
+    )
     : undefined;
   const noIndexing = !jsonLD || jsonLD.seo?.noIndexing;
 

--- a/blog/sections/Seo/SeoBlogPostListing.tsx
+++ b/blog/sections/Seo/SeoBlogPostListing.tsx
@@ -44,11 +44,13 @@ export function loader(props: Props, req: Request, ctx: AppContext) {
     descriptionProp || jsonLD?.seo?.description || "",
   );
 
-  const canonical = jsonLD?.seo?.canonical ? jsonLD?.seo?.canonical : undefined;
+  const { canonicalBaseUrl, publisher } = ctx;
+  const canonical = jsonLD?.seo?.canonical
+    ? withCanonicalBase(jsonLD.seo.canonical, canonicalBaseUrl)
+    : undefined;
   const noIndexing = !jsonLD || jsonLD.seo?.noIndexing;
 
-  const { canonicalBaseUrl, publisher } = ctx;
-  const url = withCanonicalBase(canonical ?? req.url, canonicalBaseUrl);
+  const url = canonical ?? withCanonicalBase(req.url, canonicalBaseUrl);
   const jsonLDs = jsonLD
     ? [
       {

--- a/blog/sections/Seo/SeoBlogPostListing.tsx
+++ b/blog/sections/Seo/SeoBlogPostListing.tsx
@@ -5,7 +5,12 @@ import {
 } from "../../../website/components/Seo.tsx";
 import { BlogPostListingPage } from "../../types.ts";
 import { AppContext } from "../../mod.ts";
-import { toBlogPosting } from "../../utils/jsonLD.ts";
+import {
+  toBlogPosting,
+  toBreadcrumbList,
+  toOrganization,
+  withCanonicalBase,
+} from "../../utils/jsonLD.ts";
 
 export interface Props {
   /** @title Data Source */
@@ -42,16 +47,24 @@ export function loader(props: Props, req: Request, ctx: AppContext) {
   const canonical = jsonLD?.seo?.canonical ? jsonLD?.seo?.canonical : undefined;
   const noIndexing = !jsonLD || jsonLD.seo?.noIndexing;
 
-  const url = canonical ?? req.url;
+  const { canonicalBaseUrl, publisher } = ctx;
+  const url = withCanonicalBase(canonical ?? req.url, canonicalBaseUrl);
   const jsonLDs = jsonLD
-    ? [{
-      "@type": "Blog" as const,
-      ...(title ? { name: title } : {}),
-      ...(description ? { description } : {}),
-      url,
-      mainEntityOfPage: { "@type": "WebPage" as const, "@id": url },
-      blogPost: jsonLD.posts?.map((post) => toBlogPosting(post)) ?? [],
-    }]
+    ? [
+      {
+        "@type": "Blog" as const,
+        ...(title ? { name: title } : {}),
+        ...(description ? { description } : {}),
+        url,
+        mainEntityOfPage: { "@type": "WebPage" as const, "@id": url },
+        ...(publisher?.name ? { publisher: toOrganization(publisher) } : {}),
+        blogPost: jsonLD.posts?.map((post) => toBlogPosting(post)) ?? [],
+      },
+      toBreadcrumbList(url, {
+        currentName: jsonLD.category?.name || title || undefined,
+        categories: jsonLD.categories ?? undefined,
+      }),
+    ]
     : [];
 
   return {

--- a/blog/types.ts
+++ b/blog/types.ts
@@ -51,6 +51,12 @@ export interface BlogPost {
    * @format date
    */
   date: string;
+  /**
+   * @title Modified date
+   * @format date
+   * @description Date of the last relevant content update. Emitted as dateModified in the JSON-LD.
+   */
+  dateModified?: string;
   slug: string;
   /**
    * @title Post Content
@@ -102,6 +108,14 @@ export interface Seo {
   image?: ImageWidget;
   canonical?: string;
   noIndexing?: boolean;
+}
+
+/** @titleBy name */
+export interface Publisher {
+  name: string;
+  /** @title Logo */
+  logo?: ImageWidget;
+  url?: string;
 }
 
 export interface BlogPostPage {

--- a/blog/types.ts
+++ b/blog/types.ts
@@ -9,6 +9,12 @@ import { type Section } from "@deco/deco/blocks";
 export interface Author {
   name: string;
   email: string;
+  /**
+   * @title Type
+   * @description Whether the author is a person or an organization. Emitted as the author @type in the JSON-LD. Defaults to Person.
+   * @default Person
+   */
+  type?: "Person" | "Organization";
   avatar?: ImageWidget;
   jobTitle?: string;
   company?: string;

--- a/blog/utils/jsonLD.ts
+++ b/blog/utils/jsonLD.ts
@@ -1,0 +1,42 @@
+import { Author, BlogPost } from "../types.ts";
+
+const toPerson = (author: Author) => ({
+  "@type": "Person" as const,
+  name: author.name,
+  ...(author.jobTitle ? { jobTitle: author.jobTitle } : {}),
+  ...(author.company
+    ? { worksFor: { "@type": "Organization" as const, name: author.company } }
+    : {}),
+});
+
+/**
+ * Maps a BlogPost to a schema.org BlogPosting node, following
+ * https://developers.google.com/search/docs/appearance/structured-data/article
+ *
+ * The "@context" is intentionally omitted: the Seo component adds it when
+ * serializing the top-level JSON-LD object.
+ */
+export const toBlogPosting = (post: BlogPost, url?: string) => {
+  const image = post.seo?.image || post.image;
+  const categories = post.categories
+    ?.map((category) => category.name)
+    .filter(Boolean);
+
+  return {
+    "@type": "BlogPosting" as const,
+    headline: post.title,
+    ...(post.excerpt ? { description: post.excerpt } : {}),
+    ...(image ? { image: [image] } : {}),
+    ...(post.date ? { datePublished: post.date } : {}),
+    ...(post.authors?.length ? { author: post.authors.map(toPerson) } : {}),
+    ...(categories?.length ? { articleSection: categories } : {}),
+    ...(post.readTime ? { timeRequired: `PT${post.readTime}M` } : {}),
+    ...(url
+      ? { url, mainEntityOfPage: { "@type": "WebPage" as const, "@id": url } }
+      : {}),
+    ...(post.aggregateRating ? { aggregateRating: post.aggregateRating } : {}),
+    ...(post.interactionStatistic
+      ? { interactionStatistic: post.interactionStatistic }
+      : {}),
+  };
+};

--- a/blog/utils/jsonLD.ts
+++ b/blog/utils/jsonLD.ts
@@ -1,4 +1,4 @@
-import { Author, BlogPost } from "../types.ts";
+import { Author, BlogPost, Category, Publisher } from "../types.ts";
 
 const toPerson = (author: Author) => ({
   "@type": "Person" as const,
@@ -9,6 +9,23 @@ const toPerson = (author: Author) => ({
     : {}),
 });
 
+export const toOrganization = (publisher: Publisher) => ({
+  "@type": "Organization" as const,
+  name: publisher.name,
+  ...(publisher.url ? { url: publisher.url } : {}),
+  ...(publisher.logo
+    ? { logo: { "@type": "ImageObject" as const, url: publisher.logo } }
+    : {}),
+});
+
+/** Replaces the origin of an absolute URL, keeping only its pathname. */
+export const withCanonicalBase = (url: string, canonicalBaseUrl?: string) => {
+  if (!canonicalBaseUrl) {
+    return url;
+  }
+  return new URL(new URL(url).pathname, canonicalBaseUrl).href;
+};
+
 /**
  * Maps a BlogPost to a schema.org BlogPosting node, following
  * https://developers.google.com/search/docs/appearance/structured-data/article
@@ -16,11 +33,28 @@ const toPerson = (author: Author) => ({
  * The "@context" is intentionally omitted: the Seo component adds it when
  * serializing the top-level JSON-LD object.
  */
-export const toBlogPosting = (post: BlogPost, url?: string) => {
+export const toBlogPosting = (
+  post: BlogPost,
+  url?: string,
+  publisher?: Publisher,
+) => {
   const image = post.seo?.image || post.image;
   const categories = post.categories
     ?.map((category) => category.name)
     .filter(Boolean);
+
+  // AggregateRating requires ratingValue and ratingCount/reviewCount;
+  // InteractionCounter requires userInteractionCount. Posts may carry empty
+  // {"@type": ...} stubs, which are invalid in the Rich Results Test.
+  const aggregateRating = post.aggregateRating?.ratingValue != null &&
+      (post.aggregateRating.ratingCount != null ||
+        post.aggregateRating.reviewCount != null)
+    ? post.aggregateRating
+    : undefined;
+  const interactionStatistic =
+    post.interactionStatistic?.userInteractionCount != null
+      ? post.interactionStatistic
+      : undefined;
 
   return {
     "@type": "BlogPosting" as const,
@@ -28,15 +62,55 @@ export const toBlogPosting = (post: BlogPost, url?: string) => {
     ...(post.excerpt ? { description: post.excerpt } : {}),
     ...(image ? { image: [image] } : {}),
     ...(post.date ? { datePublished: post.date } : {}),
+    ...(post.dateModified ? { dateModified: post.dateModified } : {}),
     ...(post.authors?.length ? { author: post.authors.map(toPerson) } : {}),
+    ...(publisher?.name ? { publisher: toOrganization(publisher) } : {}),
     ...(categories?.length ? { articleSection: categories } : {}),
     ...(post.readTime ? { timeRequired: `PT${post.readTime}M` } : {}),
     ...(url
       ? { url, mainEntityOfPage: { "@type": "WebPage" as const, "@id": url } }
       : {}),
-    ...(post.aggregateRating ? { aggregateRating: post.aggregateRating } : {}),
-    ...(post.interactionStatistic
-      ? { interactionStatistic: post.interactionStatistic }
-      : {}),
+    ...(aggregateRating ? { aggregateRating } : {}),
+    ...(interactionStatistic ? { interactionStatistic } : {}),
   };
+};
+
+const humanize = (slug: string) =>
+  decodeURIComponent(slug)
+    .replace(/[-_]+/g, " ")
+    .replace(/^./, (char) => char.toUpperCase());
+
+/**
+ * Builds a schema.org BreadcrumbList from the pathname of the given absolute
+ * URL. Intermediate segments resolve their names against the known categories
+ * (falling back to a humanized slug) and link to absolute URLs; the last item
+ * uses the real page name and omits "item", as allowed by Google.
+ */
+export const toBreadcrumbList = (
+  url: string,
+  { currentName, categories }: {
+    currentName?: string;
+    categories?: Category[];
+  } = {},
+) => {
+  const { origin, pathname } = new URL(url);
+  const segments = pathname.split("/").filter(Boolean);
+
+  const nameOf = (segment: string) =>
+    categories?.find((category) => category.slug === segment)?.name ??
+      humanize(segment);
+
+  const itemListElement = segments.map((segment, index) => {
+    const isLast = index === segments.length - 1;
+    return {
+      "@type": "ListItem" as const,
+      position: index + 1,
+      name: isLast ? currentName || nameOf(segment) : nameOf(segment),
+      ...(isLast
+        ? {}
+        : { item: `${origin}/${segments.slice(0, index + 1).join("/")}` }),
+    };
+  });
+
+  return { "@type": "BreadcrumbList" as const, itemListElement };
 };

--- a/blog/utils/jsonLD.ts
+++ b/blog/utils/jsonLD.ts
@@ -24,12 +24,16 @@ export const toOrganization = (publisher: Publisher) => ({
     : {}),
 });
 
-/** Replaces the origin of an absolute URL, keeping only its pathname. */
+/**
+ * Replaces the origin of a URL, keeping path, query and hash. Relative URLs
+ * are resolved against the canonical base.
+ */
 export const withCanonicalBase = (url: string, canonicalBaseUrl?: string) => {
   if (!canonicalBaseUrl) {
     return url;
   }
-  return new URL(new URL(url).pathname, canonicalBaseUrl).href;
+  const { pathname, search, hash } = new URL(url, canonicalBaseUrl);
+  return new URL(pathname + search + hash, canonicalBaseUrl).href;
 };
 
 /**
@@ -72,7 +76,9 @@ export const toBlogPosting = (
     ...(post.authors?.length ? { author: post.authors.map(toAuthor) } : {}),
     ...(publisher?.name ? { publisher: toOrganization(publisher) } : {}),
     ...(categories?.length ? { articleSection: categories } : {}),
-    ...(post.readTime ? { timeRequired: `PT${post.readTime}M` } : {}),
+    ...(post.readTime && post.readTime > 0 && Number.isFinite(post.readTime)
+      ? { timeRequired: `PT${post.readTime}M` }
+      : {}),
     ...(url
       ? { url, mainEntityOfPage: { "@type": "WebPage" as const, "@id": url } }
       : {}),

--- a/blog/utils/jsonLD.ts
+++ b/blog/utils/jsonLD.ts
@@ -1,13 +1,19 @@
 import { Author, BlogPost, Category, Publisher } from "../types.ts";
 
-const toPerson = (author: Author) => ({
-  "@type": "Person" as const,
-  name: author.name,
-  ...(author.jobTitle ? { jobTitle: author.jobTitle } : {}),
-  ...(author.company
-    ? { worksFor: { "@type": "Organization" as const, name: author.company } }
-    : {}),
-});
+const toAuthor = (author: Author) => {
+  const type = author.type ?? "Person";
+  return {
+    "@type": type,
+    name: author.name,
+    // jobTitle and worksFor are Person-only properties
+    ...(type === "Person" && author.jobTitle
+      ? { jobTitle: author.jobTitle }
+      : {}),
+    ...(type === "Person" && author.company
+      ? { worksFor: { "@type": "Organization" as const, name: author.company } }
+      : {}),
+  };
+};
 
 export const toOrganization = (publisher: Publisher) => ({
   "@type": "Organization" as const,
@@ -63,7 +69,7 @@ export const toBlogPosting = (
     ...(image ? { image: [image] } : {}),
     ...(post.date ? { datePublished: post.date } : {}),
     ...(post.dateModified ? { dateModified: post.dateModified } : {}),
-    ...(post.authors?.length ? { author: post.authors.map(toPerson) } : {}),
+    ...(post.authors?.length ? { author: post.authors.map(toAuthor) } : {}),
     ...(publisher?.name ? { publisher: toOrganization(publisher) } : {}),
     ...(categories?.length ? { articleSection: categories } : {}),
     ...(post.readTime ? { timeRequired: `PT${post.readTime}M` } : {}),

--- a/website/components/Seo.tsx
+++ b/website/components/Seo.tsx
@@ -140,7 +140,12 @@ function Component({
               "@context": "https://schema.org",
               // @ts-expect-error Trust me, I'm an engineer
               ...json,
-            }),
+            })
+              // "<" would allow a "</script>" in the data to break out of the
+              // tag; the unicode escapes stay equivalent when parsed as JSON
+              .replace(/</g, "\\u003c")
+              .replace(/\u2028/g, "\\u2028")
+              .replace(/\u2029/g, "\\u2029"),
           }}
         />
       ))}


### PR DESCRIPTION
## Problem

`blog/sections/Seo/SeoBlogPost.tsx` and `blog/sections/Seo/SeoBlogPostListing.tsx` were serializing the raw page object straight into the `<script type="application/ld+json">` tag:

- **SeoBlogPost** emitted `{"@type": "BlogPostPage", post: {...}, seo: {...}}` — `BlogPostPage` is not a schema.org type and none of the nested fields (`title`, `excerpt`, `slug`, ...) are recognized properties, so Google ignored the markup entirely.
- **SeoBlogPostListing** was worse: no `@type` at all, plus a `{ ...jsonLD?.posts }` spread of an **array** into an object, producing garbage like `{"0": {...}, "1": {...}}`.

## Fix

Following [Google's Article structured data guidelines](https://developers.google.com/search/docs/appearance/structured-data/article):

- New `blog/utils/jsonLD.ts` with a `toBlogPosting` helper mapping a `BlogPost` to a `BlogPosting` node: `headline`, `description`, `image`, `datePublished`, `dateModified`, `author` (as `Person` with `jobTitle`/`worksFor` when available), `publisher`, `articleSection`, `timeRequired` (ISO 8601 duration), `url`/`mainEntityOfPage`, and `aggregateRating`/`interactionStatistic` when present. Post `content` (raw HTML) is excluded by construction, so the old strip-content workaround is gone.
- **SeoBlogPost** now emits a `BlogPosting` plus a `BreadcrumbList`, using the canonical URL (falling back to the request URL) as `mainEntityOfPage`.
- **SeoBlogPostListing** now emits a `Blog` node with `name`, `description`, `url`, `publisher` and a `blogPost` array of `BlogPosting` items, plus a `BreadcrumbList`.

The top-level `"@context": "https://schema.org"` is added by `website/components/Seo.tsx` at serialization time, as before.

### Validity guards

`AggregateRating` requires `ratingValue` + `ratingCount`/`reviewCount`, and `InteractionCounter` requires `userInteractionCount`. Posts carrying empty `{"@type": ...}` stubs would fail the Rich Results Test, so these keys are only emitted when the required data is present.

### New app/type fields

- `BlogPost.dateModified` (optional, `@format date`) → emitted as `dateModified` to signal content freshness.
- Blog app state `publisher` (`{ name, logo?, url? }`) → emitted as an `Organization` node on `BlogPosting` (post page) and `Blog` (listing).
- Blog app state `canonicalBaseUrl` → overrides the **origin** of `url`/`mainEntityOfPage`, which are otherwise built from the request host (useful behind proxies/multiple domains).

### BreadcrumbList

Derived from the canonical pathname. Intermediate segments resolve real category names when known (falling back to humanized slugs) and always carry absolute `item` URLs; the last item uses the real page name (post title / category name) and omits `item`, as allowed by Google:

```json
{
  "@type": "BreadcrumbList",
  "itemListElement": [
    { "@type": "ListItem", "position": 1, "name": "Inspira", "item": "https://loja.example.com.br/inspira" },
    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://loja.example.com.br/inspira/blog" },
    { "@type": "ListItem", "position": 3, "name": "Dicas", "item": "https://loja.example.com.br/inspira/blog/dicas" },
    { "@type": "ListItem", "position": 4, "name": "Mitos e verdades sobre o uso do micro-ondas no dia a dia" }
  ]
}
```

Sample `BlogPosting` output for a post page:

```json
{
  "@context": "https://schema.org",
  "@type": "BlogPosting",
  "headline": "Mitos e verdades sobre o uso do micro-ondas no dia a dia",
  "description": "Resumo",
  "image": ["https://cdn.site.com/img.png"],
  "datePublished": "2026-06-01",
  "dateModified": "2026-07-10",
  "author": [{ "@type": "Person", "name": "Ana" }],
  "publisher": { "@type": "Organization", "name": "Acme", "url": "https://loja.example.com.br", "logo": { "@type": "ImageObject", "url": "https://cdn.site.com/logo.png" } },
  "articleSection": ["Dicas"],
  "url": "https://loja.example.com.br/inspira/blog/dicas/mitos-e-verdades",
  "mainEntityOfPage": { "@type": "WebPage", "@id": "https://loja.example.com.br/inspira/blog/dicas/mitos-e-verdades" }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved blog post and listing SEO metadata with richer structured data, including authors, publishers, categories, dates, ratings, interactions, and breadcrumbs.
  * Added support for canonical URL configuration and publisher details.
  * Added author type and post modification date metadata.

* **Bug Fixes**
  * Prevented unsafe characters in structured data from breaking or escaping SEO scripts.
  * Improved handling of incomplete rating and interaction data to maintain valid rich results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->