### PR TITLE
fix(blog): strip query string and hash from SEO canonical and JSON-LD URLs

### DIFF
--- a/blog/utils/jsonLD.ts
+++ b/blog/utils/jsonLD.ts
@@ -25,15 +25,22 @@ export const toOrganization = (publisher: Publisher) => ({
 });
 
 /**
- * Replaces the origin of a URL, keeping path, query and hash. Relative URLs
- * are resolved against the canonical base.
+ * Normalizes a page URL for SEO use (canonical and JSON-LD): strips the query
+ * string and hash, keeping only origin + pathname, and replaces the origin
+ * with the canonical base's when one is configured. Relative URLs are
+ * resolved against the canonical base; without a base, relative URLs are
+ * returned unchanged.
  */
 export const withCanonicalBase = (url: string, canonicalBaseUrl?: string) => {
   if (!canonicalBaseUrl) {
-    return url;
+    if (!URL.canParse(url)) {
+      return url;
+    }
+    const { origin, pathname } = new URL(url);
+    return origin + pathname;
   }
-  const { pathname, search, hash } = new URL(url, canonicalBaseUrl);
-  return new URL(pathname + search + hash, canonicalBaseUrl).href;
+  const { pathname } = new URL(url, canonicalBaseUrl);
+  return new URL(pathname, canonicalBaseUrl).href;
 };
 
 /**


### PR DESCRIPTION
## Problem

The blog SEO sections (`blog/sections/Seo/SeoBlogPost.tsx` and `blog/sections/Seo/SeoBlogPostListing.tsx`) build the page URL used for the `<link rel="canonical">`, the `url`/`mainEntityOfPage` of the `BlogPosting`/`Blog` JSON-LD nodes, and the `BreadcrumbList` items. A request arriving with `?utm_source=x`, `?page=2` or a `#hash` leaked those into every emitted URL, producing dirty canonicals and JSON-LD URLs that vary between requests for the same page.

This happened in both paths: with `canonicalBaseUrl` configured (`withCanonicalBase` preserved `search + hash`) and without it (the request URL passed through untouched).

## Fix

Normalize in `withCanonicalBase` (`blog/utils/jsonLD.ts`), which every emitted URL flows through: keep only **origin + pathname**, dropping query string and hash in both paths.

Preserved behavior:
- relative canonicals are still resolved against `req.url` in the sections (no exceptions thrown);
- without a base, relative URLs still pass through unchanged (guarded by `URL.canParse`);
- the rest of the JSON-LD (readTime/aggregateRating guards, publisher, BreadcrumbList structure) is untouched.

## Validation

- `deno check`, `deno fmt --check` and `deno lint` pass on the helper and both sections (pre-commit hook also ran the repo-wide check).
- `deno eval` assertions covering:
  - `https://loja.com/blog/post?page=2#top` → `https://loja.com/blog/post` (no base)
  - `https://loja.com/blog/post?page=2#top` + base `https://www.loja.com.br` → `https://www.loja.com.br/blog/post`
  - relative canonical `/blog/dicas` resolved against a `req.url` carrying `?utm_source=x`, with and without base
  - relative URL without base passes through unchanged; clean absolute URLs are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip query strings and hashes from blog SEO URLs so canonicals and JSON-LD stay clean and consistent across requests. Fixes noise from UTM params, pagination, and hash fragments.

- **Bug Fixes**
  - Normalize all SEO URLs via `withCanonicalBase` to origin + pathname; works with or without a base.
  - Applies to `<link rel="canonical">`, JSON-LD `url`/`mainEntityOfPage`, and `BreadcrumbList`; relative URLs without a base pass through unchanged.

<sup>Written for commit 42a147617e010273a9ed91dd060ce50632ef6f18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

