### PR TITLE
fix(website): isolate Lazy fallback-discovery from page cache state

### DIFF
--- a/website/sections/Rendering/Lazy.tsx
+++ b/website/sections/Rendering/Lazy.tsx
@@ -6,6 +6,7 @@ import {
 } from "@deco/deco/blocks";
 import { useContext } from "preact/hooks";
 import { shouldForceRender } from "../../../utils/deferred.ts";
+import { newIsolatedRequestState } from "../../utils/isolatedRequestState.ts";
 import type { AppContext } from "../../mod.ts";
 const useSectionContext = () =>
   useContext<SectionContext | undefined>(SectionCtx);
@@ -83,7 +84,14 @@ export const loader = async (props: Props, req: Request, ctx: AppContext) => {
   const resolveSection = isDeferred<Section>(section)
     ? RequestContext.bind({ signal: abortController.signal }, section)
     : () => section;
-  const resolvedSection = await resolveSection({}, {
+  // This resolution only discovers the selected section's loading fallback.
+  // Keep its loaders, matchers and response mutations from affecting the
+  // cache decision of the parent page. The eager partial resolves the section
+  // again with the real request state and remains personalized when needed.
+  const isolatedState = newIsolatedRequestState() as unknown as Parameters<
+    typeof resolveSection
+  >[0];
+  const resolvedSection = await resolveSection(isolatedState, {
     propagateOptions: true,
     hooks: {
       onPropsResolveStart: (resolve, _props, resolver) => {

--- a/website/utils/isolatedRequestState.test.ts
+++ b/website/utils/isolatedRequestState.test.ts
@@ -1,0 +1,30 @@
+import { assertEquals, assertNotStrictEquals } from "@std/assert";
+import { newIsolatedRequestState } from "./isolatedRequestState.ts";
+
+Deno.test("newIsolatedRequestState does not share resolver side effects", () => {
+  const first = newIsolatedRequestState();
+  const second = newIsolatedRequestState();
+
+  first.vary.shouldCache = false;
+  first.vary.push("weather/loaders/temperature.ts", "rio-de-janeiro");
+  first.flags.push({
+    name: "weather",
+    value: true,
+    isSegment: false,
+  });
+  first.response.headers.set("set-cookie", "personalized=true");
+
+  assertNotStrictEquals(first.vary, second.vary);
+  assertNotStrictEquals(first.flags, second.flags);
+  assertNotStrictEquals(first.response, second.response);
+  assertNotStrictEquals(first.bag, second.bag);
+  assertEquals(first.vary.shouldCache, false);
+  assertEquals(
+    first.vary.build(),
+    "rio-de-janeiro,weather/loaders/temperature.ts",
+  );
+  assertEquals(second.vary.shouldCache, true);
+  assertEquals(second.vary.build(), "");
+  assertEquals(second.flags, []);
+  assertEquals(second.response.headers.has("set-cookie"), false);
+});

--- a/website/utils/isolatedRequestState.ts
+++ b/website/utils/isolatedRequestState.ts
@@ -1,0 +1,37 @@
+import type { AppContext } from "../mod.ts";
+
+type IsolatedRequestState = Pick<
+  AppContext,
+  "bag" | "flags" | "response" | "vary"
+>;
+
+/**
+ * Creates request-scoped state for speculative/deferred resolutions.
+ *
+ * Resolvers can mutate cache eligibility, flags, response headers and the
+ * request bag. Those mutations must not leak when the resolved value is used
+ * only to inspect metadata such as a loading fallback.
+ */
+export const newIsolatedRequestState = (): IsolatedRequestState => {
+  const keys: string[] = [];
+  const debugEntries: unknown[] = [];
+
+  return {
+    bag: new WeakMap(),
+    flags: [],
+    response: { headers: new Headers() },
+    vary: {
+      shouldCache: true,
+      push: (...key: string[]) => {
+        keys.push(...key);
+      },
+      build: () => keys.sort().join(),
+      debug: {
+        push: <T>(entry: T) => {
+          debugEntries.push(entry);
+        },
+        build: <T>() => debugEntries as T[],
+      },
+    },
+  };
+};


### PR DESCRIPTION
## Problem

Storefront home pages (e.g. `www.farmrio.com.br/`) were served with
`Cache-Control: no-store` while PLP/PDP cached normally
(`public,max-age=180,stale-while-revalidate=3600`). CDN full-page cache
was fully disabled on the highest-traffic page.

## Root cause

`website/sections/Rendering/Lazy.tsx` defers rendering of its child
section, but its **loader** resolves that child once up front just to
read its `LoadingFallback` and `metadata`:

```ts
const resolvedSection = await resolveSection({}, { ... });
```

The engine resolves a deferred value with `{ ...context, ...partialCtx }`
(`engine/core/mod.ts`). Passing `{}` means the child's whole resolve
subtree runs against the **parent page's** request state — its `vary`,
`flags`, `response` and `bag`. So any deferred section whose loader is
`no-store` (or returns a null cache key) sets `ctx.vary.shouldCache =
false` on the page (`blocks/loader.ts`), and the middleware then writes
`no-store` for the entire page (`runtime/middleware.ts`,
`applyPageCacheDecision`).

A home with ~70 `Lazy` sections only needs **one** of them to touch a
per-user loader (cart, weather, session, …) for the whole page to become
uncacheable — even though that section is deferred and its real render
happens later in a separate partial request.

## Fix

Resolve the fallback against an **isolated** request state
(`newIsolatedRequestState()`), covering exactly the four keys the engine
threads as request state (`bag`, `flags`, `response`, `vary` — see
`runtime/utils.ts`). Speculative mutations during fallback discovery are
discarded. The eager partial still re-resolves the section with the real
request state, so personalized/deferred sections stay personalized.

## Tests

`website/utils/isolatedRequestState.test.ts` asserts two isolated states
don't share `vary`/`flags`/`response`/`bag` and that side effects on one
don't leak to the other. `deno test` passes; `deno check` clean on both
changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where deferred sections in `Lazy` could disable full-page caching by leaking per-user loader mutations into the page state. Fallback discovery now runs in an isolated request state, restoring CDN caching on homepages while keeping personalization intact.

- **Bug Fixes**
  - Resolve `Lazy` fallback with `newIsolatedRequestState()` so `bag`, `flags`, `response`, and `vary` mutations don’t affect the page.
  - Keep the eager partial re-resolving with the real request state to preserve personalization.
  - Added tests to ensure no leakage between isolated and real request states.

<sup>Written for commit 0bb69c240998bb26303c5a9d9392176b8767d689. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lazy-loaded section handling to prevent speculative resolution from affecting the parent page’s caching, response headers, or feature state.
  * Preserved existing eager and lazy rendering behavior.

* **Tests**
  * Added coverage confirming isolated request state remains independent across separate resolutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->