### PR TITLE
fix(weather): mark temperature matcher as cacheable

### DIFF
--- a/weather/matchers/temperature.ts
+++ b/weather/matchers/temperature.ts
@@ -20,6 +20,14 @@ export interface Props {
 }
 
 /**
+ * The weather match is derived from the visitor's geo (Cf-Iplatitude /
+ * Cf-Iplongitude) and never from per-user identity, so it is safe to bake
+ * into cached HTML shared across visitors. Without this, any page using this
+ * matcher falls through to `Cache-Control: no-store` (see blocks/matcher.ts).
+ */
+export const cacheable = true;
+
+/**
  * @title Weather
  * @description Target users based on specific temperature
  * @icon cloud-storm


### PR DESCRIPTION
## Problem

Storefront homes that use a **weather-targeted section** (e.g. FarmRio, whose home uses `weather/matchers/temperature.ts` ×4) always respond with `Cache-Control: no-store, no-cache, must-revalidate`, so the CDN never caches the home. PLP/PDP on the same site cache normally (`public, max-age=..., stale-while-revalidate=...`).

## Root cause

A page is only eligible for full-page CDN caching when **every** active flag's matcher declares `cacheable: true` — otherwise `applyPageCacheDecision` (deco `runtime/middleware.ts`) hits `!allFlagsCacheable` and forces `NO_STORE`. See the contract in `blocks/matcher.ts`:

> Default: `undefined` → page falls through to `Cache-Control: no-store`.

`weather/matchers/temperature.ts` never exported `cacheable`. Even when the weather section is deferred behind `Rendering/Lazy.tsx`, **matchers are still evaluated in the main request** (Lazy aborts loaders but not matchers), so the weather matcher registers a flag with `cacheable=undefined` and disqualifies the whole page from caching.

## Fix

Declare `export const cacheable = true`. The match derives only from the visitor's geo (`Cf-Iplatitude`/`Cf-Iplongitude`), never from per-user identity — the same class as `matchers/device.ts`, `date.ts`, etc. which already declare it. The deferred weather section still resolves per-request in its own partial, so its variant is not frozen by page caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark the weather temperature matcher as cacheable to restore full-page CDN caching on pages using weather-targeted sections. Homepages now cache normally instead of returning no-store.

- **Bug Fixes**
  - Exported `cacheable = true` from `weather/matchers/temperature.ts` (match uses only `Cf-Iplatitude`/`Cf-Iplongitude`).
  - Avoids `applyPageCacheDecision` forcing `no-store` when this matcher runs, even if the section is lazy.

<sup>Written for commit c5c472b26ca415953f8fda192081888043e36f81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

