### PR TITLE
feat(vtex): make hideUnavailableItems configurable at app level

### DIFF
--- a/vtex/loaders/intelligentSearch/productList.ts
+++ b/vtex/loaders/intelligentSearch/productList.ts
@@ -147,14 +147,17 @@ const isQueryList = (p: any): p is QueryProps =>
 const isProductIDList = (p: any): p is ProductIDProps =>
   Array.isArray(p.ids) && p.ids.length > 0;
 
-const fromProps = ({ props }: Props) => {
+const fromProps = ({ props }: Props, ctx: AppContext) => {
+  const hideUnavailableItems = (p: CommonProps) =>
+    p.hideUnavailableItems ?? ctx.hideUnavailableItems;
+
   if (isFacetsList(props)) {
     return {
       query: props.query,
       count: props.count || 12,
       sort: props.sort || "",
       selectedFacets: [{ key: "", value: props.facets }],
-      hideUnavailableItems: props.hideUnavailableItems,
+      hideUnavailableItems: hideUnavailableItems(props),
       simulationBehavior: props.simulationBehavior || "default",
     } as const;
   }
@@ -165,7 +168,7 @@ const fromProps = ({ props }: Props) => {
       count: props.ids.length || 12,
       sort: "",
       selectedFacets: [],
-      hideUnavailableItems: props.hideUnavailableItems,
+      hideUnavailableItems: hideUnavailableItems(props),
       simulationBehavior: props.simulationBehavior || "default",
     } as const;
   }
@@ -177,7 +180,7 @@ const fromProps = ({ props }: Props) => {
       sort: props.sort || "",
       fuzzy: mapLabelledFuzzyToFuzzy(props.fuzzy),
       selectedFacets: [],
-      hideUnavailableItems: props.hideUnavailableItems,
+      hideUnavailableItems: hideUnavailableItems(props),
       simulationBehavior: props.simulationBehavior || "default",
     } as const;
   }
@@ -188,7 +191,7 @@ const fromProps = ({ props }: Props) => {
       count: props.count || 12,
       sort: props.sort || "",
       selectedFacets: [{ key: "productClusterIds", value: props.collection }],
-      hideUnavailableItems: props.hideUnavailableItems,
+      hideUnavailableItems: hideUnavailableItems(props),
       simulationBehavior: props.simulationBehavior || "default",
     } as const;
   }
@@ -221,7 +224,7 @@ const loader = async (
   const locale = segment?.payload?.cultureInfo ??
     ctx.defaultSegment?.cultureInfo ?? "pt-BR";
 
-  const { selectedFacets, ...args } = fromProps({ props });
+  const { selectedFacets, ...args } = fromProps({ props }, ctx);
   const params = withDefaultParams({ ...args, locale });
   const facets = withDefaultFacets(selectedFacets, ctx);
 
@@ -260,6 +263,7 @@ type Entry = [string, string];
 const getSearchParams = (
   props: Props["props"],
   searchParams: URLSearchParams,
+  ctx: AppContext,
 ): Entry[] => {
   if (isFacetsList(props)) {
     return [
@@ -269,7 +273,8 @@ const getSearchParams = (
       ["selectedFacets", props.facets],
       [
         "hideUnavailableItems",
-        (props.hideUnavailableItems ?? false).toString(),
+        (props.hideUnavailableItems ?? ctx.hideUnavailableItems ?? false)
+          .toString(),
       ],
       ["simulationBehavior", props.simulationBehavior || "default"],
     ];
@@ -283,7 +288,8 @@ const getSearchParams = (
       ["fuzzy", mapLabelledFuzzyToFuzzy(props.fuzzy) ?? ""],
       [
         "hideUnavailableItems",
-        (props.hideUnavailableItems ?? false).toString(),
+        (props.hideUnavailableItems ?? ctx.hideUnavailableItems ?? false)
+          .toString(),
       ],
       ["simulationBehavior", props.simulationBehavior || "default"],
     ];
@@ -296,7 +302,8 @@ const getSearchParams = (
       ["collection", props.collection],
       [
         "hideUnavailableItems",
-        (props.hideUnavailableItems ?? false).toString(),
+        (props.hideUnavailableItems ?? ctx.hideUnavailableItems ?? false)
+          .toString(),
       ],
       ["simulationBehavior", props.simulationBehavior || "default"],
     ];
@@ -337,7 +344,7 @@ export const cacheKey = (
     ? getSegmentCacheKeyWithoutUTM(ctx)
     : getSegmentFromBag(ctx)?.token;
   const params = new URLSearchParams([
-    ...getSearchParams(props, url.searchParams),
+    ...getSearchParams(props, url.searchParams, ctx),
     ["segment", segmentCacheKey],
   ]);
 

--- a/vtex/loaders/intelligentSearch/productList.ts
+++ b/vtex/loaders/intelligentSearch/productList.ts
@@ -149,7 +149,7 @@ const isProductIDList = (p: any): p is ProductIDProps =>
 
 const fromProps = ({ props }: Props, ctx: AppContext) => {
   const hideUnavailableItems = (p: CommonProps) =>
-    p.hideUnavailableItems ?? ctx.hideUnavailableItems;
+    p.hideUnavailableItems ?? ctx.advancedConfigs?.hideUnavailableItems;
 
   if (isFacetsList(props)) {
     return {
@@ -273,7 +273,8 @@ const getSearchParams = (
       ["selectedFacets", props.facets],
       [
         "hideUnavailableItems",
-        (props.hideUnavailableItems ?? ctx.hideUnavailableItems ?? false)
+        (props.hideUnavailableItems ??
+          ctx.advancedConfigs?.hideUnavailableItems ?? false)
           .toString(),
       ],
       ["simulationBehavior", props.simulationBehavior || "default"],
@@ -288,7 +289,8 @@ const getSearchParams = (
       ["fuzzy", mapLabelledFuzzyToFuzzy(props.fuzzy) ?? ""],
       [
         "hideUnavailableItems",
-        (props.hideUnavailableItems ?? ctx.hideUnavailableItems ?? false)
+        (props.hideUnavailableItems ??
+          ctx.advancedConfigs?.hideUnavailableItems ?? false)
           .toString(),
       ],
       ["simulationBehavior", props.simulationBehavior || "default"],
@@ -302,7 +304,8 @@ const getSearchParams = (
       ["collection", props.collection],
       [
         "hideUnavailableItems",
-        (props.hideUnavailableItems ?? ctx.hideUnavailableItems ?? false)
+        (props.hideUnavailableItems ??
+          ctx.advancedConfigs?.hideUnavailableItems ?? false)
           .toString(),
       ],
       ["simulationBehavior", props.simulationBehavior || "default"],

--- a/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -161,7 +161,7 @@ export interface Props {
 }
 const searchArgsOf = (props: Props, url: URL, ctx: AppContext) => {
   const hideUnavailableItems = props.hideUnavailableItems ??
-    ctx.hideUnavailableItems;
+    ctx.advancedConfigs?.hideUnavailableItems;
   const simulationBehavior =
     url.searchParams.get("simulationBehavior") as SimulationBehavior ||
     props.simulationBehavior || "default";
@@ -468,7 +468,8 @@ export const cacheKey = (props: Props, req: Request, ctx: AppContext) => {
     ["fuzzy", props.fuzzy ?? url.searchParams.get("fuzzy") ?? ""],
     [
       "hideUnavailableItems",
-      (props.hideUnavailableItems ?? ctx.hideUnavailableItems)?.toString() ??
+      (props.hideUnavailableItems ?? ctx.advancedConfigs?.hideUnavailableItems)
+        ?.toString() ??
         "",
     ],
     ["pageOffset", (props.pageOffset ?? 1).toString()],

--- a/vtex/loaders/intelligentSearch/productListingPage.ts
+++ b/vtex/loaders/intelligentSearch/productListingPage.ts
@@ -159,8 +159,9 @@ export interface Props {
    */
   simulationBehavior?: SimulationBehavior;
 }
-const searchArgsOf = (props: Props, url: URL) => {
-  const hideUnavailableItems = props.hideUnavailableItems;
+const searchArgsOf = (props: Props, url: URL, ctx: AppContext) => {
+  const hideUnavailableItems = props.hideUnavailableItems ??
+    ctx.hideUnavailableItems;
   const simulationBehavior =
     url.searchParams.get("simulationBehavior") as SimulationBehavior ||
     props.simulationBehavior || "default";
@@ -283,6 +284,7 @@ const loader = async (
   const { selectedFacets: baseSelectedFacets, page, ...args } = searchArgsOf(
     props,
     url,
+    ctx,
   );
   let pathToUse = url.href.replace(url.origin, "");
 
@@ -464,7 +466,11 @@ export const cacheKey = (props: Props, req: Request, ctx: AppContext) => {
     ["page", (props.page ?? url.searchParams.get("page") ?? 1).toString()],
     ["sort", props.sort ?? url.searchParams.get("sort") ?? ""],
     ["fuzzy", props.fuzzy ?? url.searchParams.get("fuzzy") ?? ""],
-    ["hideUnavailableItems", props.hideUnavailableItems?.toString() ?? ""],
+    [
+      "hideUnavailableItems",
+      (props.hideUnavailableItems ?? ctx.hideUnavailableItems)?.toString() ??
+        "",
+    ],
     ["pageOffset", (props.pageOffset ?? 1).toString()],
     [
       "selectedFacets",

--- a/vtex/loaders/legacy/relatedProductsLoader.ts
+++ b/vtex/loaders/legacy/relatedProductsLoader.ts
@@ -52,7 +52,7 @@ async function loader(
     count,
   } = props;
   const hideUnavailableItems = props.hideUnavailableItems ??
-    ctx.hideUnavailableItems;
+    ctx.advancedConfigs?.hideUnavailableItems;
   const segment = getSegmentFromBag(ctx);
   const params = toSegmentParams(segment);
 
@@ -180,7 +180,8 @@ export const cacheKey = (props: Props, req: Request, ctx: AppContext) => {
     ["count", (props.count ?? 0).toString()],
     [
       "hideUnavailableItems",
-      (props.hideUnavailableItems ?? ctx.hideUnavailableItems ?? false)
+      (props.hideUnavailableItems ??
+        ctx.advancedConfigs?.hideUnavailableItems ?? false)
         .toString(),
     ],
     ["segment", segment ?? ""],

--- a/vtex/loaders/legacy/relatedProductsLoader.ts
+++ b/vtex/loaders/legacy/relatedProductsLoader.ts
@@ -48,10 +48,11 @@ async function loader(
 ): Promise<Product[] | null> {
   const { vcsDeprecated } = ctx;
   const {
-    hideUnavailableItems,
     crossSelling = "similars",
     count,
   } = props;
+  const hideUnavailableItems = props.hideUnavailableItems ??
+    ctx.hideUnavailableItems;
   const segment = getSegmentFromBag(ctx);
   const params = toSegmentParams(segment);
 
@@ -177,7 +178,11 @@ export const cacheKey = (props: Props, req: Request, ctx: AppContext) => {
     ["id", props.id ?? ""],
     ["crossSelling", props.crossSelling],
     ["count", (props.count ?? 0).toString()],
-    ["hideUnavailableItems", (props.hideUnavailableItems ?? false).toString()],
+    [
+      "hideUnavailableItems",
+      (props.hideUnavailableItems ?? ctx.hideUnavailableItems ?? false)
+        .toString(),
+    ],
     ["segment", segment ?? ""],
   ]);
 

--- a/vtex/mod.ts
+++ b/vtex/mod.ts
@@ -79,11 +79,6 @@ export interface Props {
   defaultSegment?: SegmentCulture;
   usePortalSitemap?: boolean;
   /**
-   * @title Hide Unavailable Items
-   * @description Default behavior for hiding out of stock items across search, shelves and listing loaders. Individual loaders can still override this. When unset, defaults to false.
-   */
-  hideUnavailableItems?: boolean;
-  /**
    * @description Use VTEX as backend platform
    * @default vtex
    * @hide true
@@ -92,6 +87,11 @@ export interface Props {
 
   advancedConfigs?: {
     doNotFetchVariantsForRelatedProducts?: boolean;
+    /**
+     * @title Hide Unavailable Items
+     * @description Default behavior for hiding out of stock items across search, shelves and listing loaders. Individual loaders can still override this. When unset, defaults to false.
+     */
+    hideUnavailableItems?: boolean;
     /**
      * @title Remove UTM from cache key
      * @description Remove UTM from cache key to prevent cache fragmentation.

--- a/vtex/mod.ts
+++ b/vtex/mod.ts
@@ -79,6 +79,11 @@ export interface Props {
   defaultSegment?: SegmentCulture;
   usePortalSitemap?: boolean;
   /**
+   * @title Hide Unavailable Items
+   * @description Default behavior for hiding out of stock items across search, shelves and listing loaders. Individual loaders can still override this. When unset, defaults to false.
+   */
+  hideUnavailableItems?: boolean;
+  /**
    * @description Use VTEX as backend platform
    * @default vtex
    * @hide true


### PR DESCRIPTION
## Problema

Para esconder produtos indisponíveis (out of stock) a única opção era setar a prop `hideUnavailableItems` **em cada página/loader**. Isso não escala: toda página nova criada volta ao comportamento padrão (`false`), então itens sem estoque reaparecem até alguém lembrar de setar a prop de novo.

## Solução

Torna `hideUnavailableItems` **configurável no nível do app VTEX** (`vtex/mod.ts`), usado como fallback padrão em todos os loaders relevantes. A prop por página continua funcionando e tem prioridade.

**Precedência:** `prop do loader > config do app > false`

Como `state = { ...props }` no app VTEX, o valor fica disponível como `ctx.hideUnavailableItems`.

### Loaders ajustados (fallback para `ctx.hideUnavailableItems`)
- `intelligentSearch/productListingPage.ts` — PLP (`searchArgsOf` + `cacheKey`)
- `intelligentSearch/productList.ts` — prateleiras/shelves (`fromProps` + `getSearchParams`/`cacheKey`)
- `legacy/relatedProductsLoader.ts` — produtos relacionados (loader + `cacheKey`)

O valor do ctx foi incluído nos `cacheKey` para evitar colisão de cache quando a config muda.

## Como usar (ex.: Osklen)

Ligar o toggle **Hide Unavailable Items** na config do app VTEX. Todas as páginas — inclusive as novas — passam a esconder itens sem estoque por padrão, sem editar página por página.

## Notas
- Não afeta a PLP legada (`loaders/legacy/productListingPage.ts`), que usa a API antiga (`fq`) e não consome esse parâmetro.
- `deno check` limpo nos arquivos alterados (o único erro do typecheck é pré-existente em `website/utils/crypto.ts`, não tocado neste PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an app-level default to hide out-of-stock items for VTEX, now stored at `advancedConfigs.hideUnavailableItems`. Search, shelves, and listings use this as a fallback to cut per-page flags and keep new pages consistent.

- **New Features**
  - Added `advancedConfigs.hideUnavailableItems?: boolean` in `vtex/mod.ts`; precedence: loader prop > app config > false.
  - Loaders now read `ctx.advancedConfigs?.hideUnavailableItems`: `intelligentSearch/productListingPage.ts`, `intelligentSearch/productList.ts`, and `legacy/relatedProductsLoader.ts`.
  - Included this value in cache keys to avoid collisions when the config changes.

- **Migration**
  - In the VTEX app config, under Advanced Configs, toggle “Hide Unavailable Items” to set the store-wide default.
  - Override per page/loader with the `hideUnavailableItems` prop when needed.

<sup>Written for commit dd74cc575b4facfb4d2f6dddb18f50138d7ce83e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global option to hide unavailable products across search results, product shelves, and listing pages.
  * Individual components can override the global setting when needed.

* **Bug Fixes**
  * Product availability filtering now consistently respects configured defaults.
  * Updated caching to distinguish results based on availability settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->