### PR TITLE
feat(website): AllowPageCache section for CMS-only pages

### DIFF
--- a/website/manifest.gen.ts
+++ b/website/manifest.gen.ts
@@ -50,6 +50,7 @@ import * as $$$$$$$14 from "./matchers/site.ts";
 import * as $$$$$$$15 from "./matchers/userAgent.ts";
 import * as $$$$$0 from "./pages/Page.tsx";
 import * as $$$$$$0 from "./sections/Analytics/Analytics.tsx";
+import * as $$$$$$6 from "./sections/Cache/AllowPageCache.tsx";
 import * as $$$$$$1 from "./sections/Rendering/Deferred.tsx";
 import * as $$$$$$2 from "./sections/Rendering/Lazy.tsx";
 import * as $$$$$$3 from "./sections/Rendering/SingleDeferred.tsx";
@@ -89,6 +90,7 @@ const manifest = {
   },
   "sections": {
     "website/sections/Analytics/Analytics.tsx": $$$$$$0,
+    "website/sections/Cache/AllowPageCache.tsx": $$$$$$6,
     "website/sections/Rendering/Deferred.tsx": $$$$$$1,
     "website/sections/Rendering/Lazy.tsx": $$$$$$2,
     "website/sections/Rendering/SingleDeferred.tsx": $$$$$$3,

--- a/website/sections/Cache/AllowPageCache.tsx
+++ b/website/sections/Cache/AllowPageCache.tsx
@@ -1,0 +1,25 @@
+import { PAGE_CACHE_ALLOWED_KEY } from "@deco/deco/blocks";
+import type { AppContext } from "../../mod.ts";
+
+/**
+ * Opts the current page into CDN page caching.
+ *
+ * The runtime only emits a public `Cache-Control` when some middleware marks
+ * the request as safe to cache (see `PAGE_CACHE_ALLOWED_KEY`). Commerce apps
+ * like VTEX do this from their middleware, but CMS-only pages (e.g. a home
+ * built purely from `website` sections, with no commerce loader) never opt in
+ * and therefore stay uncached.
+ *
+ * Drop this section on such a page to make it cacheable. It is still guarded by
+ * the runtime: if a foreign `Set-Cookie` is present, or another block on the
+ * same page marks the response `no-store`, that decision wins.
+ */
+export const loader = (_props: unknown, _req: Request, ctx: AppContext) => {
+  ctx.bag?.set(PAGE_CACHE_ALLOWED_KEY, true);
+  return {};
+};
+
+// Renders nothing — this section exists only to opt the page into caching.
+export default function AllowPageCache() {
+  return null;
+}


### PR DESCRIPTION
## Problem

The FARM home (and any CMS-only page) isn't being CDN-cached because it doesn't go through any VTEX loader.

The runtime (`deco/runtime/middleware.ts` → `applyPageCacheDecision`) uses an **opt-in** model: it only emits a public `Cache-Control` when some middleware has set `PAGE_CACHE_ALLOWED_KEY` on the request bag.

The only thing that sets that key is `apps/vtex/middleware.ts`. But an app `middleware` is composed as a **resolver middleware** (`blocks/appsUtil.ts` → `compose(...middlewares, blockResolver)`), so it **only runs when a block from that app is resolved**. A page built purely from `website`/CMS sections with no commerce loader never triggers it → `isPageCacheAllowed = false` → no public `Cache-Control` → the page is never cached.

## Fix

An editor-droppable `website` section that opts the current page into the existing caching pipeline by setting `PAGE_CACHE_ALLOWED_KEY` from its loader. It renders nothing.

```tsx
export const loader = (_props, _req, ctx: AppContext) => {
  ctx.bag?.set(PAGE_CACHE_ALLOWED_KEY, true);
  return {};
};
```

Drop **Allow Page Cache** on a CMS-only page (e.g. the home) to make it cacheable.

## Why it's safe

It's still fully guarded by the runtime `applyPageCacheDecision`:
- a foreign (non-framework) `Set-Cookie` → `no-store` wins;
- `shouldCacheFromVary === false` → `no-store` wins;
- any block that already set `Cache-Control` (e.g. a VTEX loader marking `no-store` for a logged-in/segmented request) wins, since the runtime only sets the public directive `if (!headers.has("Cache-Control"))`.

So it never forces caching of a personalized response — it only fills the opt-in gap for pages that have no app to vouch for them.

## Notes
- Uses the same `ctx.bag.set(PAGE_CACHE_ALLOWED_KEY, true)` API as the VTEX middleware.
- Registered in `website/manifest.gen.ts`.
- `deno check website/mod.ts` passes; `deno fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `AllowPageCache` website section that lets CMS‑only pages opt into CDN caching by setting `PAGE_CACHE_ALLOWED_KEY`. It renders nothing and respects existing runtime cache safety checks.

- **New Features**
  - Droppable section that sets `PAGE_CACHE_ALLOWED_KEY` in its loader to enable public Cache-Control on CMS-only pages (e.g., home).
  - Safe by design: runtime still prefers no-store when `Set-Cookie` is present or another block sets cache headers.

- **Migration**
  - Add `AllowPageCache` to any CMS-only page you want cached; no props needed.

<sup>Written for commit 4580918c1441c362aca184295267c3f278b73566. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

