### PR TITLE
feat(website): Deco Analytics collector, gated like its predecessor

### DIFF
--- a/website/components/Stats.tsx
+++ b/website/components/Stats.tsx
@@ -1,0 +1,68 @@
+import { Head } from "$fresh/runtime.ts";
+
+/**
+ * Deco Analytics — the first-party collector.
+ *
+ * Replaces `<OneDollarStats />`, and the difference that matters is not the vendor. It is
+ * WHERE THE LOGIC LIVES.
+ *
+ * OneDollarStats ships roughly sixty lines of tracking code inside the site bundle: the
+ * pushState patch, the flag reading, the event mapping, the truncation. Every one of those
+ * is a decision that can be wrong, and fixing any of them means redeploying every site
+ * that embeds it — across ~500 storefronts that is not a fix, it is a campaign.
+ *
+ * This component is a script tag and nothing else. The runtime, the commerce mapping, the
+ * deco adapter and the per-site module composition are all served from the edge and
+ * versioned there, so a correction ships with a cache purge instead of a fleet deploy.
+ * That is also why there is deliberately NO npm package: a package would put a copy of the
+ * runtime back inside every site bundle, which is the problem this shape exists to avoid.
+ *
+ * It also does not stringify money. OneDollarStats flattens every param through
+ * `JSON.stringify` into a 990-byte string prop, so a purchase value arrives as text and
+ * revenue cannot be summed without parsing it back. Ours lands in typed columns.
+ *
+ * NOTE ON NAMING: `analytics/loaders/DecoAnalyticsScript.ts` already exists in this repo
+ * and is a **Plausible** loader despite the name. This is unrelated to it.
+ */
+export interface Props {
+  /**
+   * Where the script is served from and where events are sent.
+   *
+   * EMPTY IS THE RIGHT ANSWER for a site behind our CDN: a relative path keeps the request
+   * first-party, which is not a detail — a first-party request is not blocked by tracking
+   * protection, and the `Host` header then identifies the site. `Host` cannot be forged,
+   * which is why it is the only source billing may trust.
+   */
+  origin?: string;
+
+  /**
+   * Only for a site NOT served through our CDN.
+   *
+   * A declared key rides in a public script attribute, so anyone can read it and post with
+   * someone else's. Events carrying one are recorded as tag-sourced and are never used for
+   * billing — the key identifies, it does not authenticate.
+   */
+  siteKey?: string;
+
+  /**
+   * Off by default. The script is already `async` and nothing renders from it, so deferring
+   * only delays the first pageview — which is the one event a realtime view needs.
+   */
+  defer?: boolean;
+}
+
+export default function Stats({ origin = "", siteKey, defer }: Props) {
+  const src = `${origin}/_dq/a.js${siteKey ? `?k=${encodeURIComponent(siteKey)}` : ""}`;
+  return (
+    <Head>
+      {/* Only when the collector is on another origin. Preconnecting to our own is noise. */}
+      {origin ? <link rel="preconnect" href={origin} /> : null}
+      {/*
+        `async`, and nothing on the page waits on it. A failure here has to degrade to
+        "analytics stopped", never to "the page broke" — no island awaits this and no
+        rendering path reads from it.
+      */}
+      <script async={!defer} defer={defer} src={src} />
+    </Head>
+  );
+}

--- a/website/pages/Page.tsx
+++ b/website/pages/Page.tsx
@@ -18,6 +18,7 @@ import { Component, JSX } from "preact";
 import ErrorPageComponent from "../../utils/defaultErrorPage.tsx";
 import { DefaultImageQualityContext } from "../components/Image.tsx";
 import OneDollarStats from "../components/OneDollarStats.tsx";
+import Stats from "../components/Stats.tsx";
 import Events from "../components/Events.tsx";
 import { SEOSection } from "../components/Seo.tsx";
 import LiveControls from "../components/_Controls.tsx";
@@ -28,6 +29,20 @@ const noIndexedDomains = ["decocdn.com", "deco.site", "deno.dev"];
 const ONEDOLLAR_ENABLED = Deno.env.get("ONEDOLLAR_ENABLED") !== "false";
 const ONEDOLLAR_COLLECTOR = Deno.env.get("ONEDOLLAR_COLLECTOR");
 const ONEDOLLAR_STATIC_SCRIPT = Deno.env.get("ONEDOLLAR_STATIC_SCRIPT");
+
+// Deco Analytics, gated the same way its predecessor is, for the same reason: enabling a
+// collector is a fleet decision, not something to configure per site in the CMS.
+//
+// OFF BY DEFAULT, unlike ONEDOLLAR_ENABLED which is on unless explicitly "false". A new
+// collector that turns itself on everywhere the moment this ships would start collecting
+// from sites nobody has registered, and every one of those events would resolve to no site
+// and be dropped — a lot of requests bought for nothing.
+const DECO_ANALYTICS_ENABLED = Deno.env.get("DECO_ANALYTICS_ENABLED") === "true";
+// Empty means same-origin, which is the first-party path and the default we want. Set it
+// only for a site that is not behind our CDN.
+const DECO_ANALYTICS_ORIGIN = Deno.env.get("DECO_ANALYTICS_ORIGIN") ?? "";
+// Only for a site we do not host. Public by construction — it ships in the script tag.
+const DECO_ANALYTICS_KEY = Deno.env.get("DECO_ANALYTICS_KEY");
 
 /**
  * @title Sections
@@ -147,6 +162,15 @@ function Page(
             collectorAddress={ONEDOLLAR_COLLECTOR}
             staticScriptUrl={ONEDOLLAR_STATIC_SCRIPT}
           />
+        )}
+        {/*
+          Deliberately INDEPENDENT of the gate above, so both can run at once. Comparing two
+          collectors on the same traffic is the only way to know whether the new one agrees
+          with the incumbent, and that comparison is the point of the migration — making this
+          an either/or would force the switch to be a leap.
+        */}
+        {DECO_ANALYTICS_ENABLED && (
+          <Stats origin={DECO_ANALYTICS_ORIGIN} siteKey={DECO_ANALYTICS_KEY} />
         )}
         {sections?.map(renderSection)}
       </ErrorBoundary>


### PR DESCRIPTION
Adds `<Stats />` — a script tag for the first-party collector — and wires it in `Page.tsx` behind env vars, in the same shape `OneDollarStats` already uses.

```
DECO_ANALYTICS_ENABLED   "true" to enable. OFF by default.
DECO_ANALYTICS_ORIGIN    empty = same-origin (the first-party path). Set only for a site not behind our CDN.
DECO_ANALYTICS_KEY       only for a site we do not host. Public by construction — it ships in the tag.
```

## Three choices worth reviewing

**Env-gated, not a CMS section.** Enabling a collector is a fleet decision, and `OneDollarStats` already established this seam. A section would mean ~500 CMS edits to turn one thing on.

**Off by default**, unlike `ONEDOLLAR_ENABLED` which is on unless explicitly `"false"`. A new collector that switched itself on everywhere the moment this shipped would collect from sites nobody has registered — every one of those events resolves to no site and is dropped, so it is a lot of requests bought for nothing.

**The gate is independent of `ONEDOLLAR_ENABLED`, so both can run at once.** Comparing two collectors on the same traffic is the only way to know whether the new one agrees with the incumbent, and that comparison is the point of the migration. Either/or would force the switch to be a leap.

## What it deliberately is not

A package. `OneDollarStats` ships ~60 lines of tracking logic inside the site bundle — the pushState patch, the flag reading, the event mapping, the truncation — so fixing any of them means redeploying every site that embeds it. Across ~500 storefronts that is a campaign, not a fix. Here the runtime, the commerce mapping and per-site module composition are served from the edge and versioned there, so a correction ships with a cache purge. An npm package would put the copy back in every bundle, which is the problem this shape exists to avoid.

It also does not stringify money: `OneDollarStats` flattens every param through `JSON.stringify` into a 990-byte string prop, so a purchase value arrives as text and revenue cannot be summed without parsing it back. This lands in typed columns.

## Verification

`deno check` clean on both touched files. The two `TS2769` errors in that output are **pre-existing** in `website/utils/crypto.ts` and reproduce on a clean `main` — confirmed by stashing.

No manifest change: components are not manifest entries, only sections and loaders are.

## Not enough on its own

A site pins `apps/` by version (the storefront is on `0.144.1`), so this reaches a site only after a release and a version bump there. The env var is the last step, not the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a first‑party Deco Analytics collector via a `<Stats />` script tag and wires it into `Page.tsx`, gated by env vars. Replaces in‑bundle `OneDollarStats` logic with an edge‑served runtime to avoid fleet redeploys and to allow side‑by‑side comparison during migration.

- `DECO_ANALYTICS_ENABLED`: off by default; independent from `ONEDOLLAR_ENABLED` so both collectors can run simultaneously.
- `DECO_ANALYTICS_ORIGIN`: empty uses same‑origin (preferred, first‑party path); set only for non‑CDN sites. Adds `<link rel="preconnect">` only when cross‑origin.
- `DECO_ANALYTICS_KEY`: public site key for non‑hosted sites; used for identification, not authentication.
- `<Stats />` loads `/_dq/a.js` with `async`/`defer` and has no rendering dependencies; failure degrades to “analytics stopped,” not “page broke.”
- Metrics land in typed columns (no money stringification). No CMS section and no manifest changes.

- To enable: release a new `apps/` version to the storefront, then set `DECO_ANALYTICS_ENABLED="true"`. Optionally set `DECO_ANALYTICS_ORIGIN` and `DECO_ANALYTICS_KEY` for non‑CDN sites.

<sup>Written for commit 5af3c4156fd14715c4d55a5cbeb1b0ec92ac6aa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Deco Analytics tracking to pages.
  - Supports configurable analytics origins, site keys, deferred loading, and connection optimization.
  - Analytics can be enabled independently from existing site metrics and remains off by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->