### PR TITLE
fix(website): deno fmt on the analytics component and its gate

### DIFF
--- a/website/components/Stats.tsx
+++ b/website/components/Stats.tsx
@@ -52,16 +52,20 @@ export interface Props {
 }
 
 export default function Stats({ origin = "", siteKey, defer }: Props) {
-  const src = `${origin}/_dq/a.js${siteKey ? `?k=${encodeURIComponent(siteKey)}` : ""}`;
+  const src = `${origin}/_dq/a.js${
+    siteKey ? `?k=${encodeURIComponent(siteKey)}` : ""
+  }`;
   return (
     <Head>
       {/* Only when the collector is on another origin. Preconnecting to our own is noise. */}
       {origin ? <link rel="preconnect" href={origin} /> : null}
-      {/*
+      {
+        /*
         `async`, and nothing on the page waits on it. A failure here has to degrade to
         "analytics stopped", never to "the page broke" — no island awaits this and no
         rendering path reads from it.
-      */}
+      */
+      }
       <script async={!defer} defer={defer} src={src} />
     </Head>
   );

--- a/website/pages/Page.tsx
+++ b/website/pages/Page.tsx
@@ -37,7 +37,8 @@ const ONEDOLLAR_STATIC_SCRIPT = Deno.env.get("ONEDOLLAR_STATIC_SCRIPT");
 // collector that turns itself on everywhere the moment this ships would start collecting
 // from sites nobody has registered, and every one of those events would resolve to no site
 // and be dropped — a lot of requests bought for nothing.
-const DECO_ANALYTICS_ENABLED = Deno.env.get("DECO_ANALYTICS_ENABLED") === "true";
+const DECO_ANALYTICS_ENABLED =
+  Deno.env.get("DECO_ANALYTICS_ENABLED") === "true";
 // Empty means same-origin, which is the first-party path and the default we want. Set it
 // only for a site that is not behind our CDN.
 const DECO_ANALYTICS_ORIGIN = Deno.env.get("DECO_ANALYTICS_ORIGIN") ?? "";
@@ -163,12 +164,14 @@ function Page(
             staticScriptUrl={ONEDOLLAR_STATIC_SCRIPT}
           />
         )}
-        {/*
+        {
+          /*
           Deliberately INDEPENDENT of the gate above, so both can run at once. Comparing two
           collectors on the same traffic is the only way to know whether the new one agrees
           with the incumbent, and that comparison is the point of the migration — making this
           an either/or would force the switch to be a leap.
-        */}
+        */
+        }
         {DECO_ANALYTICS_ENABLED && (
           <Stats origin={DECO_ANALYTICS_ORIGIN} siteKey={DECO_ANALYTICS_KEY} />
         )}


### PR DESCRIPTION
CI on `main` is red on `deno fmt --check` alone — both files touched by #1660 were over the line width. No behaviour change in this commit; `deno lint` and `deno check` pass.

```
website/components/Stats.tsx | 10 +++++++---
website/pages/Page.tsx       |  9 ++++++---
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `deno fmt --check` failure on `website/components/Stats.tsx` and `website/pages/Page.tsx` so CI on `main` goes green. No behavior change; this only reformats lines that exceeded the width limit.

<sup>Written for commit b38f61211e9a2b6aa8557577b25e2856b0e64efc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/apps/pull/1661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted analytics-related component code and comments for improved readability.
  * No changes to functionality, behavior, or rendered output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->